### PR TITLE
Integrating telemetry to record GcsAnalyticsCoreInputStream metrics

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -53,6 +53,11 @@ limitations under the License.
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.cloud.gcs.analytics</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!--Test Dependencies-->
         <dependency>
             <groupId>com.google.truth</groupId>

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
@@ -19,6 +19,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auth.Credentials;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
+import com.google.cloud.gcs.analyticscore.common.telemetry.TelemetryOptions;
 import com.google.cloud.storage.BlobId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
@@ -43,6 +45,7 @@ public class GcsFileSystemImpl implements GcsFileSystem {
     this.executorServiceSupplier = initializeExecutionServiceSupplier();
     this.gcsClient =
         new GcsClientImpl(getGcsClientOptions(fileSystemOptions), executorServiceSupplier);
+    initializeTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions());
   }
 
   public GcsFileSystemImpl(Credentials credentials, GcsFileSystemOptions fileSystemOptions) {
@@ -51,6 +54,7 @@ public class GcsFileSystemImpl implements GcsFileSystem {
     this.gcsClient =
         new GcsClientImpl(
             credentials, getGcsClientOptions(fileSystemOptions), executorServiceSupplier);
+    initializeTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions());
   }
 
   @VisibleForTesting
@@ -58,6 +62,7 @@ public class GcsFileSystemImpl implements GcsFileSystem {
     this.gcsClient = gcsClient;
     this.fileSystemOptions = fileSystemOptions;
     this.executorServiceSupplier = initializeExecutionServiceSupplier();
+    initializeTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions());
   }
 
   @Override
@@ -126,6 +131,11 @@ public class GcsFileSystemImpl implements GcsFileSystem {
     return fileSystemOptions.getGcsClientOptions() == null
         ? GcsClientOptions.builder().build()
         : fileSystemOptions.getGcsClientOptions();
+  }
+
+  @VisibleForTesting
+  void initializeTelemetry(TelemetryOptions telemetryOptions) {
+    telemetryOptions.getOperationListeners().forEach(Telemetry.getInstance()::addListener);
   }
 
   @VisibleForTesting

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptions.java
@@ -16,6 +16,7 @@
 package com.google.cloud.gcs.analyticscore.client;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.gcs.analyticscore.common.telemetry.TelemetryOptions;
 import java.util.Map;
 
 /** Configuration options for the GCS File System. */
@@ -37,11 +38,14 @@ public abstract class GcsFileSystemOptions {
 
   public abstract GcsClientOptions getGcsClientOptions();
 
+  public abstract TelemetryOptions getAnalyticsCoreTelemetryOptions();
+
   public static Builder builder() {
     return new AutoValue_GcsFileSystemOptions.Builder()
         .setReadThreadCount(16)
         .setClientType(ClientType.HTTP_CLIENT)
-        .setGcsClientOptions(GcsClientOptions.builder().build());
+        .setGcsClientOptions(GcsClientOptions.builder().build())
+        .setAnalyticsCoreTelemetryOptions(TelemetryOptions.builder().build());
   }
 
   public static GcsFileSystemOptions createFromOptions(
@@ -70,6 +74,8 @@ public abstract class GcsFileSystemOptions {
     public abstract Builder setReadThreadCount(int readThreadCount);
 
     public abstract Builder setGcsClientOptions(GcsClientOptions gcsClientOptions);
+
+    public abstract Builder setAnalyticsCoreTelemetryOptions(TelemetryOptions telemetryOptions);
 
     public abstract GcsFileSystemOptions build();
   }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -61,6 +61,10 @@ limitations under the License.
             <artifactId>truth</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
     </dependencies>
 </project>

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/DefaultTelemetryFormatter.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/DefaultTelemetryFormatter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.gcs.analyticscore.common.telemetry;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Default implementation of TelemetryFormatter. */
+public class DefaultTelemetryFormatter implements TelemetryFormatter {
+
+  @Override
+  public String formatOperationStart(Operation operation) {
+    return String.format("Operation %s started", operation.getName());
+  }
+
+  @Override
+  public String formatOperationEnd(Operation operation, Map<MetricKey, Long> metrics) {
+    String metricsString = formatMetrics(metrics);
+    return String.format("Operation %s: %s", operation.getName(), metricsString);
+  }
+
+  private String formatMetrics(Map<MetricKey, Long> metrics) {
+    return metrics.entrySet().stream()
+        .map(
+            entry -> {
+              MetricKey key = entry.getKey();
+              String keyString = key.getName();
+              Map<String, String> attributes = key.getAttributes();
+              List<String> attrs = new ArrayList<>();
+              attributes.forEach((k, v) -> attrs.add(k + "=" + v));
+
+              if (!attrs.isEmpty()) {
+                keyString += "{" + String.join(", ", attrs) + "}";
+              }
+              return keyString + "=" + entry.getValue();
+            })
+        .collect(java.util.stream.Collectors.joining(", "));
+  }
+}

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/LogTelemetryReporter.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/LogTelemetryReporter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.gcs.analyticscore.common.telemetry;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+/** A listener that logs telemetry events. */
+public class LogTelemetryReporter implements OperationListener {
+
+  private final Logger logger;
+  private final TelemetryFormatter formatter;
+  private final Level level;
+
+  public LogTelemetryReporter(TelemetryFormatter formatter, String level) {
+    this(LoggerFactory.getLogger(LogTelemetryReporter.class.getName()), formatter, level);
+  }
+
+  @VisibleForTesting
+  protected LogTelemetryReporter(Logger logger, TelemetryFormatter formatter, String level) {
+    this.logger = logger;
+    this.formatter = formatter != null ? formatter : new DefaultTelemetryFormatter();
+    this.level = level != null ? Level.valueOf(level.toUpperCase()) : Level.DEBUG;
+  }
+
+  @Override
+  public void onOperationStart(Operation operation) {
+    logAtLevel(formatter.formatOperationStart(operation));
+  }
+
+  @Override
+  public void onOperationEnd(Operation operation, Map<MetricKey, Long> metrics) {
+    logAtLevel(formatter.formatOperationEnd(operation, metrics));
+  }
+
+  private void logAtLevel(String message) {
+    switch (level) {
+      case ERROR:
+        if (logger.isErrorEnabled()) logger.error(message);
+        break;
+      case WARN:
+        if (logger.isWarnEnabled()) logger.warn(message);
+        break;
+      case INFO:
+        if (logger.isInfoEnabled()) logger.info(message);
+        break;
+      case DEBUG:
+        if (logger.isDebugEnabled()) logger.debug(message);
+        break;
+      case TRACE:
+        if (logger.isTraceEnabled()) logger.trace(message);
+        break;
+    }
+  }
+}

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/TelemetryFormatter.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/TelemetryFormatter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.gcs.analyticscore.common.telemetry;
+
+import java.util.Map;
+
+/** Interface for formatting telemetry events into log strings. */
+public interface TelemetryFormatter {
+
+  /** Formats the start of an operation. */
+  String formatOperationStart(Operation operation);
+
+  /** Formats the end of an operation with its metrics. */
+  String formatOperationEnd(Operation operation, Map<MetricKey, Long> metrics);
+}

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/TelemetryOptions.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/TelemetryOptions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.gcs.analyticscore.common.telemetry;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+/** Options for Telemetry. */
+@AutoValue
+public abstract class TelemetryOptions {
+
+  public abstract ImmutableList<OperationListener> getOperationListeners();
+
+  public static Builder builder() {
+    return new AutoValue_TelemetryOptions.Builder().setOperationListeners(ImmutableList.of());
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setOperationListeners(List<OperationListener> operationListeners);
+
+    public abstract TelemetryOptions build();
+  }
+}

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/DefaultTelemetryFormatterTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/DefaultTelemetryFormatterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.gcs.analyticscore.common.telemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DefaultTelemetryFormatterTest {
+
+  private DefaultTelemetryFormatter formatter;
+
+  @BeforeEach
+  void setUp() {
+    formatter = new DefaultTelemetryFormatter();
+  }
+
+  @Test
+  void formatOperationStart_returnsFormattedString() {
+    Operation operation = Operation.builder().setName("READ").build();
+
+    String result = formatter.formatOperationStart(operation);
+
+    assertEquals("Operation READ started", result);
+  }
+
+  @Test
+  void formatOperationEnd_singleMetric_returnsFormattedString() {
+    Operation operation = Operation.builder().setName("READ").build();
+    MetricKey key = MetricKey.builder().setName("bytes").build();
+
+    String result = formatter.formatOperationEnd(operation, ImmutableMap.of(key, 100L));
+
+    assertEquals("Operation READ: bytes=100", result);
+  }
+
+  @Test
+  void formatOperationEnd_withAttributesAndMultipleMetrics_returnsFormattedString() {
+    Operation operation = Operation.builder().setName("READ").build();
+    Map<String, String> attributes =
+        ImmutableMap.of("className", "TestClass", "readLength", "1024");
+    MetricKey key1 = MetricKey.builder().setName("bytes").setAttributes(attributes).build();
+    MetricKey key2 = MetricKey.builder().setName("latency").build();
+    Map<MetricKey, Long> metrics =
+        com.google.common.collect.ImmutableMap.of(key1, 1024L, key2, 123L);
+
+    String result = formatter.formatOperationEnd(operation, metrics);
+
+    assertTrue(result.startsWith("Operation READ: "));
+    assertTrue(result.contains("bytes{className=TestClass, readLength=1024}=1024"));
+    assertTrue(result.contains("latency=123"));
+  }
+}

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/LogTelemetryReporterTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/LogTelemetryReporterTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.gcs.analyticscore.common.telemetry;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+@ExtendWith(MockitoExtension.class)
+class LogTelemetryReporterTest {
+
+  @Mock private Logger mockLogger;
+  @Mock private TelemetryFormatter mockFormatter;
+
+  private Operation operation;
+  private Map<MetricKey, Long> metrics;
+
+  @BeforeEach
+  void setUp() {
+    metrics = Collections.emptyMap();
+    operation = Operation.builder().setName("VECTORED_READ").setOperationId("test-op-id").build();
+  }
+
+  @Test
+  void onOperationStart_logsAtDebug_whenLevelIsDebug() {
+    when(mockLogger.isDebugEnabled()).thenReturn(true);
+    when(mockFormatter.formatOperationStart(operation)).thenReturn("start message");
+
+    LogTelemetryReporter reporter = new LogTelemetryReporter(mockLogger, mockFormatter, "DEBUG");
+    reporter.onOperationStart(operation);
+
+    verify(mockLogger).debug("start message");
+  }
+
+  @Test
+  void onOperationEnd_logsAtInfo_whenLevelIsInfo() {
+    when(mockLogger.isInfoEnabled()).thenReturn(true);
+    when(mockFormatter.formatOperationEnd(operation, metrics)).thenReturn("end message");
+
+    LogTelemetryReporter reporter = new LogTelemetryReporter(mockLogger, mockFormatter, "INFO");
+    reporter.onOperationEnd(operation, metrics);
+
+    verify(mockLogger).info("end message");
+  }
+
+  @Test
+  void onOperationStart_doesNotLog_whenLevelDisabled() {
+    when(mockLogger.isTraceEnabled()).thenReturn(false);
+    when(mockFormatter.formatOperationStart(operation)).thenReturn("start message");
+
+    LogTelemetryReporter reporter = new LogTelemetryReporter(mockLogger, mockFormatter, "TRACE");
+    reporter.onOperationStart(operation);
+
+    verify(mockLogger).isTraceEnabled();
+    verify(mockLogger, never()).trace(anyString());
+  }
+
+  @Test
+  void onOperationStart_logsAtError() {
+    when(mockLogger.isErrorEnabled()).thenReturn(true);
+    when(mockFormatter.formatOperationStart(operation)).thenReturn("error msg");
+
+    LogTelemetryReporter reporter = new LogTelemetryReporter(mockLogger, mockFormatter, "ERROR");
+    reporter.onOperationStart(operation);
+
+    verify(mockLogger).error("error msg");
+  }
+
+  @Test
+  void onOperationStart_logsAtWarn() {
+    when(mockLogger.isWarnEnabled()).thenReturn(true);
+    when(mockFormatter.formatOperationStart(operation)).thenReturn("warn msg");
+
+    LogTelemetryReporter reporter = new LogTelemetryReporter(mockLogger, mockFormatter, "WARN");
+    reporter.onOperationStart(operation);
+
+    verify(mockLogger).warn("warn msg");
+  }
+
+  @Test
+  void constructor_defaultsToDebug_whenLevelIsNull() {
+    when(mockLogger.isDebugEnabled()).thenReturn(true);
+    when(mockFormatter.formatOperationStart(operation)).thenReturn("default msg");
+
+    LogTelemetryReporter reporter = new LogTelemetryReporter(mockLogger, mockFormatter, null);
+    reporter.onOperationStart(operation);
+
+    verify(mockLogger).debug("default msg");
+  }
+
+  @Test
+  void constructor_throwsException_whenLevelIsInvalid() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new LogTelemetryReporter(mockLogger, mockFormatter, "INVALID_LEVEL"));
+  }
+}

--- a/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
+++ b/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
@@ -25,6 +25,10 @@ import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemImpl;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsItemId;
+import com.google.cloud.gcs.analyticscore.common.telemetry.MetricKey;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Operation;
+import com.google.cloud.gcs.analyticscore.common.telemetry.OperationListener;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.BlobId;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
@@ -32,8 +36,10 @@ import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -161,5 +167,55 @@ class GoogleCloudStorageInputStreamIntegrationTest {
     int bytesRead = googleCloudStorageInputStream.read(buffer);
     assertTrue(bytesRead > 0);
     googleCloudStorageInputStream.close();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        IntegrationTestHelper.TPCDS_CUSTOMER_SMALL_FILE,
+      })
+  void read_capturesTelemetryAttributes_withCorrectReadLength(String fileName) throws IOException {
+    Telemetry telemetry = Telemetry.getInstance();
+    AtomicReference<Map<MetricKey, Long>> capturedMetrics = new AtomicReference<>();
+    OperationListener listener =
+        new OperationListener() {
+          @Override
+          public void onOperationStart(Operation operation) {}
+
+          @Override
+          public void onOperationEnd(Operation operation, Map<MetricKey, Long> metrics) {
+            if (operation.getName().equals("READ")) {
+              capturedMetrics.set(metrics);
+            }
+          }
+        };
+    telemetry.addListener(listener);
+    URI uri = IntegrationTestHelper.getGcsObjectUriForFile(fileName);
+    BlobId blobId = BlobId.fromGsUtilUri(uri.toString());
+    GcsItemId gcsItemId =
+        GcsItemId.builder()
+            .setBucketName(blobId.getBucket())
+            .setObjectName(blobId.getName())
+            .build();
+    GcsFileSystemOptions gcsFileSystemOptions =
+        GcsFileSystemOptions.createFromOptions(Map.of(), "gcs.");
+    GcsFileSystem gcsFileSystem = new GcsFileSystemImpl(gcsFileSystemOptions);
+    ByteBuffer buffer = ByteBuffer.allocate(10);
+    buffer.limit(5);
+
+    try (GoogleCloudStorageInputStream googleCloudStorageInputStream =
+        GoogleCloudStorageInputStream.create(gcsFileSystem, gcsItemId)) {
+      googleCloudStorageInputStream.read(buffer);
+    }
+    telemetry.removeListener(listener);
+    
+    Map<MetricKey, Long> metrics = capturedMetrics.get();
+    MetricKey bytesReadKey =
+        metrics.keySet().stream()
+            .filter(k -> k.getName().equals("analytics-core.read.bytes"))
+            .filter(k -> k.getAttributes().containsKey("readLength"))
+            .findFirst()
+            .get();
+    assertThat(bytesReadKey.getAttributes().get("readLength")).isEqualTo(5);
   }
 }

--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
@@ -18,12 +18,17 @@ package com.google.cloud.gcs.analyticscore.core;
 import static com.google.common.base.Preconditions.*;
 
 import com.google.cloud.gcs.analyticscore.client.*;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Operation;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.BlobId;
+import com.google.common.collect.ImmutableMap;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.IntFunction;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -32,6 +37,12 @@ import org.slf4j.LoggerFactory;
 /** This is a seekable input stream for GCS objects. It is backed by a GcsFileSystem instance. */
 public class GoogleCloudStorageInputStream extends SeekableInputStream {
   private static final Logger LOG = LoggerFactory.getLogger(GoogleCloudStorageInputStream.class);
+  private static final String CLASS_NAME_METRIC_NAME = "gcs-analytics-core.class.name";
+  private static final String SEEK_DISTANCE_METRIC_NAME = "gcs-analytics-core.seek.distance";
+  private static final String READ_BYTES_METRIC_NAME = "gcs-analytics-core.read.bytes";
+  private static final String READ_DURATION_METRIC_NAME = "gcs-analytics-core.read.duration";
+  private static final String READ_CACHE_HIT_METRIC_NAME = "gcs-analytics-core.read.cache.hit";
+  private static final String READ_CACHE_MISS_METRIC_NAME = "gcs-analytics-core.read.cache.miss";
 
   private static final int LARGE_FILE_SIZE_THRESHOLD = 1024 * 1024 * 1024; // 1 GB.
   // Used for single-byte reads to avoid repeated allocation.
@@ -101,44 +112,93 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
 
   @Override
   public void seek(long newPos) throws IOException {
-    checkArgument(newPos >= 0, "position can't be negative: %s", newPos);
-    checkNotClosed("Cannot seek: already closed");
-    position = newPos;
-    channel.position(newPos);
+    Telemetry.getInstance()
+        .measure(
+            Operation.builder()
+                .setAttributes(
+                    ImmutableMap.of(
+                        CLASS_NAME_METRIC_NAME, GoogleCloudStorageInputStream.class.getName()))
+                .setName("SEEK")
+                .build(),
+            recorder -> {
+              checkArgument(newPos >= 0, "position can't be negative: %s", newPos);
+              checkNotClosed("Cannot seek: already closed");
+              recorder.record(SEEK_DISTANCE_METRIC_NAME, newPos - position, Collections.emptyMap());
+              position = newPos;
+              channel.position(newPos);
+              return null;
+            });
   }
 
   @Override
   public int read() throws IOException {
-    checkNotClosed("Cannot read: already closed");
-    // Delegate to the byte array read method to reuse the cache logic.
-    int bytesRead = read(singleByteBuffer.array(), 0, 1);
-    if (bytesRead == -1) {
-      return -1;
-    }
-    return singleByteBuffer.array()[0] & 0xFF;
+    return Telemetry.getInstance()
+        .measure(
+            Operation.builder()
+                .setName("READ")
+                .setAttributes(
+                    ImmutableMap.of(
+                        CLASS_NAME_METRIC_NAME, GoogleCloudStorageInputStream.class.getName()))
+                .setDurationMetricName(READ_DURATION_METRIC_NAME)
+                .build(),
+            recorder -> {
+              checkNotClosed("Cannot read: already closed");
+              // Delegate to the byte array read method to reuse the cache logic.
+              int bytesRead = read(singleByteBuffer.array(), 0, 1);
+              if (bytesRead == -1) {
+                return -1;
+              }
+              recorder.record(READ_BYTES_METRIC_NAME, bytesRead, Collections.emptyMap());
+
+              return singleByteBuffer.array()[0] & 0xFF;
+            });
   }
 
   @Override
   public int read(ByteBuffer byteBuffer) throws IOException {
-    checkNotClosed("Cannot read: already closed");
-    if (isMetadataInitialized() && prefetchBuffer == null && position >= fileSize - prefetchSize) {
-      cacheObjectOrFooter();
-    }
-    if (prefetchBuffer != null && (position >= fileSize - prefetchSize)) {
-      return serveFromCache(byteBuffer);
-    }
-    long channelPosition = channel.position();
-    checkState(
-        channelPosition == position,
-        "Channel position (%s) and stream position (%s) should be the same",
-        channelPosition,
-        position);
+    Map<String, String> telemetryAttributes =
+        ImmutableMap.<String, String>builder()
+            .put(CLASS_NAME_METRIC_NAME, GoogleCloudStorageInputStream.class.getName())
+            .put("read_length", String.valueOf(byteBuffer.remaining()))
+            .put("read_offset", String.valueOf(byteBuffer.position()))
+            .build();
+    return Telemetry.getInstance()
+        .measure(
+            Operation.builder()
+                .setName("READ")
+                .setDurationMetricName(READ_DURATION_METRIC_NAME)
+                .setAttributes(telemetryAttributes)
+                .build(),
+            recorder -> {
+              checkNotClosed("Cannot read: already closed");
+              if (isMetadataInitialized()
+                  && prefetchBuffer == null
+                  && position >= fileSize - prefetchSize) {
+                cacheObjectOrFooter();
+              }
+              if (prefetchBuffer != null && (position >= fileSize - prefetchSize)) {
+                int bytesRead = serveFromCache(byteBuffer);
+                if (bytesRead > 0) {
+                  recorder.record(READ_BYTES_METRIC_NAME, bytesRead, Collections.emptyMap());
+                  recorder.record(READ_CACHE_HIT_METRIC_NAME, 1, Collections.emptyMap());
+                }
+                return bytesRead;
+              }
+              recorder.record(READ_CACHE_MISS_METRIC_NAME, 1, Collections.emptyMap());
+              long channelPosition = channel.position();
+              checkState(
+                  channelPosition == position,
+                  "Channel position (%s) and stream position (%s) should be the same",
+                  channelPosition,
+                  position);
 
-    int bytesRead = channel.read(byteBuffer);
-    if (bytesRead > 0) {
-      position += bytesRead;
-    }
-    return bytesRead;
+              int bytesRead = channel.read(byteBuffer);
+              if (bytesRead > 0) {
+                position += bytesRead;
+                recorder.record(READ_BYTES_METRIC_NAME, bytesRead, Collections.emptyMap());
+              }
+              return bytesRead;
+            });
   }
 
   @Override
@@ -157,12 +217,18 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
 
   @Override
   public void close() throws IOException {
-    if (!closed) {
-      closed = true;
-      if (channel != null) {
-        channel.close();
-      }
-    }
+    Telemetry.getInstance()
+        .measure(
+            Operation.builder().setName("CLOSE").build(),
+            recorder -> {
+              if (!closed) {
+                closed = true;
+                if (channel != null) {
+                  channel.close();
+                }
+              }
+              return null;
+            });
   }
 
   private void checkNotClosed(String msg) throws IOException {
@@ -173,29 +239,51 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
 
   @Override
   public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
-    try (VectoredSeekableByteChannel byteChannel = openReadChannel()) {
-      byteChannel.position(position);
-      int numberOfBytesRead = byteChannel.read(ByteBuffer.wrap(buffer, offset, length));
-      if (numberOfBytesRead < length) {
-        throw new EOFException(
-            "Reached the end of stream with "
-                + (length - numberOfBytesRead)
-                + " bytes left to read");
-      }
-    }
+    Telemetry.getInstance()
+        .measure(
+            Operation.builder()
+                .setName("READ_FULLY")
+                .setDurationMetricName(READ_DURATION_METRIC_NAME)
+                .build(),
+            recorder -> {
+              try (VectoredSeekableByteChannel byteChannel = openReadChannel()) {
+                byteChannel.position(position);
+                int numberOfBytesRead = byteChannel.read(ByteBuffer.wrap(buffer, offset, length));
+                if (numberOfBytesRead < length) {
+                  throw new EOFException(
+                      "Reached the end of stream with "
+                          + (length - numberOfBytesRead)
+                          + " bytes left to read");
+                }
+                recorder.record(READ_BYTES_METRIC_NAME, numberOfBytesRead, Collections.emptyMap());
+              }
+              return null;
+            });
   }
 
   @Override
   public int readTail(byte[] buffer, int offset, int length) throws IOException {
-    if (!isMetadataInitialized()) {
-      initializeMetadata();
-    }
-    try (VectoredSeekableByteChannel byteChannel = openReadChannel()) {
-      long size = gcsFileInfo.getItemInfo().getSize();
-      long startPosition = Math.max(0, size - length);
-      byteChannel.position(startPosition);
-      return byteChannel.read(ByteBuffer.wrap(buffer, offset, length));
-    }
+    return Telemetry.getInstance()
+        .measure(
+            Operation.builder()
+                .setName("READ_TAIL")
+                .setDurationMetricName(READ_DURATION_METRIC_NAME)
+                .build(),
+            recorder -> {
+              if (!isMetadataInitialized()) {
+                initializeMetadata();
+              }
+              try (VectoredSeekableByteChannel byteChannel = openReadChannel()) {
+                long size = gcsFileInfo.getItemInfo().getSize();
+                long startPosition = Math.max(0, size - length);
+                byteChannel.position(startPosition);
+                int bytesRead = byteChannel.read(ByteBuffer.wrap(buffer, offset, length));
+                if (bytesRead > 0) {
+                  recorder.record(READ_BYTES_METRIC_NAME, bytesRead, Collections.emptyMap());
+                }
+                return bytesRead;
+              }
+            });
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@ limitations under the License.
         <apache.parquet.version>1.16.0</apache.parquet.version>
         <apache.avro.version>1.12.1</apache.avro.version>
         <apache.hadoop.version>3.4.2</apache.hadoop.version>
+        <slf4j.version>1.7.36</slf4j.version>
     </properties>
 
     <profiles>
@@ -381,8 +382,13 @@ limitations under the License.
 
             <dependency>
                 <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.36</version>
+                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.parquet</groupId>


### PR DESCRIPTION
The PR integrates telemetry to record following metrics.
1. READ_BYTES
2. READ_DURATION
3. SEEK_DISTANCE
4. CACHE_HIT count
5. CACHE_MISS count
All the captured metrics are logged using a default log reporter, enabled with configuration.
