### PR TITLE
feat: add support for multiple types of telemetry reporters.

### DIFF
--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.auth.Credentials;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.*;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
@@ -40,20 +41,27 @@ class GcsClientImpl implements GcsClient {
   @VisibleForTesting Storage storage;
   private final GcsClientOptions clientOptions;
   private Supplier<ExecutorService> executorServiceSupplier;
+  private final Telemetry telemetry;
 
   GcsClientImpl(
       Credentials credentials,
       GcsClientOptions clientOptions,
-      Supplier<ExecutorService> executorServiceSupplier) {
+      Supplier<ExecutorService> executorServiceSupplier,
+      Telemetry telemetry) {
     this.clientOptions = clientOptions;
     this.storage = createStorage(Optional.of(credentials));
     this.executorServiceSupplier = executorServiceSupplier;
+    this.telemetry = telemetry;
   }
 
-  GcsClientImpl(GcsClientOptions clientOptions, Supplier<ExecutorService> executorServiceSupplier) {
+  GcsClientImpl(
+      GcsClientOptions clientOptions,
+      Supplier<ExecutorService> executorServiceSupplier,
+      Telemetry telemetry) {
     this.clientOptions = clientOptions;
     this.storage = createStorage(Optional.empty());
     this.executorServiceSupplier = executorServiceSupplier;
+    this.telemetry = telemetry;
   }
 
   @Override
@@ -65,7 +73,8 @@ class GcsClientImpl implements GcsClient {
         gcsItemInfo.getItemId().isGcsObject(),
         "Expected GCS object to be provided. But got: " + gcsItemInfo.getItemId());
 
-    return new GcsReadChannel(storage, gcsItemInfo, readOptions, executorServiceSupplier);
+    return new GcsReadChannel(
+        storage, gcsItemInfo, readOptions, executorServiceSupplier, telemetry);
   }
 
   @Override
@@ -73,7 +82,7 @@ class GcsClientImpl implements GcsClient {
       GcsItemId gcsItemId, GcsReadOptions readOptions) throws IOException {
     checkNotNull(gcsItemId, "gcsItemId should not be null");
     checkNotNull(readOptions, "readOptions should not be null");
-    return new GcsReadChannel(storage, gcsItemId, readOptions, executorServiceSupplier) {
+    return new GcsReadChannel(storage, gcsItemId, readOptions, executorServiceSupplier, telemetry) {
       @Override
       public long size() throws IOException {
         if (itemInfo == null) {

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -21,7 +21,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.auth.Credentials;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
-import com.google.cloud.storage.*;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
@@ -48,20 +52,25 @@ class GcsClientImpl implements GcsClient {
       GcsClientOptions clientOptions,
       Supplier<ExecutorService> executorServiceSupplier,
       Telemetry telemetry) {
-    this.clientOptions = clientOptions;
-    this.storage = createStorage(Optional.of(credentials));
-    this.executorServiceSupplier = executorServiceSupplier;
-    this.telemetry = telemetry;
+    this(Optional.of(credentials), clientOptions, executorServiceSupplier, telemetry);
   }
 
   GcsClientImpl(
       GcsClientOptions clientOptions,
       Supplier<ExecutorService> executorServiceSupplier,
       Telemetry telemetry) {
+    this(Optional.empty(), clientOptions, executorServiceSupplier, telemetry);
+  }
+
+  private GcsClientImpl(
+      Optional<Credentials> credentials,
+      GcsClientOptions clientOptions,
+      Supplier<ExecutorService> executorServiceSupplier,
+      Telemetry telemetry) {
     this.clientOptions = clientOptions;
-    this.storage = createStorage(Optional.empty());
     this.executorServiceSupplier = executorServiceSupplier;
     this.telemetry = telemetry;
+    this.storage = createStorage(credentials);
   }
 
   @Override

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystem.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystem.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.gcs.analyticscore.client;
 
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
@@ -60,6 +61,9 @@ public interface GcsFileSystem extends AutoCloseable {
 
   /** Retrieve the gcs client used to create this GcsFileSystem. */
   GcsClient getGcsClient();
+
+  /** Retrieve the telemetry instance used by this file system. */
+  Telemetry getTelemetry();
 
   /** Close the file system. */
   @Override

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auth.Credentials;
 import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants;
-import com.google.cloud.gcs.analyticscore.common.telemetry.CustomTelemetryOptions;
 import com.google.cloud.gcs.analyticscore.common.telemetry.LoggingTelemetryOptions;
 import com.google.cloud.gcs.analyticscore.common.telemetry.LoggingTelemetryReporter;
 import com.google.cloud.gcs.analyticscore.common.telemetry.OperationListener;
@@ -32,12 +31,9 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -163,16 +159,17 @@ public class GcsFileSystemImpl implements GcsFileSystem {
       executorService.shutdownNow();
       Thread.currentThread().interrupt();
     }
-    telemetry.close();
     gcsClient.close();
+    telemetry.close();
   }
 
   @VisibleForTesting
   static Telemetry createTelemetry(TelemetryOptions telemetryOptions) {
     ImmutableList.Builder<OperationListener> listeners = ImmutableList.builder();
-    telemetryOptions.getLoggingTelemetryOptions()
-    .filter(LoggingTelemetryOptions::isEnabled)
-    .ifPresent(options -> listeners.add(new LoggingTelemetryReporter(options)));
+    telemetryOptions
+        .getLoggingTelemetryOptions()
+        .filter(LoggingTelemetryOptions::isEnabled)
+        .ifPresent(options -> listeners.add(new LoggingTelemetryReporter(options)));
     telemetryOptions
         .getCustomTelemetryOptions()
         .ifPresent(options -> listeners.addAll(options.getOperationListeners()));

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
@@ -20,6 +20,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auth.Credentials;
 import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants;
+import com.google.cloud.gcs.analyticscore.common.telemetry.CustomTelemetryOptions;
+import com.google.cloud.gcs.analyticscore.common.telemetry.LoggingTelemetryOptions;
+import com.google.cloud.gcs.analyticscore.common.telemetry.LoggingTelemetryReporter;
+import com.google.cloud.gcs.analyticscore.common.telemetry.OperationListener;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.gcs.analyticscore.common.telemetry.TelemetryOptions;
 import com.google.cloud.storage.BlobId;
@@ -31,7 +35,9 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -56,7 +62,7 @@ public class GcsFileSystemImpl implements GcsFileSystem {
             Collections.emptyMap(),
             recorder ->
                 new GcsClientImpl(
-                    getGcsClientOptions(fileSystemOptions), executorServiceSupplier, telemetry));
+                    fileSystemOptions.getGcsClientOptions(), executorServiceSupplier, telemetry));
   }
 
   public GcsFileSystemImpl(Credentials credentials, GcsFileSystemOptions fileSystemOptions) {
@@ -71,7 +77,7 @@ public class GcsFileSystemImpl implements GcsFileSystem {
             recorder ->
                 new GcsClientImpl(
                     credentials,
-                    getGcsClientOptions(fileSystemOptions),
+                    fileSystemOptions.getGcsClientOptions(),
                     executorServiceSupplier,
                     telemetry));
   }
@@ -161,19 +167,16 @@ public class GcsFileSystemImpl implements GcsFileSystem {
     gcsClient.close();
   }
 
-  private static GcsClientOptions getGcsClientOptions(GcsFileSystemOptions fileSystemOptions) {
-    return fileSystemOptions.getGcsClientOptions() == null
-        ? GcsClientOptions.builder().build()
-        : fileSystemOptions.getGcsClientOptions();
-  }
-
   @VisibleForTesting
   static Telemetry createTelemetry(TelemetryOptions telemetryOptions) {
-    return new Telemetry(
-        telemetryOptions
-            .getCustomTelemetryOptions()
-            .map(options -> options.getOperationListeners())
-            .orElse(ImmutableList.of()));
+    ImmutableList.Builder<OperationListener> listeners = ImmutableList.builder();
+    telemetryOptions.getLoggingTelemetryOptions()
+    .filter(LoggingTelemetryOptions::isEnabled)
+    .ifPresent(options -> listeners.add(new LoggingTelemetryReporter(options)));
+    telemetryOptions
+        .getCustomTelemetryOptions()
+        .ifPresent(options -> listeners.addAll(options.getOperationListeners()));
+    return new Telemetry(listeners.build());
   }
 
   @VisibleForTesting

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
@@ -41,44 +41,54 @@ public class GcsFileSystemImpl implements GcsFileSystem {
   private final GcsFileSystemOptions fileSystemOptions;
   private final Supplier<ExecutorService> executorServiceSupplier;
 
+  private final Telemetry telemetry;
+
   public GcsFileSystemImpl(GcsFileSystemOptions fileSystemOptions) {
     this.fileSystemOptions = fileSystemOptions;
     this.executorServiceSupplier = initializeExecutionServiceSupplier();
-    initializeTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions());
+    this.telemetry = createTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions());
     this.gcsClient =
-        Telemetry.getInstance()
-            .measure(
-                GcsAnalyticsCoreTelemetryConstants.Operation.GCS_CLIENT_CREATE.name(),
-                GcsAnalyticsCoreTelemetryConstants.Metric.GCS_CLIENT_CREATE_DURATION.name(),
-                Collections.emptyMap(),
-                recorder ->
-                    new GcsClientImpl(
-                        getGcsClientOptions(fileSystemOptions), executorServiceSupplier));
+        telemetry.measure(
+            GcsAnalyticsCoreTelemetryConstants.Operation.GCS_CLIENT_CREATE.name(),
+            GcsAnalyticsCoreTelemetryConstants.Metric.GCS_CLIENT_CREATE_DURATION.name(),
+            Collections.emptyMap(),
+            recorder ->
+                new GcsClientImpl(
+                    getGcsClientOptions(fileSystemOptions), executorServiceSupplier, telemetry));
   }
 
   public GcsFileSystemImpl(Credentials credentials, GcsFileSystemOptions fileSystemOptions) {
     this.fileSystemOptions = fileSystemOptions;
     this.executorServiceSupplier = initializeExecutionServiceSupplier();
-    initializeTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions());
+    this.telemetry = createTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions());
     this.gcsClient =
-        Telemetry.getInstance()
-            .measure(
-                GcsAnalyticsCoreTelemetryConstants.Operation.GCS_CLIENT_CREATE.name(),
-                GcsAnalyticsCoreTelemetryConstants.Metric.GCS_CLIENT_CREATE_DURATION.name(),
-                Collections.emptyMap(),
-                recorder ->
-                    new GcsClientImpl(
-                        credentials,
-                        getGcsClientOptions(fileSystemOptions),
-                        executorServiceSupplier));
+        telemetry.measure(
+            GcsAnalyticsCoreTelemetryConstants.Operation.GCS_CLIENT_CREATE.name(),
+            GcsAnalyticsCoreTelemetryConstants.Metric.GCS_CLIENT_CREATE_DURATION.name(),
+            Collections.emptyMap(),
+            recorder ->
+                new GcsClientImpl(
+                    credentials,
+                    getGcsClientOptions(fileSystemOptions),
+                    executorServiceSupplier,
+                    telemetry));
   }
 
   @VisibleForTesting
   GcsFileSystemImpl(GcsClient gcsClient, GcsFileSystemOptions fileSystemOptions) {
+    this(
+        gcsClient,
+        fileSystemOptions,
+        createTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions()));
+  }
+
+  @VisibleForTesting
+  GcsFileSystemImpl(
+      GcsClient gcsClient, GcsFileSystemOptions fileSystemOptions, Telemetry telemetry) {
     this.gcsClient = gcsClient;
     this.fileSystemOptions = fileSystemOptions;
     this.executorServiceSupplier = initializeExecutionServiceSupplier();
-    initializeTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions());
+    this.telemetry = telemetry;
   }
 
   @Override
@@ -129,6 +139,11 @@ public class GcsFileSystemImpl implements GcsFileSystem {
   }
 
   @Override
+  public Telemetry getTelemetry() {
+    return telemetry;
+  }
+
+  @Override
   public void close() {
     ExecutorService executorService = executorServiceSupplier.get();
     executorService.shutdown();
@@ -140,10 +155,7 @@ public class GcsFileSystemImpl implements GcsFileSystem {
       executorService.shutdownNow();
       Thread.currentThread().interrupt();
     }
-    fileSystemOptions
-        .getAnalyticsCoreTelemetryOptions()
-        .getOperationListeners()
-        .forEach(Telemetry.getInstance()::removeListener);
+    telemetry.close();
     gcsClient.close();
   }
 
@@ -154,8 +166,8 @@ public class GcsFileSystemImpl implements GcsFileSystem {
   }
 
   @VisibleForTesting
-  void initializeTelemetry(TelemetryOptions telemetryOptions) {
-    telemetryOptions.getOperationListeners().forEach(Telemetry.getInstance()::addListener);
+  static Telemetry createTelemetry(TelemetryOptions telemetryOptions) {
+    return new Telemetry(telemetryOptions.getOperationListeners());
   }
 
   @VisibleForTesting

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
@@ -26,7 +26,9 @@ import com.google.cloud.storage.BlobId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
@@ -167,7 +169,11 @@ public class GcsFileSystemImpl implements GcsFileSystem {
 
   @VisibleForTesting
   static Telemetry createTelemetry(TelemetryOptions telemetryOptions) {
-    return new Telemetry(telemetryOptions.getOperationListeners());
+    return new Telemetry(
+        telemetryOptions
+            .getCustomTelemetryOptions()
+            .map(options -> options.getOperationListeners())
+            .orElse(ImmutableList.of()));
   }
 
   @VisibleForTesting

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
@@ -50,20 +50,25 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
   private static final ImmutableMap<String, String> COMMON_ATTRIBUTES =
       ImmutableMap.of(Attribute.CLASS_NAME.name(), GcsReadChannel.class.getName());
 
+  private final Telemetry telemetry;
+
   GcsReadChannel(
       Storage storage,
       GcsItemInfo itemInfo,
       GcsReadOptions readOptions,
-      Supplier<ExecutorService> executorServiceSupplier)
+      Supplier<ExecutorService> executorServiceSupplier,
+      Telemetry telemetry)
       throws IOException {
     checkNotNull(storage, "Storage instance cannot be null");
     checkNotNull(itemInfo, "Item info cannot be null");
     checkNotNull(executorServiceSupplier, "Thread pool supplier must not be null");
+    checkNotNull(telemetry, "Telemetry instance cannot be null");
     this.storage = storage;
     this.readOptions = readOptions;
     this.itemInfo = itemInfo;
     this.itemId = itemInfo.getItemId();
     this.executorServiceSupplier = executorServiceSupplier;
+    this.telemetry = telemetry;
     this.readChannel = openReadChannel(itemId, readOptions);
   }
 
@@ -71,15 +76,18 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
       Storage storage,
       GcsItemId itemId,
       GcsReadOptions readOptions,
-      Supplier<ExecutorService> executorServiceSupplier)
+      Supplier<ExecutorService> executorServiceSupplier,
+      Telemetry telemetry)
       throws IOException {
     checkNotNull(storage, "Storage instance cannot be null");
     checkNotNull(itemId, "Item id cannot be null");
     checkNotNull(executorServiceSupplier, "Thread pool supplier must not be null");
+    checkNotNull(telemetry, "Telemetry instance cannot be null");
     this.storage = storage;
     this.readOptions = readOptions;
     this.itemId = itemId;
     this.executorServiceSupplier = executorServiceSupplier;
+    this.telemetry = telemetry;
     this.readChannel = openReadChannel(itemId, readOptions);
   }
 
@@ -166,46 +174,45 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
       GcsObjectCombinedRange combinedObjectRange,
       IntFunction<ByteBuffer> allocate,
       Operation operation) {
-    Telemetry.getInstance()
-        .measure(
-            operation,
-            recorder -> {
-              try (ReadChannel channel = openReadChannel(itemId, readOptions)) {
-                validatePosition(combinedObjectRange.getOffset());
-                channel.seek(combinedObjectRange.getOffset());
-                channel.limit(combinedObjectRange.getOffset() + combinedObjectRange.getLength());
-                ByteBuffer dataBuffer = allocate.apply(combinedObjectRange.getLength());
-                int numOfBytesRead = 0;
-                while (dataBuffer.hasRemaining()) {
-                  int bytesRead = channel.read(dataBuffer);
-                  if (bytesRead < 0) {
-                    // EOF reached.
-                    break;
-                  }
-                  recorder.record(Metric.READ_BYTES.name(), bytesRead, Collections.emptyMap());
-                  numOfBytesRead += bytesRead;
-                }
-                if (numOfBytesRead < combinedObjectRange.getLength()) {
-                  throw new EOFException(
-                      String.format(
-                          "EOF reached while reading combinedObjectRange, range: %s, item: "
-                              + "%s, numRead: %d, expected: %d",
-                          combinedObjectRange,
-                          itemId,
-                          numOfBytesRead,
-                          combinedObjectRange.getLength()));
-                }
-                // making it ready for reading
-                dataBuffer.flip();
-                for (GcsObjectRange underlyingRange : combinedObjectRange.getUnderlyingRanges()) {
-                  populateGcsObjectRangeFromCombinedObjectRange(
-                      combinedObjectRange, underlyingRange, numOfBytesRead, dataBuffer);
-                }
-              } catch (Exception e) {
-                completeWithException(combinedObjectRange, e);
+    telemetry.measure(
+        operation,
+        recorder -> {
+          try (ReadChannel channel = openReadChannel(itemId, readOptions)) {
+            validatePosition(combinedObjectRange.getOffset());
+            channel.seek(combinedObjectRange.getOffset());
+            channel.limit(combinedObjectRange.getOffset() + combinedObjectRange.getLength());
+            ByteBuffer dataBuffer = allocate.apply(combinedObjectRange.getLength());
+            int numOfBytesRead = 0;
+            while (dataBuffer.hasRemaining()) {
+              int bytesRead = channel.read(dataBuffer);
+              if (bytesRead < 0) {
+                // EOF reached.
+                break;
               }
-              return null;
-            });
+              recorder.record(Metric.READ_BYTES.name(), bytesRead, Collections.emptyMap());
+              numOfBytesRead += bytesRead;
+            }
+            if (numOfBytesRead < combinedObjectRange.getLength()) {
+              throw new EOFException(
+                  String.format(
+                      "EOF reached while reading combinedObjectRange, range: %s, item: "
+                          + "%s, numRead: %d, expected: %d",
+                      combinedObjectRange,
+                      itemId,
+                      numOfBytesRead,
+                      combinedObjectRange.getLength()));
+            }
+            // making it ready for reading
+            dataBuffer.flip();
+            for (GcsObjectRange underlyingRange : combinedObjectRange.getUnderlyingRanges()) {
+              populateGcsObjectRangeFromCombinedObjectRange(
+                  combinedObjectRange, underlyingRange, numOfBytesRead, dataBuffer);
+            }
+          } catch (Exception e) {
+            completeWithException(combinedObjectRange, e);
+          }
+          return null;
+        });
   }
 
   private void populateGcsObjectRangeFromCombinedObjectRange(
@@ -276,5 +283,4 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
               "Invalid seek offset: position value (%d) must be >= 0 for '%s'", position, itemId));
     }
   }
-
 }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
@@ -59,21 +59,28 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
       Supplier<ExecutorService> executorServiceSupplier,
       Telemetry telemetry)
       throws IOException {
-    checkNotNull(storage, "Storage instance cannot be null");
-    checkNotNull(itemInfo, "Item info cannot be null");
-    checkNotNull(executorServiceSupplier, "Thread pool supplier must not be null");
-    checkNotNull(telemetry, "Telemetry instance cannot be null");
-    this.storage = storage;
-    this.readOptions = readOptions;
-    this.itemInfo = itemInfo;
-    this.itemId = itemInfo.getItemId();
-    this.executorServiceSupplier = executorServiceSupplier;
-    this.telemetry = telemetry;
-    this.readChannel = openReadChannel(itemId, readOptions);
+    this(
+        storage,
+        itemInfo,
+        checkNotNull(itemInfo, "Item info cannot be null").getItemId(),
+        readOptions,
+        executorServiceSupplier,
+        telemetry);
   }
 
   GcsReadChannel(
       Storage storage,
+      GcsItemId itemId,
+      GcsReadOptions readOptions,
+      Supplier<ExecutorService> executorServiceSupplier,
+      Telemetry telemetry)
+      throws IOException {
+    this(storage, null, itemId, readOptions, executorServiceSupplier, telemetry);
+  }
+
+  private GcsReadChannel(
+      Storage storage,
+      GcsItemInfo itemInfo,
       GcsItemId itemId,
       GcsReadOptions readOptions,
       Supplier<ExecutorService> executorServiceSupplier,
@@ -85,6 +92,7 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
     checkNotNull(telemetry, "Telemetry instance cannot be null");
     this.storage = storage;
     this.readOptions = readOptions;
+    this.itemInfo = itemInfo;
     this.itemId = itemId;
     this.executorServiceSupplier = executorServiceSupplier;
     this.telemetry = telemetry;

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -19,7 +19,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import autovalue.shaded.com.google.common.collect.ImmutableList;
 import com.google.auth.Credentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
@@ -27,6 +26,7 @@ import com.google.cloud.storage.*;
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -19,8 +19,10 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import autovalue.shaded.com.google.common.collect.ImmutableList;
 import com.google.auth.Credentials;
 import com.google.cloud.NoCredentials;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.*;
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.base.Supplier;
@@ -43,13 +45,14 @@ class GcsClientImplTest {
   private final Storage storage = LocalStorageHelper.getOptions().getService();
   private final Supplier<ExecutorService> executorServiceSupplier =
       Suppliers.memoize(() -> Executors.newFixedThreadPool(30));
+  private final Telemetry telemetry = new Telemetry(ImmutableList.of());
 
   private GcsClient gcsClient;
 
   @BeforeEach
   void setUp() throws IOException {
     gcsClient =
-        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier) {
+        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
           @Override
           protected Storage createStorage(Optional<Credentials> credentials) {
             return GcsClientImplTest.this.storage;
@@ -214,7 +217,10 @@ class GcsClientImplTest {
   void createStore_withCredentials_usesProvidedCredentials() throws IOException {
     GcsClientImpl client =
         new GcsClientImpl(
-            NoCredentials.getInstance(), TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier);
+            NoCredentials.getInstance(),
+            TEST_GCS_CLIENT_OPTIONS,
+            executorServiceSupplier,
+            telemetry);
 
     assertThat(client.storage.getOptions().getCredentials()).isEqualTo(NoCredentials.getInstance());
   }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
@@ -24,16 +24,19 @@ import static org.mockito.Mockito.*;
 
 import com.google.cloud.NoCredentials;
 import com.google.cloud.gcs.analyticscore.common.telemetry.CustomTelemetryOptions;
+import com.google.cloud.gcs.analyticscore.common.telemetry.LoggingTelemetryOptions;
+import com.google.cloud.gcs.analyticscore.common.telemetry.LoggingTelemetryReporter;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Operation;
 import com.google.cloud.gcs.analyticscore.common.telemetry.OperationListener;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.gcs.analyticscore.common.telemetry.TelemetryOptions;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -114,7 +117,7 @@ class GcsFileSystemImplTest {
               capturedSupplier.set(supplier);
             })) {
 
-      try (GcsFileSystemImpl ignored = new GcsFileSystemImpl(TEST_GCS_FILESYSTEM_OPTIONS)) {
+      try (GcsFileSystemImpl fs = new GcsFileSystemImpl(TEST_GCS_FILESYSTEM_OPTIONS)) {
         ExecutorService executorService1 = capturedSupplier.get().get();
         ExecutorService executorService2 = capturedSupplier.get().get();
 
@@ -396,8 +399,85 @@ class GcsFileSystemImplTest {
             .setAnalyticsCoreTelemetryOptions(telemetryOptions)
             .build();
 
-    try (var unused = new GcsFileSystemImpl(options)) {
+    try (GcsFileSystemImpl unused = new GcsFileSystemImpl(options)) {
       verify(mockListener, times(1)).onOperationStart(any(Operation.class));
+    }
+  }
+
+  @Test
+  void initializeTelemetry_withLoggingTelemetryOptionsEnabled_registersLoggingTelemetryReporter() {
+    LoggingTelemetryOptions loggingOptions =
+        LoggingTelemetryOptions.builder().setEnabled(true).build();
+    TelemetryOptions telemetryOptions =
+        TelemetryOptions.builder().setLoggingTelemetryOptions(loggingOptions).build();
+    GcsFileSystemOptions options =
+        GcsFileSystemOptions.builder()
+            .setGcsClientOptions(TEST_GCS_CLIENT_OPTIONS)
+            .setAnalyticsCoreTelemetryOptions(telemetryOptions)
+            .build();
+
+    try (GcsFileSystemImpl fileSystem = new GcsFileSystemImpl(options)) {
+      List<OperationListener> registeredListeners =
+          getRegisteredTelemetryListeners(fileSystem.getTelemetry());
+      OperationListener reporter = registeredListeners.get(0);
+
+      assertThat(reporter).isInstanceOf(LoggingTelemetryReporter.class);
+      assertThat(getRegisteredTelemetryListeners(fileSystem.getTelemetry())).contains(reporter);
+    }
+  }
+
+  @Test
+  void
+      initializeTelemetry_withLoggingTelemetryOptionsDisabled_doesNotRegisterLoggingTelemetryReporter() {
+    LoggingTelemetryOptions loggingOptions =
+        LoggingTelemetryOptions.builder().setEnabled(false).build();
+    TelemetryOptions telemetryOptions =
+        TelemetryOptions.builder().setLoggingTelemetryOptions(loggingOptions).build();
+    GcsFileSystemOptions options =
+        GcsFileSystemOptions.builder()
+            .setGcsClientOptions(TEST_GCS_CLIENT_OPTIONS)
+            .setAnalyticsCoreTelemetryOptions(telemetryOptions)
+            .build();
+
+    try (GcsFileSystemImpl fileSystem = new GcsFileSystemImpl(options)) {
+      assertThat(getRegisteredTelemetryListeners(fileSystem.getTelemetry())).isEmpty();
+    }
+  }
+
+  @Test
+  void close_removesRegisteredLoggingTelemetryReporters() {
+    LoggingTelemetryOptions loggingOptions =
+        LoggingTelemetryOptions.builder().setEnabled(true).build();
+    TelemetryOptions telemetryOptions =
+        TelemetryOptions.builder().setLoggingTelemetryOptions(loggingOptions).build();
+    GcsFileSystemOptions options =
+        GcsFileSystemOptions.builder()
+            .setGcsClientOptions(TEST_GCS_CLIENT_OPTIONS)
+            .setAnalyticsCoreTelemetryOptions(telemetryOptions)
+            .build();
+
+    GcsFileSystemImpl fileSystem = new GcsFileSystemImpl(options);
+    List<OperationListener> registeredListeners =
+        getRegisteredTelemetryListeners(fileSystem.getTelemetry());
+    assertThat(registeredListeners).hasSize(1);
+    OperationListener reporter = registeredListeners.get(0);
+
+    assertThat(getRegisteredTelemetryListeners(fileSystem.getTelemetry())).contains(reporter);
+
+    fileSystem.close();
+
+    assertThat(getRegisteredTelemetryListeners(fileSystem.getTelemetry())).isEmpty();
+    assertThat(getRegisteredTelemetryListeners(fileSystem.getTelemetry())).doesNotContain(reporter);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<OperationListener> getRegisteredTelemetryListeners(Telemetry telemetry) {
+    try {
+      java.lang.reflect.Field field = Telemetry.class.getDeclaredField("listeners");
+      field.setAccessible(true);
+      return (List<OperationListener>) field.get(telemetry);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to get Telemetry listeners", e);
     }
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
@@ -379,7 +379,9 @@ class GcsFileSystemImplTest {
   void initializeTelemetry_registerListenersToTelemetry() {
     OperationListener mockListener = mock(OperationListener.class);
     TelemetryOptions telemetryOptions =
-        TelemetryOptions.builder().setOperationListeners(Collections.singletonList(mockListener)).build();
+        TelemetryOptions.builder()
+            .setOperationListeners(Collections.singletonList(mockListener))
+            .build();
     GcsFileSystemOptions options =
         GcsFileSystemOptions.builder()
             .setGcsClientOptions(TEST_GCS_CLIENT_OPTIONS)

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
@@ -17,13 +17,19 @@ package com.google.cloud.gcs.analyticscore.client;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.google.cloud.NoCredentials;
+import com.google.cloud.gcs.analyticscore.common.telemetry.CustomTelemetryOptions;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Operation;
 import com.google.cloud.gcs.analyticscore.common.telemetry.OperationListener;
 import com.google.cloud.gcs.analyticscore.common.telemetry.TelemetryOptions;
 import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -378,10 +384,12 @@ class GcsFileSystemImplTest {
   @Test
   void initializeTelemetry_registerListenersToTelemetry() {
     OperationListener mockListener = mock(OperationListener.class);
-    TelemetryOptions telemetryOptions =
-        TelemetryOptions.builder()
-            .setOperationListeners(Collections.singletonList(mockListener))
+    CustomTelemetryOptions customTelemetryOptions =
+        CustomTelemetryOptions.builder()
+            .setOperationListeners(ImmutableList.of(mockListener))
             .build();
+    TelemetryOptions telemetryOptions =
+        TelemetryOptions.builder().setCustomTelemetryOptions(customTelemetryOptions).build();
     GcsFileSystemOptions options =
         GcsFileSystemOptions.builder()
             .setGcsClientOptions(TEST_GCS_CLIENT_OPTIONS)

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelTest.java
@@ -36,6 +36,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -43,7 +44,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.IntFunction;
 import org.junit.jupiter.api.Test;
@@ -58,6 +58,7 @@ class GcsReadChannelTest {
   private final Supplier<ExecutorService> executorServiceSupplier =
       Suppliers.memoize(() -> Executors.newFixedThreadPool(30));
   private final Storage storage = Mockito.spy(LocalStorageHelper.getOptions().getService());
+  private final Telemetry telemetry = new Telemetry(ImmutableList.of());
 
   @Test
   void constructor_nullStorage_throwsNullPointerException() {
@@ -75,7 +76,8 @@ class GcsReadChannelTest {
         assertThrows(
             NullPointerException.class,
             () ->
-                new GcsReadChannel(null, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier));
+                new GcsReadChannel(
+                    null, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry));
 
     assertThat(e).hasMessageThat().isEqualTo("Storage instance cannot be null");
   }
@@ -90,7 +92,7 @@ class GcsReadChannelTest {
             IllegalArgumentException.class,
             () ->
                 new GcsReadChannel(
-                    storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier));
+                    storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry));
 
     assertThat(e).hasMessageThat().isEqualTo("Expected Gcs Object but got " + itemInfo.getItemId());
   }
@@ -103,7 +105,9 @@ class GcsReadChannelTest {
     NullPointerException e =
         assertThrows(
             NullPointerException.class,
-            () -> new GcsReadChannel(null, itemId, TEST_GCS_READ_OPTIONS, executorServiceSupplier));
+            () ->
+                new GcsReadChannel(
+                    null, itemId, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry));
 
     assertThat(e).hasMessageThat().isEqualTo("Storage instance cannot be null");
   }
@@ -117,7 +121,7 @@ class GcsReadChannelTest {
             IllegalArgumentException.class,
             () ->
                 new GcsReadChannel(
-                    storage, itemId, TEST_GCS_READ_OPTIONS, executorServiceSupplier));
+                    storage, itemId, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry));
 
     assertThat(e).hasMessageThat().isEqualTo("Expected Gcs Object but got " + itemId);
   }
@@ -129,7 +133,11 @@ class GcsReadChannelTest {
             NullPointerException.class,
             () ->
                 new GcsReadChannel(
-                    storage, (GcsItemId) null, TEST_GCS_READ_OPTIONS, executorServiceSupplier));
+                    storage,
+                    (GcsItemId) null,
+                    TEST_GCS_READ_OPTIONS,
+                    executorServiceSupplier,
+                    telemetry));
 
     assertThat(e).hasMessageThat().isEqualTo("Item id cannot be null");
   }
@@ -141,7 +149,11 @@ class GcsReadChannelTest {
             NullPointerException.class,
             () ->
                 new GcsReadChannel(
-                    storage, (GcsItemInfo) null, TEST_GCS_READ_OPTIONS, executorServiceSupplier));
+                    storage,
+                    (GcsItemInfo) null,
+                    TEST_GCS_READ_OPTIONS,
+                    executorServiceSupplier,
+                    telemetry));
 
     assertThat(e).hasMessageThat().isEqualTo("Item info cannot be null");
   }
@@ -162,7 +174,7 @@ class GcsReadChannelTest {
         .thenReturn(mockReadChannel);
     Mockito.when(mockReadChannel.isOpen()).thenReturn(true);
 
-    new GcsReadChannel(mockStorage, itemInfo, readOptions, executorServiceSupplier);
+    new GcsReadChannel(mockStorage, itemInfo, readOptions, executorServiceSupplier, telemetry);
 
     Mockito.verify(mockReadChannel).setChunkSize(1024);
   }
@@ -181,7 +193,8 @@ class GcsReadChannelTest {
     createBlobInStorage(
         BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
     ByteBuffer buffer1 = ByteBuffer.allocate(5);
     ByteBuffer buffer2 = ByteBuffer.allocate(6);
 
@@ -209,7 +222,8 @@ class GcsReadChannelTest {
     createBlobInStorage(
         BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
     ByteBuffer buffer = ByteBuffer.allocate(objectData.length());
 
     int bytesRead = gcsReadChannel.read(buffer);
@@ -233,7 +247,8 @@ class GcsReadChannelTest {
     createBlobInStorage(
         BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
     gcsReadChannel.position(6);
     ByteBuffer buffer = ByteBuffer.allocate(5);
 
@@ -258,7 +273,8 @@ class GcsReadChannelTest {
     createBlobInStorage(
         BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
 
     EOFException e = assertThrows(EOFException.class, () -> gcsReadChannel.position(-1L));
 
@@ -281,7 +297,8 @@ class GcsReadChannelTest {
     createBlobInStorage(
         BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
     long size = objectData.length();
 
     gcsReadChannel.position(size + 1);
@@ -303,7 +320,8 @@ class GcsReadChannelTest {
     createBlobInStorage(
         BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
     ByteBuffer src = ByteBuffer.allocate(10);
 
     assertThrows(UnsupportedOperationException.class, () -> gcsReadChannel.write(src));
@@ -323,7 +341,8 @@ class GcsReadChannelTest {
     createBlobInStorage(
         BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
 
     assertThrows(UnsupportedOperationException.class, () -> gcsReadChannel.truncate(5L));
   }
@@ -342,7 +361,8 @@ class GcsReadChannelTest {
     createBlobInStorage(
         BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
 
     assertThat(gcsReadChannel.isOpen()).isTrue();
   }
@@ -361,7 +381,8 @@ class GcsReadChannelTest {
     createBlobInStorage(
         BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
     gcsReadChannel.close();
 
     assertThat(gcsReadChannel.isOpen()).isFalse();
@@ -381,7 +402,8 @@ class GcsReadChannelTest {
     createBlobInStorage(
         BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
 
     assertThat(gcsReadChannel.size()).isEqualTo(objectData.length());
   }
@@ -392,7 +414,8 @@ class GcsReadChannelTest {
         GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
     // Do not create the blob in storage to ensure metadata is not loaded
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemId, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            storage, itemId, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
 
     IOException e = assertThrows(IOException.class, () -> gcsReadChannel.size());
     assertThat(e).hasMessageThat().isEqualTo("Object metadata not initialized");
@@ -405,7 +428,8 @@ class GcsReadChannelTest {
     GcsItemInfo itemInfo =
         GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, TEST_GCS_READ_OPTIONS, Suppliers.memoize(() -> null));
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, Suppliers.memoize(() -> null), telemetry);
 
     NullPointerException e =
         assertThrows(
@@ -429,7 +453,7 @@ class GcsReadChannelTest {
     GcsReadOptions readOptions =
         TEST_GCS_READ_OPTIONS.builder().setGcsVectoredReadOptions(vectoredReadOptions).build();
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, readOptions, executorServiceSupplier);
+        new GcsReadChannel(storage, itemInfo, readOptions, executorServiceSupplier, telemetry);
     List<Storage.BlobSourceOption> sourceOptions = Lists.newArrayList();
     BlobId blobId = BlobId.of(itemId.getBucketName(), itemId.getObjectName().get());
     // "hello", "this", "test string"
@@ -447,7 +471,7 @@ class GcsReadChannelTest {
   @Test
   void readVectored_rangesCanBeMerged_readsRanges()
       throws IOException, ExecutionException, InterruptedException {
-    Telemetry telemetry = Telemetry.getInstance();
+
     AtomicLong totalBytesReadFromMetrics = new AtomicLong(0L);
     GcsVectoredReadOptions vectoredReadOptions =
         GcsVectoredReadOptions.builder().setMaxMergeGap(10).build();
@@ -482,9 +506,9 @@ class GcsReadChannelTest {
             }
           }
         };
-    telemetry.addListener(listener);
+    Telemetry telemetry = new Telemetry(Collections.singletonList(listener));
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, readOptions, executorServiceSupplier);
+        new GcsReadChannel(storage, itemInfo, readOptions, executorServiceSupplier, telemetry);
     // "hello", "world", "this", "string", "vectored"
     ImmutableList<GcsObjectRange> ranges =
         createRanges(ImmutableMap.of(0L, 5, 6L, 5, 12L, 4, 27L, 6, 38L, 8));
@@ -501,7 +525,7 @@ class GcsReadChannelTest {
     assertThat(totalBytesReadFromMetrics.get()).isEqualTo(35L);
 
     // Clean up.
-    telemetry.removeListener(listener);
+
     gcsReadChannel.close();
   }
 
@@ -519,7 +543,8 @@ class GcsReadChannelTest {
     createBlobInStorage(
         BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
     ImmutableList<GcsObjectRange> ranges = createRanges(ImmutableMap.of(0L, 5));
     IntFunction<ByteBuffer> badAllocator =
         size -> {
@@ -582,7 +607,8 @@ class GcsReadChannelTest {
             });
 
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
     GcsObjectRange range1 = createRange(0, 10);
     ImmutableList<GcsObjectRange> ranges = ImmutableList.of(range1);
     gcsReadChannel.readVectored(ranges, ByteBuffer::allocate);
@@ -627,7 +653,8 @@ class GcsReadChannelTest {
               }
             });
     GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier);
+        new GcsReadChannel(
+            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
     // Request 10 bytes, but only 5 are returned before EOF
     GcsObjectRange range1 = createRange(0, 10);
     ImmutableList<GcsObjectRange> ranges = ImmutableList.of(range1);

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -65,5 +65,9 @@ limitations under the License.
             <artifactId>truth</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -41,6 +41,10 @@ limitations under the License.
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
@@ -61,6 +65,5 @@ limitations under the License.
             <artifactId>truth</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 </project>

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/CustomTelemetryOptions.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/CustomTelemetryOptions.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,23 +16,23 @@
 package com.google.cloud.gcs.analyticscore.common.telemetry;
 
 import com.google.auto.value.AutoValue;
-import java.util.Optional;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 
-/** Options for Telemetry. */
+/** Options for Custom Telemetry. */
 @AutoValue
-public abstract class TelemetryOptions {
+public abstract class CustomTelemetryOptions {
 
-  public abstract Optional<CustomTelemetryOptions> getCustomTelemetryOptions();
+  public abstract ImmutableList<OperationListener> getOperationListeners();
 
   public static Builder builder() {
-    return new AutoValue_TelemetryOptions.Builder();
+    return new AutoValue_CustomTelemetryOptions.Builder().setOperationListeners(ImmutableList.of());
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
+    public abstract Builder setOperationListeners(List<OperationListener> operationListeners);
 
-    public abstract Builder setCustomTelemetryOptions(CustomTelemetryOptions options);
-
-    public abstract TelemetryOptions build();
+    public abstract CustomTelemetryOptions build();
   }
 }

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/LoggingTelemetryOptions.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/LoggingTelemetryOptions.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,37 @@
 package com.google.cloud.gcs.analyticscore.common.telemetry;
 
 import com.google.auto.value.AutoValue;
-import java.util.Optional;
 
-/** Options for Telemetry. */
+/** Options for Logging Telemetry. */
 @AutoValue
-public abstract class TelemetryOptions {
+public abstract class LoggingTelemetryOptions {
 
-  public abstract Optional<CustomTelemetryOptions> getCustomTelemetryOptions();
+  public enum LogLevel {
+    TRACE,
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR
+  }
 
-  public abstract Optional<LoggingTelemetryOptions> getLoggingTelemetryOptions();
+  public abstract LogLevel getLogLevel();
+
+  public abstract boolean isEnabled();
 
   public static Builder builder() {
-    return new AutoValue_TelemetryOptions.Builder();
+    return new AutoValue_LoggingTelemetryOptions.Builder()
+        .setEnabled(false)
+        .setLogLevel(LogLevel.DEBUG);
   }
+
+  public abstract Builder toBuilder();
 
   @AutoValue.Builder
   public abstract static class Builder {
+    public abstract Builder setLogLevel(LogLevel logLevel);
 
-    public abstract Builder setCustomTelemetryOptions(CustomTelemetryOptions options);
+    public abstract Builder setEnabled(boolean enabled);
 
-    public abstract Builder setLoggingTelemetryOptions(LoggingTelemetryOptions options);
-
-    public abstract TelemetryOptions build();
+    public abstract LoggingTelemetryOptions build();
   }
 }

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/LoggingTelemetryReporter.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/LoggingTelemetryReporter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.gcs.analyticscore.common.telemetry;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A telemetry reporter that logs operations and their metrics using SLF4J. The format and log level
+ * are customizable through {@link LoggingTelemetryOptions}.
+ */
+public class LoggingTelemetryReporter implements OperationListener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LoggingTelemetryReporter.class);
+
+  private final LoggingTelemetryOptions options;
+
+  public LoggingTelemetryReporter(LoggingTelemetryOptions options) {
+    this.options = options;
+  }
+
+  @Override
+  public void onOperationStart(Operation operation) {
+    String message =
+        String.format(
+            "Operation started: [%s], id: [%s], attributes: %s",
+            operation.getName(), operation.getOperationId(), operation.getAttributes());
+    logMessage(message);
+  }
+
+  @Override
+  public void onOperationEnd(Operation operation, Map<MetricKey, Long> metrics) {
+    String message =
+        String.format(
+            "Operation ended: [%s], id: [%s], attributes: %s, metrics: %s",
+            operation.getName(),
+            operation.getOperationId(),
+            operation.getAttributes(),
+            formatMetrics(metrics));
+    logMessage(message);
+  }
+
+  /**
+   * Formats a map of metrics into a generic, readable string. Sample : {metric1=1, metric2=2,
+   * metric3=3}
+   */
+  @VisibleForTesting
+  String formatMetrics(Map<MetricKey, Long> metrics) {
+    if (metrics == null || metrics.isEmpty()) {
+      return "{}";
+    }
+    StringBuilder sb = new StringBuilder("{");
+    boolean first = true;
+    for (Map.Entry<MetricKey, Long> entry : metrics.entrySet()) {
+      if (!first) {
+        sb.append(", ");
+      }
+      first = false;
+      MetricKey key = entry.getKey();
+      sb.append(key.getName());
+      if (key.getAttributes() != null && !key.getAttributes().isEmpty()) {
+        sb.append(key.getAttributes());
+      }
+      sb.append("=").append(entry.getValue());
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+
+  private void logMessage(String message) {
+    switch (options.getLogLevel()) {
+      case TRACE:
+        LOG.trace(message);
+        break;
+      case DEBUG:
+        LOG.debug(message);
+        break;
+      case WARNING:
+        LOG.warn(message);
+        break;
+      case ERROR:
+        LOG.error(message);
+        break;
+      case INFO:
+      default:
+        LOG.info(message);
+        break;
+    }
+  }
+}

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/Telemetry.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/Telemetry.java
@@ -104,7 +104,7 @@ public class Telemetry implements AutoCloseable {
       try {
         listener.onOperationStart(operation);
       } catch (Exception e) {
-        LOG.info("Exception in notifyStart for listener {}", listener.getClass().getName(), e);
+        LOG.error("Exception in notifyStart for listener {}", listener.getClass().getName(), e);
       }
     }
   }
@@ -114,7 +114,7 @@ public class Telemetry implements AutoCloseable {
       try {
         listener.onOperationEnd(operation, metrics);
       } catch (Exception e) {
-        LOG.info("Exception in notifyEnd for listener {}", listener.getClass().getName(), e);
+        LOG.error("Exception in notifyEnd for listener {}", listener.getClass().getName(), e);
       }
     }
   }

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/Telemetry.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/Telemetry.java
@@ -20,22 +20,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class Telemetry {
+public class Telemetry implements AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(Telemetry.class);
 
-  private static final Telemetry INSTANCE = new Telemetry();
   private final List<OperationListener> listeners = new CopyOnWriteArrayList<>();
 
-  public static Telemetry getInstance() {
-    return INSTANCE;
-  }
-
-  public void addListener(OperationListener listener) {
-    listeners.add(listener);
-  }
-
-  public void removeListener(OperationListener listener) {
-    listeners.remove(listener);
+  public Telemetry(List<OperationListener> listeners) {
+    this.listeners.addAll(listeners);
   }
 
   /** Executes an operation with telemetry tracking. */
@@ -47,8 +41,8 @@ public class Telemetry {
           MetricKey key = MetricKey.builder().setName(name).setAttributes(attributes).build();
           currentMetrics.merge(key, value, Long::sum);
         };
-    long startTime = System.nanoTime();
     notifyStart(operation);
+    long startTime = System.nanoTime();
     try {
       return operationSupplier.get(recorder);
     } finally {
@@ -107,13 +101,26 @@ public class Telemetry {
 
   private void notifyStart(Operation operation) {
     for (OperationListener listener : listeners) {
-      listener.onOperationStart(operation);
+      try {
+        listener.onOperationStart(operation);
+      } catch (Exception e) {
+        LOG.info("Exception in notifyStart for listener {}", listener.getClass().getName(), e);
+      }
     }
   }
 
   private void notifyEnd(Operation operation, Map<MetricKey, Long> metrics) {
     for (OperationListener listener : listeners) {
-      listener.onOperationEnd(operation, metrics);
+      try {
+        listener.onOperationEnd(operation, metrics);
+      } catch (Exception e) {
+        LOG.info("Exception in notifyEnd for listener {}", listener.getClass().getName(), e);
+      }
     }
+  }
+
+  @Override
+  public void close() {
+    listeners.clear();
   }
 }

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/LoggingTelemetryReporterTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/LoggingTelemetryReporterTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.gcs.analyticscore.common.telemetry;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LoggingTelemetryReporterTest {
+
+  @Test
+  public void testLoggingOptionsDefaultValues() {
+    LoggingTelemetryOptions options = LoggingTelemetryOptions.builder().build();
+
+    assertThat(options.isEnabled()).isFalse();
+    assertThat(options.getLogLevel()).isEqualTo(LoggingTelemetryOptions.LogLevel.DEBUG);
+  }
+
+  @Test
+  public void testLoggingOptionsCustomValues() {
+    LoggingTelemetryOptions options =
+        LoggingTelemetryOptions.builder()
+            .setEnabled(true)
+            .setLogLevel(LoggingTelemetryOptions.LogLevel.INFO)
+            .build();
+
+    assertThat(options.isEnabled()).isTrue();
+    assertThat(options.getLogLevel()).isEqualTo(LoggingTelemetryOptions.LogLevel.INFO);
+  }
+
+  @Test
+  public void testFormatMetrics_singleMetricWithoutAttributes() {
+    LoggingTelemetryReporter reporter =
+        new LoggingTelemetryReporter(LoggingTelemetryOptions.builder().build());
+    Map<MetricKey, Long> metrics = Map.of(MetricKey.builder().setName("TestMetric").build(), 100L);
+
+    String formattedMetrics = reporter.formatMetrics(metrics);
+
+    assertThat(formattedMetrics).isEqualTo("{TestMetric=100}");
+  }
+
+  @Test
+  public void testFormatMetrics_singleMetricWithAttributes() {
+    LoggingTelemetryReporter reporter =
+        new LoggingTelemetryReporter(LoggingTelemetryOptions.builder().build());
+    Map<MetricKey, Long> metrics =
+        Map.of(
+            MetricKey.builder()
+                .setName("TestMetric")
+                .setAttributes(Map.of("key1", "value1", "key2", "value2"))
+                .build(),
+            100L);
+
+    String formattedMetrics = reporter.formatMetrics(metrics);
+
+    assertThat(formattedMetrics)
+        .isAnyOf(
+            "{TestMetric{key1=value1, key2=value2}=100}",
+            "{TestMetric{key2=value2, key1=value1}=100}");
+  }
+
+  @Test
+  public void testFormatMetrics_multipleMetrics() {
+    LoggingTelemetryReporter reporter =
+        new LoggingTelemetryReporter(LoggingTelemetryOptions.builder().build());
+    Map<MetricKey, Long> metrics =
+        Map.of(
+            MetricKey.builder().setName("Metric1").build(),
+            100L,
+            MetricKey.builder().setName("Metric2").setAttributes(Map.of("key", "value")).build(),
+            200L);
+
+    String formattedMetrics = reporter.formatMetrics(metrics);
+
+    assertThat(formattedMetrics)
+        .isAnyOf("{Metric1=100, Metric2{key=value}=200}", "{Metric2{key=value}=200, Metric1=100}");
+  }
+}

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/TelemetryOptionsTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/TelemetryOptionsTest.java
@@ -23,13 +23,7 @@ import org.junit.jupiter.api.Test;
 public class TelemetryOptionsTest {
 
   @Test
-  public void testDefaultBuilder() {
-    TelemetryOptions options = TelemetryOptions.builder().build();
-    assertThat(options.getOperationListeners()).isEmpty();
-  }
-
-  @Test
-  public void testBuilderWithOperationListeners() {
+  public void testBuilderWithCustomTelemetryOptions() {
     OperationListener listener =
         new OperationListener() {
           @Override
@@ -38,8 +32,12 @@ public class TelemetryOptionsTest {
           @Override
           public void onOperationEnd(Operation operation, java.util.Map<MetricKey, Long> metrics) {}
         };
+    CustomTelemetryOptions customTelemetryOptions =
+        CustomTelemetryOptions.builder().setOperationListeners(ImmutableList.of(listener)).build();
     TelemetryOptions options =
-        TelemetryOptions.builder().setOperationListeners(ImmutableList.of(listener)).build();
-    assertThat(options.getOperationListeners()).containsExactly(listener);
+        TelemetryOptions.builder().setCustomTelemetryOptions(customTelemetryOptions).build();
+
+    assertThat(options.getCustomTelemetryOptions().get().getOperationListeners())
+        .containsExactly(listener);
   }
 }

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/TelemetryTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/TelemetryTest.java
@@ -19,7 +19,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Collections;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,14 +29,8 @@ class TelemetryTest {
 
   @BeforeEach
   void setUp() {
-    telemetry = Telemetry.getInstance();
     listener = new FakeOperationMetricsListener();
-    telemetry.addListener(listener);
-  }
-
-  @AfterEach
-  void tearDown() {
-    telemetry.removeListener(listener);
+    telemetry = new Telemetry(Collections.singletonList(listener));
   }
 
   @Test

--- a/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
+++ b/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
@@ -162,14 +162,13 @@ class GoogleCloudStorageInputStreamIntegrationTest {
                 "gcs.analytics-core.small-file.cache.threshold-bytes",
                 "1048576"),
             "gcs.");
-    GcsFileSystem gcsFileSystem = new GcsFileSystemImpl(gcsFileSystemOptions);
-    GoogleCloudStorageInputStream googleCloudStorageInputStream =
-            GoogleCloudStorageInputStream.create(gcsFileSystem, gcsItemId);
-
-    byte[] buffer = new byte[1024];
-    int bytesRead = googleCloudStorageInputStream.read(buffer);
-    assertTrue(bytesRead > 0);
-    googleCloudStorageInputStream.close();
+    try (GcsFileSystem gcsFileSystem = new GcsFileSystemImpl(gcsFileSystemOptions);
+         GoogleCloudStorageInputStream googleCloudStorageInputStream =
+             GoogleCloudStorageInputStream.create(gcsFileSystem, gcsItemId)) {
+      byte[] buffer = new byte[1024];
+      int bytesRead = googleCloudStorageInputStream.read(buffer);
+      assertTrue(bytesRead > 0);
+    }
   }
 
   @ParameterizedTest
@@ -204,16 +203,24 @@ class GoogleCloudStorageInputStreamIntegrationTest {
             .build();
     GcsFileSystemOptions gcsFileSystemOptions =
         GcsFileSystemOptions.createFromOptions(Map.of(), "gcs.");
-    gcsFileSystemOptions = gcsFileSystemOptions.toBuilder().setAnalyticsCoreTelemetryOptions(TelemetryOptions.builder().setCustomTelemetryOptions(CustomTelemetryOptions.builder().setOperationListeners(listeners).build()).build()).build();
-    GcsFileSystem gcsFileSystem = new GcsFileSystemImpl(gcsFileSystemOptions);
-    ByteBuffer buffer = ByteBuffer.allocate(10);
-    buffer.limit(5);
+    gcsFileSystemOptions =
+        gcsFileSystemOptions.toBuilder()
+            .setAnalyticsCoreTelemetryOptions(
+                TelemetryOptions.builder()
+                    .setCustomTelemetryOptions(
+                        CustomTelemetryOptions.builder()
+                            .setOperationListeners(listeners)
+                            .build())
+                    .build())
+            .build();
+    try (GcsFileSystem gcsFileSystem = new GcsFileSystemImpl(gcsFileSystemOptions);
+        GoogleCloudStorageInputStream googleCloudStorageInputStream =
+            GoogleCloudStorageInputStream.create(gcsFileSystem, gcsItemId)) {
+      ByteBuffer buffer = ByteBuffer.allocate(10);
+      buffer.limit(5);
 
-    try (GoogleCloudStorageInputStream googleCloudStorageInputStream =
-        GoogleCloudStorageInputStream.create(gcsFileSystem, gcsItemId)) {
       googleCloudStorageInputStream.read(buffer);
     }
-    gcsFileSystem.close();
     
     MetricKey bytesReadKey =
         capturedReadMetrics.get().keySet().stream()

--- a/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
+++ b/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
@@ -26,6 +26,7 @@ import com.google.cloud.gcs.analyticscore.client.GcsFileSystemImpl;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsItemId;
 import com.google.cloud.gcs.analyticscore.common.telemetry.MetricKey;
+import com.google.cloud.gcs.analyticscore.common.telemetry.CustomTelemetryOptions;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Operation;
 import com.google.cloud.gcs.analyticscore.common.telemetry.OperationListener;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
@@ -203,7 +204,7 @@ class GoogleCloudStorageInputStreamIntegrationTest {
             .build();
     GcsFileSystemOptions gcsFileSystemOptions =
         GcsFileSystemOptions.createFromOptions(Map.of(), "gcs.");
-    gcsFileSystemOptions = gcsFileSystemOptions.toBuilder().setAnalyticsCoreTelemetryOptions(TelemetryOptions.builder().setOperationListeners(listeners).build()).build();
+    gcsFileSystemOptions = gcsFileSystemOptions.toBuilder().setAnalyticsCoreTelemetryOptions(TelemetryOptions.builder().setCustomTelemetryOptions(CustomTelemetryOptions.builder().setOperationListeners(listeners).build()).build()).build();
     GcsFileSystem gcsFileSystem = new GcsFileSystemImpl(gcsFileSystemOptions);
     ByteBuffer buffer = ByteBuffer.allocate(10);
     buffer.limit(5);
@@ -212,6 +213,7 @@ class GoogleCloudStorageInputStreamIntegrationTest {
         GoogleCloudStorageInputStream.create(gcsFileSystem, gcsItemId)) {
       googleCloudStorageInputStream.read(buffer);
     }
+    gcsFileSystem.close();
     
     MetricKey bytesReadKey =
         capturedReadMetrics.get().keySet().stream()

--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
@@ -21,7 +21,6 @@ import com.google.cloud.gcs.analyticscore.client.*;
 import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Attribute;
 import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Metric;
 import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Operation;
-import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.BlobId;
 import com.google.common.collect.ImmutableMap;
 import java.io.EOFException;
@@ -105,7 +104,8 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
 
   @Override
   public void seek(long newPos) throws IOException {
-    Telemetry.getInstance()
+    gcsFileSystem
+        .getTelemetry()
         .measure(
             Operation.SEEK.name(),
             Metric.SEEK_DURATION.name(),
@@ -141,7 +141,8 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
             .put(Attribute.READ_LENGTH.name(), String.valueOf(byteBuffer.remaining()))
             .put(Attribute.READ_OFFSET.name(), String.valueOf(byteBuffer.position()))
             .build();
-    return Telemetry.getInstance()
+    return gcsFileSystem
+        .getTelemetry()
         .measure(
             Operation.READ.name(),
             Metric.READ_DURATION.name(),
@@ -194,7 +195,8 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
 
   @Override
   public void close() throws IOException {
-    Telemetry.getInstance()
+    gcsFileSystem
+        .getTelemetry()
         .measure(
             Operation.CLOSE.name(),
             Metric.CLOSE_DURATION.name(),
@@ -218,7 +220,8 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
 
   @Override
   public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
-    Telemetry.getInstance()
+    gcsFileSystem
+        .getTelemetry()
         .measure(
             Operation.READ_FULLY.name(),
             Metric.READ_DURATION.name(),
@@ -243,7 +246,8 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
 
   @Override
   public int readTail(byte[] buffer, int offset, int length) throws IOException {
-    return Telemetry.getInstance()
+    return gcsFileSystem
+        .getTelemetry()
         .measure(
             Operation.READ_TAIL.name(),
             Metric.READ_DURATION.name(),
@@ -359,7 +363,8 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
   private static VectoredSeekableByteChannel openReadChannel(
       GcsFileSystem gcsFileSystem, GcsItemId gcsItemId, GcsFileInfo gcsFileInfo)
       throws IOException {
-    return Telemetry.getInstance()
+    return gcsFileSystem
+        .getTelemetry()
         .measure(
             Operation.OPEN.name(),
             Metric.OPEN_DURATION.name(),

--- a/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamTest.java
+++ b/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamTest.java
@@ -21,6 +21,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.google.cloud.gcs.analyticscore.client.*;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
+import com.google.common.collect.ImmutableList;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.URI;
@@ -62,6 +64,7 @@ class GoogleCloudStorageInputStreamTest {
     when(mockGcsFileInfo.getUri()).thenReturn(testUri);
     when(mockGcsFileInfo.getItemInfo()).thenReturn(mockGcsItemInfo);
     when(mockGcsItemInfo.getSize()).thenReturn(fileSize);
+    when(mockFileSystem.getTelemetry()).thenReturn(new Telemetry(ImmutableList.of()));
   }
 
   GoogleCloudStorageInputStream defaultGcsInputStream() throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@ limitations under the License.
         <apache.avro.version>1.12.1</apache.avro.version>
         <apache.hadoop.version>3.4.2</apache.hadoop.version>
         <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
     </properties>
 
     <profiles>
@@ -380,6 +381,11 @@ limitations under the License.
                 <scope>import</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@ limitations under the License.
         <apache.parquet.version>1.16.0</apache.parquet.version>
         <apache.avro.version>1.12.1</apache.avro.version>
         <apache.hadoop.version>3.4.2</apache.hadoop.version>
+        <slf4j.version>1.7.36</slf4j.version>
     </properties>
 
     <profiles>
@@ -382,7 +383,12 @@ limitations under the License.
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.36</version>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.parquet</groupId>

--- a/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/FakeGcsClientImpl.java
+++ b/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/FakeGcsClientImpl.java
@@ -17,6 +17,7 @@
 package com.google.cloud.gcs.analyticscore.client;
 
 import com.google.auth.Credentials;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.base.Supplier;
@@ -33,13 +34,16 @@ public class FakeGcsClientImpl extends GcsClientImpl {
   FakeGcsClientImpl(
       Credentials credentials,
       GcsClientOptions clientOptions,
-      Supplier<ExecutorService> executorServiceSupplier) {
-    super(credentials, clientOptions, executorServiceSupplier);
+      Supplier<ExecutorService> executorServiceSupplier,
+      Telemetry telemetry) {
+    super(credentials, clientOptions, executorServiceSupplier, telemetry);
   }
 
   FakeGcsClientImpl(
-      GcsClientOptions clientOptions, Supplier<ExecutorService> executorServiceSupplier) {
-    super(clientOptions, executorServiceSupplier);
+      GcsClientOptions clientOptions,
+      Supplier<ExecutorService> executorServiceSupplier,
+      Telemetry telemetry) {
+    super(clientOptions, executorServiceSupplier, telemetry);
   }
 
   @Override

--- a/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/FakeGcsFileSystemImpl.java
+++ b/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/FakeGcsFileSystemImpl.java
@@ -16,19 +16,25 @@
 
 package com.google.cloud.gcs.analyticscore.client;
 
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class FakeGcsFileSystemImpl extends GcsFileSystemImpl {
   public FakeGcsFileSystemImpl(GcsFileSystemOptions fileSystemOptions) {
-    super(initializeGcsClient(fileSystemOptions), fileSystemOptions);
+    this(fileSystemOptions, new Telemetry(ImmutableList.of()));
   }
 
-  private static GcsClient initializeGcsClient(GcsFileSystemOptions options) {
+  private FakeGcsFileSystemImpl(GcsFileSystemOptions fileSystemOptions, Telemetry telemetry) {
+    super(initializeGcsClient(fileSystemOptions, telemetry), fileSystemOptions, telemetry);
+  }
+
+  private static GcsClient initializeGcsClient(GcsFileSystemOptions options, Telemetry telemetry) {
     Supplier<ExecutorService> executorServiceSupplier =
         Suppliers.ofInstance(Executors.newCachedThreadPool());
-    return new FakeGcsClientImpl(options.getGcsClientOptions(), executorServiceSupplier);
+    return new FakeGcsClientImpl(options.getGcsClientOptions(), executorServiceSupplier, telemetry);
   }
 }

--- a/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannel.java
+++ b/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannel.java
@@ -17,6 +17,7 @@
 package com.google.cloud.gcs.analyticscore.client;
 
 import com.google.cloud.ReadChannel;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.Storage;
 import com.google.common.base.Supplier;
 import java.io.IOException;
@@ -29,9 +30,10 @@ public class FakeGcsReadChannel extends GcsReadChannel {
       Storage storage,
       GcsItemInfo itemInfo,
       GcsReadOptions readOptions,
-      Supplier<ExecutorService> executorServiceSupplier)
+      Supplier<ExecutorService> executorServiceSupplier,
+      Telemetry telemetry)
       throws IOException {
-    super(storage, itemInfo, readOptions, executorServiceSupplier);
+    super(storage, itemInfo, readOptions, executorServiceSupplier, telemetry);
   }
 
   @Override

--- a/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeGcsClientImplTest.java
+++ b/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeGcsClientImplTest.java
@@ -19,7 +19,9 @@ package com.google.cloud.gcs.analyticscore.client;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +37,8 @@ class FakeGcsClientImplTest {
     fakeGcsClient =
         new FakeGcsClientImpl(
             options.getGcsClientOptions(),
-            Suppliers.ofInstance(Executors.newSingleThreadExecutor()));
+            Suppliers.ofInstance(Executors.newSingleThreadExecutor()),
+            new Telemetry(ImmutableList.of()));
     FakeGcsClientImpl.resetCounts();
   }
 

--- a/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannelTest.java
+++ b/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannelTest.java
@@ -18,9 +18,11 @@ package com.google.cloud.gcs.analyticscore.client;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,7 +50,8 @@ class FakeGcsReadChannelTest {
             LocalStorageHelper.getOptions().getService(),
             itemInfo,
             readOptions,
-            Suppliers.ofInstance(Executors.newSingleThreadExecutor()));
+            Suppliers.ofInstance(Executors.newSingleThreadExecutor()),
+            new Telemetry(ImmutableList.of()));
     FakeGcsReadChannel.resetCounts();
   }
 


### PR DESCRIPTION
The PR adds support for adding various kinds of telemetry :
1. inbuilt telemetry like basic logging, json logging etc [This PR]
2. custom telemetry for clients to consume and export the metrics as they see fit. [Existing]
3. open telemetry to report aggregated metrics [Follow up PR]

The PR fixes following
1. Associate each file system instance with its own telemetry instance
