### PR TITLE
feat: add new metrics for vectored read and gcs client creation operations.

### DIFF
--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auth.Credentials;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.gcs.analyticscore.common.telemetry.TelemetryOptions;
 import com.google.cloud.storage.BlobId;
@@ -43,18 +44,33 @@ public class GcsFileSystemImpl implements GcsFileSystem {
   public GcsFileSystemImpl(GcsFileSystemOptions fileSystemOptions) {
     this.fileSystemOptions = fileSystemOptions;
     this.executorServiceSupplier = initializeExecutionServiceSupplier();
-    this.gcsClient =
-        new GcsClientImpl(getGcsClientOptions(fileSystemOptions), executorServiceSupplier);
     initializeTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions());
+    this.gcsClient =
+        Telemetry.getInstance()
+            .measure(
+                GcsAnalyticsCoreTelemetryConstants.Operation.GCS_CLIENT_CREATE.name(),
+                GcsAnalyticsCoreTelemetryConstants.Metric.GCS_CLIENT_CREATE_DURATION.name(),
+                Collections.emptyMap(),
+                recorder ->
+                    new GcsClientImpl(
+                        getGcsClientOptions(fileSystemOptions), executorServiceSupplier));
   }
 
   public GcsFileSystemImpl(Credentials credentials, GcsFileSystemOptions fileSystemOptions) {
     this.fileSystemOptions = fileSystemOptions;
     this.executorServiceSupplier = initializeExecutionServiceSupplier();
-    this.gcsClient =
-        new GcsClientImpl(
-            credentials, getGcsClientOptions(fileSystemOptions), executorServiceSupplier);
     initializeTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions());
+    this.gcsClient =
+        Telemetry.getInstance()
+            .measure(
+                GcsAnalyticsCoreTelemetryConstants.Operation.GCS_CLIENT_CREATE.name(),
+                GcsAnalyticsCoreTelemetryConstants.Metric.GCS_CLIENT_CREATE_DURATION.name(),
+                Collections.emptyMap(),
+                recorder ->
+                    new GcsClientImpl(
+                        credentials,
+                        getGcsClientOptions(fileSystemOptions),
+                        executorServiceSupplier));
   }
 
   @VisibleForTesting
@@ -124,6 +140,10 @@ public class GcsFileSystemImpl implements GcsFileSystem {
       executorService.shutdownNow();
       Thread.currentThread().interrupt();
     }
+    fileSystemOptions
+        .getAnalyticsCoreTelemetryOptions()
+        .getOperationListeners()
+        .forEach(Telemetry.getInstance()::removeListener);
     gcsClient.close();
   }
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptions.java
@@ -40,6 +40,8 @@ public abstract class GcsFileSystemOptions {
 
   public abstract TelemetryOptions getAnalyticsCoreTelemetryOptions();
 
+  public abstract Builder toBuilder();
+
   public static Builder builder() {
     return new AutoValue_GcsFileSystemOptions.Builder()
         .setReadThreadCount(16)

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
@@ -181,10 +181,10 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
                   if (bytesRead < 0) {
                     // EOF reached.
                     break;
-                  }  
+                  }
+                  recorder.record(Metric.READ_BYTES.name(), bytesRead, Collections.emptyMap());
                   numOfBytesRead += bytesRead;
                 }
-                recorder.record(Metric.READ_BYTES.name(), numOfBytesRead, Collections.emptyMap());
                 if (numOfBytesRead < combinedObjectRange.getLength()) {
                   throw new EOFException(
                       String.format(

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
@@ -19,15 +19,22 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.cloud.ReadChannel;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Attribute;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Metric;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Operation;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.function.IntFunction;
@@ -129,6 +136,12 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
   @Override
   public void readVectored(List<GcsObjectRange> ranges, IntFunction<ByteBuffer> allocate)
       throws IOException {
+    Operation operation =
+        Operation.builder()
+            .setName(GcsAnalyticsCoreTelemetryConstants.Operation.VECTORED_READ.name())
+            .setDurationMetricName(Metric.READ_DURATION.name())
+            .setAttributes(buildCommonAttributes())
+            .build();
     ExecutorService executorService = executorServiceSupplier.get();
     checkNotNull(executorService, "Thread pool must not be null");
     GcsVectoredReadOptions vectoredReadOptions = readOptions.getGcsVectoredReadOptions();
@@ -142,43 +155,55 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
       var unused =
           executorService.submit(
               () -> {
-                readCombinedRange(combinedRange, allocate);
+                readCombinedRange(combinedRange, allocate, operation);
               });
     }
   }
 
   void readCombinedRange(
-      GcsObjectCombinedRange combinedObjectRange, IntFunction<ByteBuffer> allocate) {
-    try (ReadChannel channel = openReadChannel(itemId, readOptions)) {
-      validatePosition(combinedObjectRange.getOffset());
-      channel.seek(combinedObjectRange.getOffset());
-      channel.limit(combinedObjectRange.getOffset() + combinedObjectRange.getLength());
-      ByteBuffer dataBuffer = allocate.apply(combinedObjectRange.getLength());
-      int numOfBytesRead = 0;
-      while (dataBuffer.hasRemaining()) {
-        int bytesRead = channel.read(dataBuffer);
-        if (bytesRead < 0) {
-          // EOF reached.
-          break;
-        }
-        numOfBytesRead += bytesRead;
-      }
-      if (numOfBytesRead < combinedObjectRange.getLength()) {
-        throw new EOFException(
-            String.format(
-                "EOF reached while reading combinedObjectRange, range: %s, item: "
-                    + "%s, numRead: %d, expected: %d",
-                combinedObjectRange, itemId, numOfBytesRead, combinedObjectRange.getLength()));
-      }
-      // making it ready for reading
-      dataBuffer.flip();
-      for (GcsObjectRange underlyingRange : combinedObjectRange.getUnderlyingRanges()) {
-        populateGcsObjectRangeFromCombinedObjectRange(
-            combinedObjectRange, underlyingRange, numOfBytesRead, dataBuffer);
-      }
-    } catch (Exception e) {
-      completeWithException(combinedObjectRange, e);
-    }
+      GcsObjectCombinedRange combinedObjectRange,
+      IntFunction<ByteBuffer> allocate,
+      Operation operation) {
+    Telemetry.getInstance()
+        .measure(
+            operation,
+            recorder -> {
+              try (ReadChannel channel = openReadChannel(itemId, readOptions)) {
+                validatePosition(combinedObjectRange.getOffset());
+                channel.seek(combinedObjectRange.getOffset());
+                channel.limit(combinedObjectRange.getOffset() + combinedObjectRange.getLength());
+                ByteBuffer dataBuffer = allocate.apply(combinedObjectRange.getLength());
+                int numOfBytesRead = 0;
+                while (dataBuffer.hasRemaining()) {
+                  int bytesRead = channel.read(dataBuffer);
+                  if (bytesRead < 0) {
+                    // EOF reached.
+                    break;
+                  }
+                  numOfBytesRead += bytesRead;
+                }
+                if (numOfBytesRead < combinedObjectRange.getLength()) {
+                  throw new EOFException(
+                      String.format(
+                          "EOF reached while reading combinedObjectRange, range: %s, item: "
+                              + "%s, numRead: %d, expected: %d",
+                          combinedObjectRange,
+                          itemId,
+                          numOfBytesRead,
+                          combinedObjectRange.getLength()));
+                }
+                // making it ready for reading
+                dataBuffer.flip();
+                for (GcsObjectRange underlyingRange : combinedObjectRange.getUnderlyingRanges()) {
+                  populateGcsObjectRangeFromCombinedObjectRange(
+                      combinedObjectRange, underlyingRange, numOfBytesRead, dataBuffer);
+                }
+                recorder.record(Metric.READ_BYTES.name(), numOfBytesRead, Collections.emptyMap());
+              } catch (Exception e) {
+                completeWithException(combinedObjectRange, e);
+              }
+              return null;
+            });
   }
 
   private void populateGcsObjectRangeFromCombinedObjectRange(
@@ -248,5 +273,9 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
           String.format(
               "Invalid seek offset: position value (%d) must be >= 0 for '%s'", position, itemId));
     }
+  }
+
+  private static ImmutableMap<String, String> buildCommonAttributes() {
+    return ImmutableMap.of(Attribute.CLASS_NAME.name(), GcsReadChannel.class.getName());
   }
 }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
@@ -47,6 +47,8 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
   protected GcsItemId itemId;
   private long position = 0;
   private Supplier<ExecutorService> executorServiceSupplier;
+  private static final ImmutableMap<String, String> COMMON_ATTRIBUTES =
+      ImmutableMap.of(Attribute.CLASS_NAME.name(), GcsReadChannel.class.getName());
 
   GcsReadChannel(
       Storage storage,
@@ -140,7 +142,7 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
         Operation.builder()
             .setName(GcsAnalyticsCoreTelemetryConstants.Operation.VECTORED_READ.name())
             .setDurationMetricName(Metric.READ_DURATION.name())
-            .setAttributes(buildCommonAttributes())
+            .setAttributes(COMMON_ATTRIBUTES)
             .build();
     ExecutorService executorService = executorServiceSupplier.get();
     checkNotNull(executorService, "Thread pool must not be null");
@@ -179,9 +181,10 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
                   if (bytesRead < 0) {
                     // EOF reached.
                     break;
-                  }
+                  }  
                   numOfBytesRead += bytesRead;
                 }
+                recorder.record(Metric.READ_BYTES.name(), numOfBytesRead, Collections.emptyMap());
                 if (numOfBytesRead < combinedObjectRange.getLength()) {
                   throw new EOFException(
                       String.format(
@@ -198,7 +201,6 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
                   populateGcsObjectRangeFromCombinedObjectRange(
                       combinedObjectRange, underlyingRange, numOfBytesRead, dataBuffer);
                 }
-                recorder.record(Metric.READ_BYTES.name(), numOfBytesRead, Collections.emptyMap());
               } catch (Exception e) {
                 completeWithException(combinedObjectRange, e);
               }
@@ -275,7 +277,4 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
     }
   }
 
-  private static ImmutableMap<String, String> buildCommonAttributes() {
-    return ImmutableMap.of(Attribute.CLASS_NAME.name(), GcsReadChannel.class.getName());
-  }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
@@ -22,10 +22,8 @@ import static org.mockito.Mockito.*;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Operation;
 import com.google.cloud.gcs.analyticscore.common.telemetry.OperationListener;
-import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.gcs.analyticscore.common.telemetry.TelemetryOptions;
 import com.google.common.base.Supplier;
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -34,6 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,14 +61,22 @@ class GcsFileSystemImplTest {
     gcsFileSystem = new GcsFileSystemImpl(mockClient, TEST_GCS_FILESYSTEM_OPTIONS);
   }
 
+  @AfterEach
+  void tearDown() {
+    if (gcsFileSystem != null) {
+      gcsFileSystem.close();
+    }
+  }
+
   @Test
   void constructor_withCredentials_createsClientWithProvidedCredentials() {
-    GcsFileSystemImpl gcsFileSystem =
-        new GcsFileSystemImpl(NoCredentials.getInstance(), TEST_GCS_FILESYSTEM_OPTIONS);
-    GcsClientImpl gcsClientImpl = (GcsClientImpl) gcsFileSystem.getGcsClient();
+    try (GcsFileSystemImpl gcsFileSystem =
+        new GcsFileSystemImpl(NoCredentials.getInstance(), TEST_GCS_FILESYSTEM_OPTIONS)) {
+      GcsClientImpl gcsClientImpl = (GcsClientImpl) gcsFileSystem.getGcsClient();
 
-    assertThat(gcsClientImpl.storage.getOptions().getCredentials())
-        .isEqualTo(NoCredentials.getInstance());
+      assertThat(gcsClientImpl.storage.getOptions().getCredentials())
+          .isEqualTo(NoCredentials.getInstance());
+    }
   }
 
   @Test
@@ -79,12 +86,13 @@ class GcsFileSystemImplTest {
     GcsFileSystemOptions fileSystemOptions =
         GcsFileSystemOptions.builder().setGcsClientOptions(clientOptions).build();
 
-    GcsFileSystemImpl gcsFileSystem = new GcsFileSystemImpl(fileSystemOptions);
-    GcsClientImpl gcsClient = (GcsClientImpl) gcsFileSystem.getGcsClient();
+    try (GcsFileSystemImpl gcsFileSystem = new GcsFileSystemImpl(fileSystemOptions)) {
+      GcsClientImpl gcsClient = (GcsClientImpl) gcsFileSystem.getGcsClient();
 
-    assertThat(gcsFileSystem.getFileSystemOptions()).isSameInstanceAs(fileSystemOptions);
-    assertThat(gcsClient).isNotNull();
-    assertThat(gcsClient.storage.getOptions().getProjectId()).isEqualTo("test-project-default");
+      assertThat(gcsFileSystem.getFileSystemOptions()).isSameInstanceAs(fileSystemOptions);
+      assertThat(gcsClient).isNotNull();
+      assertThat(gcsClient.storage.getOptions().getProjectId()).isEqualTo("test-project-default");
+    }
   }
 
   @Test
@@ -100,14 +108,15 @@ class GcsFileSystemImplTest {
               capturedSupplier.set(supplier);
             })) {
 
-      new GcsFileSystemImpl(TEST_GCS_FILESYSTEM_OPTIONS);
-      ExecutorService executorService1 = capturedSupplier.get().get();
-      ExecutorService executorService2 = capturedSupplier.get().get();
+      try (GcsFileSystemImpl ignored = new GcsFileSystemImpl(TEST_GCS_FILESYSTEM_OPTIONS)) {
+        ExecutorService executorService1 = capturedSupplier.get().get();
+        ExecutorService executorService2 = capturedSupplier.get().get();
 
-      assertThat(mockGcsClientConstruction.constructed()).hasSize(1);
-      assertThat(capturedSupplier.get()).isNotNull();
-      assertThat(capturedSupplier.get().get()).isNotNull();
-      assertThat(executorService1).isEqualTo(executorService2);
+        assertThat(mockGcsClientConstruction.constructed()).hasSize(1);
+        assertThat(capturedSupplier.get()).isNotNull();
+        assertThat(capturedSupplier.get().get()).isNotNull();
+        assertThat(executorService1).isEqualTo(executorService2);
+      }
     }
   }
 
@@ -370,17 +379,15 @@ class GcsFileSystemImplTest {
   void initializeTelemetry_registerListenersToTelemetry() {
     OperationListener mockListener = mock(OperationListener.class);
     TelemetryOptions telemetryOptions =
-        TelemetryOptions.builder().setOperationListeners(ImmutableList.of(mockListener)).build();
+        TelemetryOptions.builder().setOperationListeners(Collections.singletonList(mockListener)).build();
     GcsFileSystemOptions options =
         GcsFileSystemOptions.builder()
             .setGcsClientOptions(TEST_GCS_CLIENT_OPTIONS)
             .setAnalyticsCoreTelemetryOptions(telemetryOptions)
             .build();
 
-    var unused = new GcsFileSystemImpl(options);
-    Telemetry.getInstance()
-        .measure("test-op", "test-duration", Collections.emptyMap(), (recorder) -> null);
-
-    verify(mockListener, times(2)).onOperationStart(any(Operation.class));
+    try (var unused = new GcsFileSystemImpl(options)) {
+      verify(mockListener, times(1)).onOperationStart(any(Operation.class));
+    }
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
@@ -381,6 +381,6 @@ class GcsFileSystemImplTest {
     Telemetry.getInstance()
         .measure("test-op", "test-duration", Collections.emptyMap(), (recorder) -> null);
 
-    verify(mockListener).onOperationStart(any(Operation.class));
+    verify(mockListener, times(2)).onOperationStart(any(Operation.class));
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelTest.java
@@ -19,6 +19,10 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.cloud.ReadChannel;
+import com.google.cloud.gcs.analyticscore.common.telemetry.MetricKey;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Operation;
+import com.google.cloud.gcs.analyticscore.common.telemetry.OperationListener;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
@@ -33,10 +37,14 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.IntFunction;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -439,6 +447,8 @@ class GcsReadChannelTest {
   @Test
   void readVectored_rangesCanBeMerged_readsRanges()
       throws IOException, ExecutionException, InterruptedException {
+    Telemetry telemetry = Telemetry.getInstance();
+    AtomicLong totalBytesReadFromMetrics = new AtomicLong(0L);
     GcsVectoredReadOptions vectoredReadOptions =
         GcsVectoredReadOptions.builder().setMaxMergeGap(10).build();
     List<Storage.BlobSourceOption> sourceOptions = Lists.newArrayList();
@@ -459,6 +469,20 @@ class GcsReadChannelTest {
             .build();
     BlobId blobId = BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L);
     createBlobInStorage(blobId, objectData);
+    OperationListener listener =
+        new OperationListener() {
+          @Override
+          public void onOperationStart(Operation operation) {}
+
+          @Override
+          public void onOperationEnd(Operation operation, Map<MetricKey, Long> metrics) {
+            if (operation.getName().equals("VECTORED_READ")) {
+              totalBytesReadFromMetrics.addAndGet(
+                  metrics.get(MetricKey.builder().setName("READ_BYTES").build()));
+            }
+          }
+        };
+    telemetry.addListener(listener);
     GcsReadChannel gcsReadChannel =
         new GcsReadChannel(storage, itemInfo, readOptions, executorServiceSupplier);
     // "hello", "world", "this", "string", "vectored"
@@ -474,6 +498,11 @@ class GcsReadChannelTest {
     assertThat(getGcsObjectRangeData(ranges.get(4))).isEqualTo("vectored");
     Mockito.verify(storage, Mockito.times(3))
         .reader(blobId, sourceOptions.toArray(new Storage.BlobSourceOption[0]));
+    assertThat(totalBytesReadFromMetrics.get()).isEqualTo(35L);
+
+    // Clean up.
+    telemetry.removeListener(listener);
+    gcsReadChannel.close();
   }
 
   @Test
@@ -559,6 +588,61 @@ class GcsReadChannelTest {
     gcsReadChannel.readVectored(ranges, ByteBuffer::allocate);
 
     assertThat(getGcsObjectRangeData(range1)).isEqualTo("abcdefghij");
+  }
+
+  @Test
+  void readVectored_eofReachedBeforeFullyRead_completesExceptionally() throws Exception {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
+    String objectData = "abcde";
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder()
+            .setItemId(itemId)
+            .setSize(objectData.length())
+            .setContentGeneration(0L)
+            .build();
+    createBlobInStorage(
+        BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
+    Storage mockStorage = Mockito.mock(Storage.class);
+    ReadChannel mockReadChannel = Mockito.mock(ReadChannel.class);
+    Mockito.when(
+            mockStorage.reader(
+                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
+        .thenReturn(mockReadChannel);
+    Mockito.when(mockReadChannel.isOpen()).thenReturn(true);
+    byte[] dataBytes = objectData.getBytes(StandardCharsets.UTF_8);
+    AtomicInteger callCount = new AtomicInteger(0);
+    Mockito.when(mockReadChannel.read(Mockito.any(ByteBuffer.class)))
+        .thenAnswer(
+            invocation -> {
+              ByteBuffer buffer = invocation.getArgument(0);
+              if (callCount.get() == 0) {
+                // Return 5 bytes on the first call
+                buffer.put(dataBytes, 0, 5);
+                callCount.incrementAndGet();
+                return 5;
+              } else {
+                // Return EOF on the second call
+                return -1;
+              }
+            });
+    GcsReadChannel gcsReadChannel =
+        new GcsReadChannel(mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+    // Request 10 bytes, but only 5 are returned before EOF
+    GcsObjectRange range1 = createRange(0, 10);
+    ImmutableList<GcsObjectRange> ranges = ImmutableList.of(range1);
+
+    gcsReadChannel.readVectored(ranges, ByteBuffer::allocate);
+    gcsReadChannel.close();
+
+    ExecutionException e =
+        assertThrows(ExecutionException.class, () -> range1.getByteBufferFuture().get());
+    assertThat(e).hasCauseThat().isInstanceOf(IOException.class);
+    assertThat(e).hasCauseThat().hasMessageThat().contains("Error while populating childRange");
+    assertThat(e.getCause().getCause()).isInstanceOf(EOFException.class);
+    assertThat(e.getCause().getCause())
+        .hasMessageThat()
+        .contains("EOF reached while reading combinedObjectRange");
   }
 
   private GcsObjectRange createRange(long offset, int length) {

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/GcsAnalyticsCoreTelemetryConstants.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/GcsAnalyticsCoreTelemetryConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/GcsAnalyticsCoreTelemetryConstants.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/GcsAnalyticsCoreTelemetryConstants.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.gcs.analyticscore.common;
+
+public class GcsAnalyticsCoreTelemetryConstants {
+  public enum Attribute {
+    CLASS_NAME,
+    READ_LENGTH,
+    READ_OFFSET;
+  }
+
+  public enum Metric {
+    SEEK_DISTANCE,
+    SEEK_DURATION,
+    READ_BYTES,
+    READ_DURATION,
+    OPEN_DURATION,
+    READ_CACHE_HIT,
+    READ_CACHE_MISS,
+    CLOSE_DURATION,
+    GCS_CLIENT_CREATE_DURATION;
+  }
+
+  public enum Operation {
+    SEEK,
+    READ,
+    CLOSE,
+    READ_FULLY,
+    READ_TAIL,
+    OPEN,
+    VECTORED_READ,
+    GCS_CLIENT_CREATE;
+  }
+}

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/Telemetry.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/Telemetry.java
@@ -40,18 +40,8 @@ public class Telemetry {
 
   /** Executes an operation with telemetry tracking. */
   public <T, E extends Throwable> T measure(
-      String operationName,
-      String durationMetricName,
-      Map<String, String> operationAttributes,
-      OperationSupplier<T, E> operationSupplier)
-      throws E {
+      Operation operation, OperationSupplier<T, E> operationSupplier) throws E {
     Map<MetricKey, Long> currentMetrics = new ConcurrentHashMap<>();
-    Operation operation =
-        Operation.builder()
-            .setName(operationName)
-            .setDurationMetricName(durationMetricName)
-            .setAttributes(operationAttributes)
-            .build();
     MetricsRecorder recorder =
         (name, value, attributes) -> {
           MetricKey key = MetricKey.builder().setName(name).setAttributes(attributes).build();
@@ -63,11 +53,45 @@ public class Telemetry {
       return operationSupplier.get(recorder);
     } finally {
       long durationNs = System.nanoTime() - startTime;
-      if (durationMetricName != null && !durationMetricName.isEmpty()) {
-        currentMetrics.put(MetricKey.builder().setName(durationMetricName).build(), durationNs);
+      if (operation.getDurationMetricName().isPresent()) {
+        currentMetrics.put(
+            MetricKey.builder().setName(operation.getDurationMetricName().get()).build(),
+            durationNs);
       }
       notifyEnd(operation, currentMetrics);
     }
+  }
+
+  public <T, E extends Throwable> T measure(
+      String operationId,
+      String operationName,
+      String durationMetricName,
+      Map<String, String> operationAttributes,
+      OperationSupplier<T, E> operationSupplier)
+      throws E {
+    Operation operation =
+        Operation.builder()
+            .setOperationId(operationId)
+            .setName(operationName)
+            .setDurationMetricName(durationMetricName)
+            .setAttributes(operationAttributes)
+            .build();
+    return measure(operation, operationSupplier);
+  }
+
+  public <T, E extends Throwable> T measure(
+      String operationName,
+      String durationMetricName,
+      Map<String, String> operationAttributes,
+      OperationSupplier<T, E> operationSupplier)
+      throws E {
+    Operation operation =
+        Operation.builder()
+            .setName(operationName)
+            .setDurationMetricName(durationMetricName)
+            .setAttributes(operationAttributes)
+            .build();
+    return measure(operation, operationSupplier);
   }
 
   /**

--- a/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
+++ b/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
@@ -29,6 +29,7 @@ import com.google.cloud.gcs.analyticscore.common.telemetry.MetricKey;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Operation;
 import com.google.cloud.gcs.analyticscore.common.telemetry.OperationListener;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
+import com.google.cloud.gcs.analyticscore.common.telemetry.TelemetryOptions;
 import com.google.cloud.storage.BlobId;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
@@ -37,6 +38,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -175,7 +177,6 @@ class GoogleCloudStorageInputStreamIntegrationTest {
         IntegrationTestHelper.TPCDS_CUSTOMER_SMALL_FILE,
       })
   void read_capturesTelemetryAttributes_withCorrectReadLength(String fileName) throws IOException {
-    Telemetry telemetry = Telemetry.getInstance();
     AtomicReference<Map<MetricKey, Long>> capturedReadMetrics = new AtomicReference<>();
     AtomicReference<Operation> capturedReadOperation = new AtomicReference<>();
     OperationListener listener =
@@ -191,7 +192,8 @@ class GoogleCloudStorageInputStreamIntegrationTest {
             }
           }
         };
-    telemetry.addListener(listener);
+    List<OperationListener> listeners = new ArrayList<>();
+    listeners.add(listener);
     URI uri = IntegrationTestHelper.getGcsObjectUriForFile(fileName);
     BlobId blobId = BlobId.fromGsUtilUri(uri.toString());
     GcsItemId gcsItemId =
@@ -201,6 +203,7 @@ class GoogleCloudStorageInputStreamIntegrationTest {
             .build();
     GcsFileSystemOptions gcsFileSystemOptions =
         GcsFileSystemOptions.createFromOptions(Map.of(), "gcs.");
+    gcsFileSystemOptions = gcsFileSystemOptions.toBuilder().setAnalyticsCoreTelemetryOptions(TelemetryOptions.builder().setOperationListeners(listeners).build()).build();
     GcsFileSystem gcsFileSystem = new GcsFileSystemImpl(gcsFileSystemOptions);
     ByteBuffer buffer = ByteBuffer.allocate(10);
     buffer.limit(5);
@@ -209,7 +212,6 @@ class GoogleCloudStorageInputStreamIntegrationTest {
         GoogleCloudStorageInputStream.create(gcsFileSystem, gcsItemId)) {
       googleCloudStorageInputStream.read(buffer);
     }
-    telemetry.removeListener(listener);
     
     MetricKey bytesReadKey =
         capturedReadMetrics.get().keySet().stream()

--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
@@ -18,6 +18,9 @@ package com.google.cloud.gcs.analyticscore.core;
 import static com.google.common.base.Preconditions.*;
 
 import com.google.cloud.gcs.analyticscore.client.*;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Attribute;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Metric;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Operation;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.BlobId;
 import com.google.common.collect.ImmutableMap;
@@ -39,32 +42,6 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
   private static final int LARGE_FILE_SIZE_THRESHOLD = 1024 * 1024 * 1024; // 1 GB.
   // Used for single-byte reads to avoid repeated allocation.
   private final ByteBuffer singleByteBuffer = ByteBuffer.wrap(new byte[1]);
-
-  private enum Attribute {
-    CLASS_NAME,
-    READ_LENGTH,
-    READ_OFFSET;
-  }
-
-  private enum Metric {
-    SEEK_DISTANCE,
-    SEEK_DURATION,
-    READ_BYTES,
-    READ_DURATION,
-    OPEN_DURATION,
-    READ_CACHE_HIT,
-    READ_CACHE_MISS,
-    CLOSE_DURATION;
-  }
-
-  private enum Operation {
-    SEEK,
-    READ,
-    CLOSE,
-    READ_FULLY,
-    READ_TAIL,
-    OPEN;
-  }
 
   private final GcsFileSystem gcsFileSystem;
   private final VectoredSeekableByteChannel channel;


### PR DESCRIPTION
The following metrics are added.

1. VECTORED_READ : bytes read and duration of reads.
2. GCS_CLIENT_CREATION : time taken to create gcs client.
