### PR TITLE
fix: Refactor GoogleCloudStorageInputStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To build the library:
 
 To verify the test coverage, run the following commands from main directory:
 ```shell
-./mvnw -P coverage clean verify -Dmaven.javadoc.skip=true -Dsource.skip=true  -Dgpg.skip=tru 
+./mvnw -P coverage clean verify -Dmaven.javadoc.skip=true -Dsource.skip=true  -Dgpg.skip=tru
 ```
 The coverage report can be found in `coverage/target/site/jacoco-aggregate`.
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClient.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClient.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 
 interface GcsClient {
   /** Opens a new read channel. */
-  VectoredSeekableByteChannel openReadChannel(GcsItemId itemId, GcsReadOptions readOptions)
+  VectoredSeekableByteChannel openReadChannel(GcsItemInfo itemInfo, GcsReadOptions readOptions)
       throws IOException;
 
   /** Fetches object metadata. */

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -57,11 +57,12 @@ class GcsClientImpl implements GcsClient {
   }
 
   @Override
-  public VectoredSeekableByteChannel openReadChannel(GcsItemId itemId, GcsReadOptions readOptions)
-      throws IOException {
-    checkNotNull(itemId);
-    checkArgument(itemId.isGcsObject(), "Expected GCS object to be provided. But got: " + itemId);
-    GcsItemInfo itemInfo = getGcsItemInfo(itemId);
+  public VectoredSeekableByteChannel openReadChannel(
+      GcsItemInfo itemInfo, GcsReadOptions readOptions) throws IOException {
+    checkNotNull(itemInfo, "itemInfo should not be null");
+    checkArgument(
+        itemInfo.getItemId().isGcsObject(),
+        "Expected GCS object to be provided. But got: " + itemInfo.getItemId());
 
     return new GcsReadChannel(storage, itemInfo, readOptions, executorServiceSupplier);
   }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystem.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystem.java
@@ -24,13 +24,14 @@ public interface GcsFileSystem {
   /**
    * Opens an object for reading.
    *
-   * @param path Object full path of the form gs://bucket/object-path.
+   * @param gcsFileInfo Contains information about a GCS File.
    * @param options Fine-grained read options for behaviors of retries, decryption, etc.
    * @return A channel for reading from the given object.
    * @throws FileNotFoundException if the given path does not exist.
    * @throws IOException if object exists but cannot be opened.
    */
-  VectoredSeekableByteChannel open(URI path, GcsReadOptions options) throws IOException;
+  VectoredSeekableByteChannel open(GcsFileInfo gcsFileInfo, GcsReadOptions options)
+      throws IOException;
 
   /**
    * Gets Metadata about the given path item.

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
@@ -38,8 +38,9 @@ public class GcsFileSystemImpl implements GcsFileSystem {
   private Supplier<ExecutorService> executorService;
 
   public GcsFileSystemImpl(GcsFileSystemOptions fileSystemOptions) {
-    this.gcsClient = new GcsClientImpl(getGcsClientOptions(fileSystemOptions), executorService);
+    initializeExecutorService();
     this.fileSystemOptions = fileSystemOptions;
+    this.gcsClient = new GcsClientImpl(getGcsClientOptions(fileSystemOptions), executorService);
   }
 
   public GcsFileSystemImpl(Credentials credentials, GcsFileSystemOptions fileSystemOptions) {
@@ -57,11 +58,12 @@ public class GcsFileSystemImpl implements GcsFileSystem {
   }
 
   @Override
-  public VectoredSeekableByteChannel open(URI path, GcsReadOptions readOptions) throws IOException {
-    checkNotNull(path, "path should not be null");
-    GcsItemId itemId = UriUtil.getItemIdFromString(path.toString());
+  public VectoredSeekableByteChannel open(GcsFileInfo gcsFileInfo, GcsReadOptions readOptions)
+      throws IOException {
+    checkNotNull(gcsFileInfo, "fileInfo should not be null");
+    GcsItemId itemId = UriUtil.getItemIdFromString(gcsFileInfo.getUri().toString());
     checkArgument(itemId.isGcsObject(), "Expected GCS object to be provided. But got: " + itemId);
-    return gcsClient.openReadChannel(itemId, readOptions);
+    return gcsClient.openReadChannel(gcsFileInfo.getItemInfo(), readOptions);
   }
 
   @Override

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptions.java
@@ -25,6 +25,9 @@ public abstract class GcsReadOptions {
   private static final String GCS_CHANNEL_READ_CHUNK_SIZE_KEY = "channel.read.chunk-size-bytes";
   private static final String DECRYPTION_KEY_KEY = "decryption.key";
   private static final String PROJECT_ID_KEY = "project.id";
+  private static final String FOOTER_PREFETCH_SIZE = "footer.prefetch.size";
+
+  private static final long DEFAULT_FOOTER_PREFETCH_SIZE = 2097152; // 2mb
 
   public abstract Optional<Integer> getChunkSize();
 
@@ -32,11 +35,14 @@ public abstract class GcsReadOptions {
 
   public abstract Optional<String> getProjectId();
 
+  public abstract long getFooterPrefetchSize();
+
   public abstract GcsVectoredReadOptions getGcsVectoredReadOptions();
 
   public static Builder builder() {
     return new AutoValue_GcsReadOptions.Builder()
-        .setGcsVectoredReadOptions(GcsVectoredReadOptions.builder().build());
+        .setGcsVectoredReadOptions(GcsVectoredReadOptions.builder().build())
+        .setFooterPrefetchSize(DEFAULT_FOOTER_PREFETCH_SIZE);
   }
 
   public static GcsReadOptions createFromOptions(
@@ -51,6 +57,10 @@ public abstract class GcsReadOptions {
     }
     if (analyticsCoreOptions.containsKey(prefix + PROJECT_ID_KEY)) {
       optionsBuilder.setProjectId(analyticsCoreOptions.get(prefix + PROJECT_ID_KEY));
+    }
+    if (analyticsCoreOptions.containsKey(prefix + FOOTER_PREFETCH_SIZE)) {
+      optionsBuilder.setFooterPrefetchSize(
+          Integer.parseInt(analyticsCoreOptions.get(prefix + FOOTER_PREFETCH_SIZE)));
     }
     optionsBuilder.setGcsVectoredReadOptions(
         GcsVectoredReadOptions.createFromOptions(analyticsCoreOptions, prefix));
@@ -69,6 +79,8 @@ public abstract class GcsReadOptions {
     public abstract Builder setProjectId(String projectId);
 
     public abstract Builder setGcsVectoredReadOptions(GcsVectoredReadOptions vectoredReadOptions);
+
+    public abstract Builder setFooterPrefetchSize(long footerPrefetchSize);
 
     public abstract GcsReadOptions build();
   }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -106,11 +106,17 @@ class GcsClientImplTest {
             .setBucketName("test-bucket-name")
             .setObjectName("test-object-name")
             .build();
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder()
+            .setItemId(itemId)
+            .setSize(objectData.length())
+            .setContentGeneration(0L)
+            .build();
     createBlobInStorage(
         BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
     ByteBuffer buffer = ByteBuffer.allocate(objectData.length());
 
-    SeekableByteChannel channel = gcsClient.openReadChannel(itemId, readOptions);
+    SeekableByteChannel channel = gcsClient.openReadChannel(itemInfo, readOptions);
     int bytesRead = channel.read(buffer);
 
     assertThat(channel.size()).isEqualTo(objectData.length());
@@ -119,33 +125,37 @@ class GcsClientImplTest {
   }
 
   @Test
-  void openReadChannel_nonExistentBlob_throwsIOException() {
-    GcsItemId nonExistentItemId =
-        GcsItemId.builder().setBucketName("test-bucket-name").setObjectName("non-existent").build();
+  void openReadChannel_nullItemInfo_throwsNullPointerException() {
     GcsReadOptions readOptions = GcsReadOptions.builder().setProjectId("test-project-id").build();
 
-    IOException e =
+    NullPointerException e =
         assertThrows(
-            IOException.class, () -> gcsClient.openReadChannel(nonExistentItemId, readOptions));
-
-    assertThat(e).hasMessageThat().contains("Object not found:" + nonExistentItemId);
+            NullPointerException.class, () -> gcsClient.openReadChannel(null, readOptions));
+    assertThat(e).hasMessageThat().isEqualTo("itemInfo should not be null");
   }
 
   @Test
-  void openReadChannel_itemIdPointsToDirectory_throwsIllegalArgumentException() {
+  void openReadChannel_itemInfoPointsToDirectory_throwsIllegalArgumentException() {
     GcsItemId directoryItemId = GcsItemId.builder().setBucketName("test-bucket-name").build();
+    GcsItemInfo directoryItemInfo =
+        GcsItemInfo.builder()
+            .setItemId(directoryItemId)
+            .setSize(0L)
+            .setContentGeneration(-1L)
+            .build();
     GcsReadOptions readOptions = GcsReadOptions.builder().setProjectId("test-project-id").build();
 
     IllegalArgumentException e =
         assertThrows(
             IllegalArgumentException.class,
-            () -> gcsClient.openReadChannel(directoryItemId, readOptions));
+            () -> gcsClient.openReadChannel(directoryItemInfo, readOptions));
 
     assertThat(e)
         .hasMessageThat()
         .isEqualTo("Expected GCS object to be provided. But got: " + directoryItemId);
   }
 
+  @Test
   void createStore_withCredentials_usesProvidedCredentials() throws IOException {
     GcsClientImpl client =
         new GcsClientImpl(

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptionsTest.java
@@ -18,6 +18,7 @@ class GcsReadOptionsTest {
             .put("fs.gs.project.id", "test-project")
             .put("fs.gs.vectored.read.min.range.seek.size", "1024")
             .put("fs.gs.vectored.read.merged.range.max.size", "2048")
+            .put("fs.gs.footer.prefetch.size", "4194304")
             .build();
     String prefix = "fs.gs.";
 
@@ -27,6 +28,7 @@ class GcsReadOptionsTest {
     assertThat(readOptions.getChunkSize()).isEqualTo(Optional.of(8192));
     assertThat(readOptions.getDecryptionKey()).isEqualTo(Optional.of("test-key"));
     assertThat(readOptions.getProjectId()).isEqualTo(Optional.of("test-project"));
+    assertThat(readOptions.getFooterPrefetchSize()).isEqualTo(4194304);
     assertThat(vectoredReadOptions.getMaxMergeGap()).isEqualTo(1024);
     assertThat(vectoredReadOptions.getMaxMergeSize()).isEqualTo(2048);
   }
@@ -42,6 +44,7 @@ class GcsReadOptionsTest {
     assertThat(readOptions.getChunkSize()).isEqualTo(Optional.empty());
     assertThat(readOptions.getDecryptionKey()).isEqualTo(Optional.empty());
     assertThat(readOptions.getProjectId()).isEqualTo(Optional.empty());
+    assertThat(readOptions.getFooterPrefetchSize()).isEqualTo(2 * 1024 * 1024); // Default value
     assertThat(vectoredReadOptions.getMaxMergeGap()).isEqualTo(4 * 1024); // Default value
     assertThat(vectoredReadOptions.getMaxMergeSize()).isEqualTo(8 * 1024 * 1024); // Default value
   }

--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
@@ -71,16 +71,7 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
             .getFooterPrefetchSize();
   }
 
-  /**
-   * Synchronously fetches and caches the footer of the object. This is an on-demand operation.
-   *
-   * <p>If caching fails, an error is logged, and the cache remains unpopulated, allowing the read
-   * operation to fall back to the main channel.
-   */
   private void cacheFooter() {
-    if (footerCache != null || prefetchSize <= 0) {
-      return;
-    }
 
     try {
       long fileSize = channel.size();

--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
@@ -77,7 +77,6 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
       long fileSize = channel.size();
       // File is too small to store footer.
       if (prefetchSize >= fileSize) {
-
         return;
       }
 
@@ -153,7 +152,6 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
       return 0;
     }
 
-    // If the read is in the footer region and the footer is not yet cached, cache it now.
     if (footerCache == null && prefetchSize > 0) {
       try {
         long fileSize = channel.size();
@@ -181,9 +179,6 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
     }
 
     // Fallback to a standard channel read.
-    // Making sure the underlying channel is at the correct position, as the previous read might
-    // have
-    // been served from the cache or a seek() might have happened.
     if (channel.position() != position) {
       channel.position(position);
     }


### PR DESCRIPTION
1. Refactor to provide a constructor of GoogleCloudStorageInputStream which takes GcsFileInfo.
2. Creates GcsFileInfo at GoogleCloudStorageInputStream layer and passes that down, reducing the GetMetadata GCS calls.
3. Removes unnecessary getMetadata calls from ReadTail and ReadFully methods.