### PR TITLE
Refactor GoogleCloudStorageInputStream to reduce api calls to GCS.

### DIFF
--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClient.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClient.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 
 interface GcsClient {
   /** Opens a new read channel. */
-  VectoredSeekableByteChannel openReadChannel(GcsItemId itemId, GcsReadOptions readOptions)
+  VectoredSeekableByteChannel openReadChannel(GcsItemInfo itemInfo, GcsReadOptions readOptions)
       throws IOException;
 
   /** Fetches object metadata. */

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -57,13 +57,15 @@ class GcsClientImpl implements GcsClient {
   }
 
   @Override
-  public VectoredSeekableByteChannel openReadChannel(GcsItemId itemId, GcsReadOptions readOptions)
-      throws IOException {
-    checkNotNull(itemId);
-    checkArgument(itemId.isGcsObject(), "Expected GCS object to be provided. But got: " + itemId);
-    GcsItemInfo itemInfo = getGcsItemInfo(itemId);
+  public VectoredSeekableByteChannel openReadChannel(
+      GcsItemInfo gcsItemInfo, GcsReadOptions readOptions) throws IOException {
+    checkNotNull(gcsItemInfo, "itemInfo should not be null");
+    checkNotNull(readOptions, "readOptions should not be null");
+    checkArgument(
+        gcsItemInfo.getItemId().isGcsObject(),
+        "Expected GCS object to be provided. But got: " + gcsItemInfo.getItemId());
 
-    return new GcsReadChannel(storage, itemInfo, readOptions, executorServiceSupplier);
+    return new GcsReadChannel(storage, gcsItemInfo, readOptions, executorServiceSupplier);
   }
 
   @Override

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystem.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystem.java
@@ -24,13 +24,14 @@ public interface GcsFileSystem extends AutoCloseable {
   /**
    * Opens an object for reading.
    *
-   * @param path Object full path of the form gs://bucket/object-path.
+   * @param gcsFileInfo Contains information about a GCS File.
    * @param options Fine-grained read options for behaviors of retries, decryption, etc.
    * @return A channel for reading from the given object.
    * @throws FileNotFoundException if the given path does not exist.
    * @throws IOException if object exists but cannot be opened.
    */
-  VectoredSeekableByteChannel open(URI path, GcsReadOptions options) throws IOException;
+  VectoredSeekableByteChannel open(GcsFileInfo gcsFileInfo, GcsReadOptions options)
+      throws IOException;
 
   /**
    * Gets Metadata about the given path item.

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
@@ -60,11 +60,12 @@ public class GcsFileSystemImpl implements GcsFileSystem {
   }
 
   @Override
-  public VectoredSeekableByteChannel open(URI path, GcsReadOptions readOptions) throws IOException {
-    checkNotNull(path, "path should not be null");
-    GcsItemId itemId = UriUtil.getItemIdFromString(path.toString());
+  public VectoredSeekableByteChannel open(GcsFileInfo gcsFileInfo, GcsReadOptions readOptions)
+      throws IOException {
+    checkNotNull(gcsFileInfo, "fileInfo should not be null");
+    GcsItemId itemId = UriUtil.getItemIdFromString(gcsFileInfo.getUri().toString());
     checkArgument(itemId.isGcsObject(), "Expected GCS object to be provided. But got: " + itemId);
-    return gcsClient.openReadChannel(itemId, readOptions);
+    return gcsClient.openReadChannel(gcsFileInfo.getItemInfo(), readOptions);
   }
 
   @Override

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
@@ -16,10 +16,7 @@
 package com.google.cloud.gcs.analyticscore.client;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.google.cloud.NoCredentials;
@@ -27,9 +24,7 @@ import com.google.common.base.Supplier;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
-import java.nio.channels.SeekableByteChannel;
-import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -63,44 +58,28 @@ class GcsFileSystemImplTest {
   }
 
   @Test
-  void constructor_withCredentials_createsClientWithProvidedCredentials() throws IOException {
+  void constructor_withCredentials_createsClientWithProvidedCredentials() {
     GcsFileSystemImpl gcsFileSystem =
         new GcsFileSystemImpl(NoCredentials.getInstance(), TEST_GCS_FILESYSTEM_OPTIONS);
     GcsClientImpl gcsClientImpl = (GcsClientImpl) gcsFileSystem.getGcsClient();
+
     assertThat(gcsClientImpl.storage.getOptions().getCredentials())
         .isEqualTo(NoCredentials.getInstance());
   }
 
   @Test
-  void open_withObjectPath_shouldSucceedAndReadContent() throws IOException, URISyntaxException {
-    String content = "hello world";
-    GcsItemId itemId =
-        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_OBJECT).build();
-    URI gcsPath = new URI("gs://" + TEST_BUCKET + "/" + TEST_OBJECT);
-    GcsReadOptions readOptions = GcsReadOptions.builder().setProjectId("test-project").build();
-    VectoredSeekableByteChannel mockChannel = mock(VectoredSeekableByteChannel.class);
+  void constructor_withFileSystemOptions_createsClientWithDefaultCredentials() {
+    GcsClientOptions clientOptions =
+        GcsClientOptions.builder().setProjectId("test-project-default").build();
+    GcsFileSystemOptions fileSystemOptions =
+        GcsFileSystemOptions.builder().setGcsClientOptions(clientOptions).build();
 
-    when(mockClient.openReadChannel(eq(itemId), eq(readOptions))).thenReturn(mockChannel);
-    when(mockChannel.isOpen()).thenReturn(true);
-    when(mockChannel.size()).thenReturn((long) content.length());
-    when(mockChannel.read(any(ByteBuffer.class)))
-        .thenAnswer(
-            invocation -> {
-              ByteBuffer buffer = invocation.getArgument(0);
-              buffer.put(content.getBytes(StandardCharsets.UTF_8));
-              return content.length();
-            });
+    GcsFileSystemImpl gcsFileSystem = new GcsFileSystemImpl(fileSystemOptions);
+    GcsClientImpl gcsClient = (GcsClientImpl) gcsFileSystem.getGcsClient();
 
-    try (SeekableByteChannel channel = gcsFileSystem.open(gcsPath, readOptions)) {
-      assertNotNull(channel);
-      assertTrue(channel.isOpen());
-      assertEquals(content.length(), channel.size());
-
-      ByteBuffer buffer = ByteBuffer.allocate(content.length());
-      int bytesRead = channel.read(buffer);
-      assertEquals(content.length(), bytesRead);
-      assertEquals(content, new String(buffer.array(), StandardCharsets.UTF_8));
-    }
+    assertThat(gcsFileSystem.getFileSystemOptions()).isSameInstanceAs(fileSystemOptions);
+    assertThat(gcsClient).isNotNull();
+    assertThat(gcsClient.storage.getOptions().getProjectId()).isEqualTo("test-project-default");
   }
 
   @Test
@@ -128,40 +107,52 @@ class GcsFileSystemImplTest {
   }
 
   @Test
-  void open_withNonExistentObjectPath_shouldThrowException()
-      throws URISyntaxException, IOException {
-    GcsItemId nonExistentItemId =
-        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("non-existent-object").build();
-    URI nonExistentPath = new URI("gs://" + TEST_BUCKET + "/non-existent-object");
+  void open_withFileInfo_callsGcsClientOpen() throws IOException {
+    URI testUri = URI.create("gs://test-bucket/test-object");
+    GcsItemInfo mockItemInfo = mock(GcsItemInfo.class);
+    GcsFileInfo fileInfo =
+        GcsFileInfo.builder()
+            .setUri(testUri)
+            .setItemInfo(mockItemInfo)
+            .setAttributes(Collections.emptyMap())
+            .build();
     GcsReadOptions readOptions = GcsReadOptions.builder().setProjectId("test-project").build();
-    when(mockClient.openReadChannel(eq(nonExistentItemId), eq(readOptions)))
-        .thenThrow(new IOException("Object not found:" + nonExistentItemId));
+    VectoredSeekableByteChannel mockChannel = mock(VectoredSeekableByteChannel.class);
+    when(mockClient.openReadChannel(eq(mockItemInfo), eq(readOptions))).thenReturn(mockChannel);
 
-    IOException e =
-        assertThrows(IOException.class, () -> gcsFileSystem.open(nonExistentPath, readOptions));
+    VectoredSeekableByteChannel resultChannel = gcsFileSystem.open(fileInfo, readOptions);
 
-    assertThat(e).hasMessageThat().contains("Object not found:" + nonExistentItemId);
+    verify(mockClient).openReadChannel(mockItemInfo, readOptions);
+    assertThat(resultChannel).isSameInstanceAs(mockChannel);
   }
 
   @Test
-  void open_withNullPath_throwsException() {
+  void open_withNullFileInfo_throwsNullPointerException() {
     GcsReadOptions readOptions = GcsReadOptions.builder().setProjectId("test-project").build();
 
     NullPointerException e =
         assertThrows(NullPointerException.class, () -> gcsFileSystem.open(null, readOptions));
 
-    assertThat(e).hasMessageThat().contains("path should not be null");
+    assertThat(e).hasMessageThat().contains("fileInfo should not be null");
   }
 
   @Test
-  void open_withBucketPath_shouldThrowException() throws URISyntaxException {
-    URI bucketPath = new URI("gs://" + TEST_BUCKET);
+  void open_withNonObjectFileInfo_throwsIllegalArgumentException() throws URISyntaxException {
+    URI bucketUri = new URI("gs://" + TEST_BUCKET);
+    GcsItemInfo mockItemInfo = mock(GcsItemInfo.class);
+    GcsFileInfo fileInfo =
+        GcsFileInfo.builder()
+            .setUri(bucketUri)
+            .setItemInfo(mockItemInfo)
+            .setAttributes(Collections.emptyMap())
+            .build();
     GcsReadOptions readOptions = GcsReadOptions.builder().setProjectId("test-project").build();
 
     IllegalArgumentException e =
         assertThrows(
-            IllegalArgumentException.class, () -> gcsFileSystem.open(bucketPath, readOptions));
-    assertTrue(e.getMessage().contains("Expected GCS object to be provided"));
+            IllegalArgumentException.class, () -> gcsFileSystem.open(fileInfo, readOptions));
+
+    assertThat(e).hasMessageThat().startsWith("Expected GCS object to be provided");
   }
 
   @Test

--- a/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamTest.java
+++ b/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamTest.java
@@ -16,7 +16,6 @@
 package com.google.cloud.gcs.analyticscore.core;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -40,33 +39,55 @@ class GoogleCloudStorageInputStreamTest {
   @Mock private GcsFileSystem mockFileSystem;
   @Mock private GcsFileSystemOptions mockFileSystemOptions;
   @Mock private GcsClientOptions mockClientOptions;
+  @Mock private GcsFileInfo mockGcsFileInfo;
+  @Mock private GcsItemInfo mockGcsItemInfo;
   private GoogleCloudStorageInputStream googleCloudStorageInputStream;
 
   @BeforeEach
-  void setUp() {
+  void setUp() throws IOException {
     MockitoAnnotations.openMocks(this);
     when(mockFileSystem.getFileSystemOptions()).thenReturn(mockFileSystemOptions);
     when(mockFileSystemOptions.getGcsClientOptions()).thenReturn(mockClientOptions);
+    when(mockFileSystem.getFileInfo(testUri)).thenReturn(mockGcsFileInfo);
+    when(mockGcsFileInfo.getUri()).thenReturn(testUri);
+    when(mockGcsFileInfo.getItemInfo()).thenReturn(mockGcsItemInfo);
+    when(mockGcsItemInfo.getSize()).thenReturn(fileSize);
   }
 
   GoogleCloudStorageInputStream defaultGcsInputStream() throws IOException {
     when(mockClientOptions.getGcsReadOptions()).thenReturn(GcsReadOptions.builder().build());
-    when(mockFileSystem.open(eq(testUri), eq(GcsReadOptions.builder().build())))
+    when(mockFileSystem.open(eq(mockGcsFileInfo), eq(GcsReadOptions.builder().build())))
         .thenReturn(mockChannel);
     return GoogleCloudStorageInputStream.create(mockFileSystem, testUri);
   }
 
   @Test
-  void create_usesFileSystemOptions_openMainChannelAndCallsConstructor() throws IOException {
+  void create_usesFileSystemOptions_callsGetFileInfoAndOpen() throws IOException {
     GcsReadOptions readOptions =
         GcsReadOptions.builder().setFooterPrefetchSize(prefetchSize).build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
     // Main channel is just returned, only upon call to read second channel is returned.
-    when(mockFileSystem.open(eq(testUri), any(GcsReadOptions.class))).thenReturn(mockChannel);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), any(GcsReadOptions.class)))
+        .thenReturn(mockChannel);
 
     googleCloudStorageInputStream = GoogleCloudStorageInputStream.create(mockFileSystem, testUri);
 
-    verify(mockFileSystem).open(testUri, readOptions);
+    verify(mockFileSystem).open(mockGcsFileInfo, readOptions);
+    assertThat(googleCloudStorageInputStream.getPos()).isEqualTo(0);
+  }
+
+  @Test
+  void create_withGcsFileInfo_opensChannelAndReturnsStream() throws IOException {
+    GcsReadOptions readOptions =
+        GcsReadOptions.builder().setFooterPrefetchSize(prefetchSize).build();
+    when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), any(GcsReadOptions.class)))
+        .thenReturn(mockChannel);
+
+    googleCloudStorageInputStream =
+        GoogleCloudStorageInputStream.create(mockFileSystem, mockGcsFileInfo);
+
+    verify(mockFileSystem).open(mockGcsFileInfo, readOptions);
     assertThat(googleCloudStorageInputStream.getPos()).isEqualTo(0);
   }
 
@@ -131,8 +152,7 @@ class GoogleCloudStorageInputStreamTest {
     GcsReadOptions readOptions =
         GcsReadOptions.builder().setFooterPrefetchSize(fileSize + 1).build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
-    when(mockFileSystem.open(eq(testUri), eq(readOptions))).thenReturn(mockChannel);
-    when(mockChannel.size()).thenReturn(fileSize);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), eq(readOptions))).thenReturn(mockChannel);
     // Prefetch size is greater than file size, hence no prefetch.
     when(mockChannel.read(any(ByteBuffer.class)))
         .thenAnswer(
@@ -153,8 +173,7 @@ class GoogleCloudStorageInputStreamTest {
     GcsReadOptions readOptions =
         GcsReadOptions.builder().setFooterPrefetchSize(prefetchSize).build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
-    when(mockFileSystem.open(eq(testUri), eq(readOptions))).thenReturn(mockChannel);
-    when(mockChannel.size()).thenReturn(fileSize);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), eq(readOptions))).thenReturn(mockChannel);
 
     byte[] footerData = new byte[] {50, 51, 52, 53, 54, 55, 56, 57, 58, 59};
     when(mockChannel.read(any(ByteBuffer.class)))
@@ -181,8 +200,7 @@ class GoogleCloudStorageInputStreamTest {
     GcsReadOptions readOptions =
         GcsReadOptions.builder().setFooterPrefetchSize(prefetchSize).build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
-    when(mockFileSystem.open(eq(testUri), eq(readOptions))).thenReturn(mockChannel);
-    when(mockChannel.size()).thenReturn(fileSize);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), eq(readOptions))).thenReturn(mockChannel);
 
     byte[] footerData = new byte[] {50, 51, 52, 53, 54, 55, 56, 57, 58, 59};
     when(mockChannel.read(any(ByteBuffer.class)))
@@ -211,8 +229,7 @@ class GoogleCloudStorageInputStreamTest {
     GcsReadOptions readOptions =
         GcsReadOptions.builder().setFooterPrefetchSize(prefetchSize).build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
-    when(mockChannel.size()).thenReturn(fileSize);
-    when(mockFileSystem.open(eq(testUri), eq(readOptions))).thenReturn(mockChannel);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), eq(readOptions))).thenReturn(mockChannel);
     // Mock the data that the prefetch channel will return.
     byte[] footerData = new byte[] {50, 51, 52, 53, 54, 55, 56, 57, 58, 59};
     when(mockChannel.read(any(ByteBuffer.class)))
@@ -247,7 +264,7 @@ class GoogleCloudStorageInputStreamTest {
     GcsReadOptions readOptions =
         GcsReadOptions.builder().setFooterPrefetchSize(prefetchSize).build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
-    when(mockFileSystem.open(eq(testUri), eq(readOptions))).thenReturn(mockChannel);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), eq(readOptions))).thenReturn(mockChannel);
     when(mockChannel.size()).thenReturn(fileSize);
     when(mockChannel.position()).thenReturn(1000L);
 
@@ -279,7 +296,7 @@ class GoogleCloudStorageInputStreamTest {
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
     when(mockChannel.size()).thenReturn(fileSize);
     when(mockChannel.position()).thenReturn(995L);
-    when(mockFileSystem.open(eq(testUri), eq(readOptions))).thenReturn(mockChannel);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), eq(readOptions))).thenReturn(mockChannel);
     // Mock channel to fail during the caching read.
     when(mockChannel.read(any(ByteBuffer.class)))
         .thenThrow(new IOException("Simulated cache read failure"))
@@ -326,7 +343,7 @@ class GoogleCloudStorageInputStreamTest {
         GcsReadOptions.builder().setFooterPrefetchSize(prefetchSize).build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
     when(mockChannel.size()).thenReturn(fileSize);
-    when(mockFileSystem.open(eq(testUri), eq(readOptions))).thenReturn(mockChannel);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), eq(readOptions))).thenReturn(mockChannel);
 
     byte[] partialFooterData = new byte[] {50, 51, 52, 53, 54};
     when(mockChannel.read(any(ByteBuffer.class)))
@@ -354,7 +371,7 @@ class GoogleCloudStorageInputStreamTest {
         GcsReadOptions.builder().setFooterPrefetchSize(prefetchSize).build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
     when(mockChannel.size()).thenReturn(fileSize);
-    when(mockFileSystem.open(eq(testUri), eq(readOptions))).thenReturn(mockChannel);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), eq(readOptions))).thenReturn(mockChannel);
 
     byte[] footerData = new byte[] {50, 51, 52, 53, 54, 55, 56, 57, 58, 59};
     when(mockChannel.read(any(ByteBuffer.class)))
@@ -366,16 +383,18 @@ class GoogleCloudStorageInputStreamTest {
 
     googleCloudStorageInputStream = GoogleCloudStorageInputStream.create(mockFileSystem, testUri);
 
-    googleCloudStorageInputStream.seek((fileSize - prefetchSize)-1);
+    googleCloudStorageInputStream.seek((fileSize - prefetchSize) - 1);
     byte[] readBuffer = new byte[prefetchSize];
-    when(mockChannel.position())
-        .thenReturn(0L);
+    when(mockChannel.position()).thenReturn(0L);
     var exception =
         assertThrows(
             IllegalStateException.class,
             () -> googleCloudStorageInputStream.read(readBuffer, 0, readBuffer.length));
 
-    assertThat(exception).hasMessageThat().isEqualTo(String.format("Channel position (0) and stream position (989) should be the same"));
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo(
+            String.format("Channel position (0) and stream position (989) should be the same"));
   }
 
   @Test
@@ -471,7 +490,7 @@ class GoogleCloudStorageInputStreamTest {
     when(mockFileSystem.getFileSystemOptions()).thenReturn(mockFileSystemOptions);
     when(mockFileSystemOptions.getGcsClientOptions()).thenReturn(mockClientOptions);
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
-    when(mockFileSystem.open(testUri, readOptions)).thenReturn(null);
+    when(mockFileSystem.open(mockGcsFileInfo, readOptions)).thenReturn(null);
 
     GoogleCloudStorageInputStream googleCloudStorageInputStream =
         GoogleCloudStorageInputStream.create(mockFileSystem, testUri);
@@ -488,7 +507,7 @@ class GoogleCloudStorageInputStreamTest {
     GcsReadOptions readOptions = GcsReadOptions.builder().build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
     VectoredSeekableByteChannel newMockChannel = mock(VectoredSeekableByteChannel.class);
-    when(mockFileSystem.open(testUri, readOptions)).thenReturn(newMockChannel);
+    when(mockFileSystem.open(mockGcsFileInfo, readOptions)).thenReturn(newMockChannel);
     googleCloudStorageInputStream = GoogleCloudStorageInputStream.create(mockFileSystem, testUri);
     when(newMockChannel.read(any(ByteBuffer.class)))
         .thenAnswer(
@@ -516,7 +535,7 @@ class GoogleCloudStorageInputStreamTest {
     GcsReadOptions readOptions = GcsReadOptions.builder().build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
     VectoredSeekableByteChannel newMockChannel = mock(VectoredSeekableByteChannel.class);
-    when(mockFileSystem.open(testUri, readOptions)).thenReturn(newMockChannel);
+    when(mockFileSystem.open(mockGcsFileInfo, readOptions)).thenReturn(newMockChannel);
     googleCloudStorageInputStream = GoogleCloudStorageInputStream.create(mockFileSystem, testUri);
     when(newMockChannel.read(any(ByteBuffer.class))).thenReturn(actualBytesRead);
 
@@ -559,22 +578,14 @@ class GoogleCloudStorageInputStreamTest {
     int offset = 5;
     long fileSize = 1024L;
     long expectedPosition = fileSize - offset;
-    GcsReadOptions readOptions = GcsReadOptions.builder().build();
-    when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
-    VectoredSeekableByteChannel newMockChannel = mock(VectoredSeekableByteChannel.class);
-    GcsFileInfo mockFileInfo = mock(GcsFileInfo.class);
-    GcsItemInfo mockItemInfo = mock(GcsItemInfo.class);
-    when(mockFileSystem.open(testUri, readOptions)).thenReturn(newMockChannel);
-    when(mockFileSystem.getFileInfo(testUri)).thenReturn(mockFileInfo);
-    when(mockFileInfo.getItemInfo()).thenReturn(mockItemInfo);
-    when(mockItemInfo.getSize()).thenReturn(fileSize);
-    when(newMockChannel.read(any(ByteBuffer.class)))
+    when(mockGcsItemInfo.getSize()).thenReturn(fileSize);
+    when(mockChannel.read(any(ByteBuffer.class)))
         .thenAnswer(
             inv -> {
               inv.<ByteBuffer>getArgument(0).put(data);
               return data.length;
             });
-    googleCloudStorageInputStream = GoogleCloudStorageInputStream.create(mockFileSystem, testUri);
+    googleCloudStorageInputStream = defaultGcsInputStream();
     long initialStreamPosition = googleCloudStorageInputStream.getPos();
 
     int bytesRead = googleCloudStorageInputStream.readTail(buffer, offset, length);
@@ -582,9 +593,9 @@ class GoogleCloudStorageInputStreamTest {
 
     assertThat(bytesRead).isEqualTo(data.length);
     assertThat(readData).isEqualTo(data);
-    verify(newMockChannel).position(expectedPosition);
-    verify(newMockChannel).read(any(ByteBuffer.class));
-    verify(newMockChannel).close();
+    verify(mockChannel).position(expectedPosition);
+    verify(mockChannel).read(any(ByteBuffer.class));
+    verify(mockChannel).close();
     // readTail should not affect the stream's position
     assertThat(googleCloudStorageInputStream.getPos()).isEqualTo(initialStreamPosition);
   }
@@ -592,15 +603,12 @@ class GoogleCloudStorageInputStreamTest {
   @Test
   void readTail_zeroLength_returnsZero() throws IOException {
     byte[] buffer = new byte[20];
-    VectoredSeekableByteChannel newMockChannel = mock(VectoredSeekableByteChannel.class);
-    GcsFileInfo mockFileInfo = mock(GcsFileInfo.class);
-    GcsItemInfo mockItemInfo = mock(GcsItemInfo.class);
 
-    when(mockFileSystem.getFileInfo(testUri)).thenReturn(mockFileInfo);
-    when(mockFileInfo.getItemInfo()).thenReturn(mockItemInfo);
-    when(mockItemInfo.getSize()).thenReturn(1024L);
+    when(mockGcsFileInfo.getItemInfo()).thenReturn(mockGcsItemInfo);
+    when(mockGcsItemInfo.getSize()).thenReturn(1024L);
 
     googleCloudStorageInputStream = defaultGcsInputStream();
+
     int bytesRead = googleCloudStorageInputStream.readTail(buffer, 0, 0);
 
     assertThat(bytesRead).isEqualTo(0);
@@ -608,8 +616,8 @@ class GoogleCloudStorageInputStreamTest {
 
   @Test
   void readVectored_delegatesToReadChannelAndDoesNotChangeState() throws IOException {
-      googleCloudStorageInputStream = defaultGcsInputStream();
-      long positionBeforeVectoredRead = googleCloudStorageInputStream.getPos();
+    googleCloudStorageInputStream = defaultGcsInputStream();
+    long positionBeforeVectoredRead = googleCloudStorageInputStream.getPos();
     googleCloudStorageInputStream.readVectored(any(), any());
 
     verify(mockChannel).readVectored(any(), any());
@@ -621,7 +629,8 @@ class GoogleCloudStorageInputStreamTest {
     GcsReadOptions readOptions =
         GcsReadOptions.builder().setFooterPrefetchSize(prefetchSize).build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
-    when(mockFileSystem.open(eq(testUri), any(GcsReadOptions.class))).thenReturn(mockChannel);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), any(GcsReadOptions.class)))
+        .thenReturn(mockChannel);
     when(mockChannel.size()).thenReturn(fileSize);
 
     // First read from non-cache position.
@@ -657,7 +666,7 @@ class GoogleCloudStorageInputStreamTest {
     GcsReadOptions readOptions =
         GcsReadOptions.builder().setFooterPrefetchSize(prefetchSize).build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
-    when(mockFileSystem.open(eq(testUri), eq(readOptions))).thenReturn(mockChannel);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), eq(readOptions))).thenReturn(mockChannel);
     when(mockChannel.size()).thenReturn(fileSize);
 
     byte[] footerData = new byte[] {50, 51, 52, 53, 54, 55, 56, 57, 58, 59};
@@ -697,7 +706,7 @@ class GoogleCloudStorageInputStreamTest {
     GcsReadOptions readOptions =
         GcsReadOptions.builder().setFooterPrefetchSize(prefetchSize).build();
     when(mockClientOptions.getGcsReadOptions()).thenReturn(readOptions);
-    when(mockFileSystem.open(eq(testUri), eq(readOptions))).thenReturn(mockChannel);
+    when(mockFileSystem.open(eq(mockGcsFileInfo), eq(readOptions))).thenReturn(mockChannel);
     when(mockChannel.size()).thenReturn(fileSize);
     byte[] footerData = new byte[prefetchSize];
     when(mockChannel.read(any(ByteBuffer.class)))


### PR DESCRIPTION
1. Refactor to provide a constructor of GoogleCloudStorageInputStream which takes GcsFileInfo.
2. Creates GcsFileInfo at GoogleCloudStorageInputStream layer and passes that down, reducing the GetMetadata GCS calls.
3. Removes unnecessary getMetadata calls from ReadTail and ReadFully methods.