### PR TITLE
fix: encapsulate telemetry metric name and type within a new Metric object

### DIFF
--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
@@ -56,7 +56,7 @@ public class GcsFileSystemImpl implements GcsFileSystem {
     this.gcsClient =
         telemetry.measure(
             GcsAnalyticsCoreTelemetryConstants.Operation.GCS_CLIENT_CREATE.name(),
-            GcsAnalyticsCoreTelemetryConstants.Metric.GCS_CLIENT_CREATE_DURATION.name(),
+            GcsAnalyticsCoreTelemetryConstants.Metric.GCS_CLIENT_CREATE_DURATION,
             Collections.emptyMap(),
             recorder ->
                 new GcsClientImpl(
@@ -70,7 +70,7 @@ public class GcsFileSystemImpl implements GcsFileSystem {
     this.gcsClient =
         telemetry.measure(
             GcsAnalyticsCoreTelemetryConstants.Operation.GCS_CLIENT_CREATE.name(),
-            GcsAnalyticsCoreTelemetryConstants.Metric.GCS_CLIENT_CREATE_DURATION.name(),
+            GcsAnalyticsCoreTelemetryConstants.Metric.GCS_CLIENT_CREATE_DURATION,
             Collections.emptyMap(),
             recorder ->
                 new GcsClientImpl(

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
@@ -157,7 +157,7 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
     Operation operation =
         Operation.builder()
             .setName(GcsAnalyticsCoreTelemetryConstants.Operation.VECTORED_READ.name())
-            .setDurationMetricName(Metric.READ_DURATION.name())
+            .setDurationMetric(Metric.READ_DURATION)
             .setAttributes(COMMON_ATTRIBUTES)
             .build();
     ExecutorService executorService = executorServiceSupplier.get();
@@ -197,7 +197,7 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
                 // EOF reached.
                 break;
               }
-              recorder.record(Metric.READ_BYTES.name(), bytesRead, Collections.emptyMap());
+              recorder.record(Metric.READ_BYTES, bytesRead, Collections.emptyMap());
               numOfBytesRead += bytesRead;
             }
             if (numOfBytesRead < combinedObjectRange.getLength()) {

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.cloud.ReadChannel;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Metric;
 import com.google.cloud.gcs.analyticscore.common.telemetry.MetricKey;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Operation;
 import com.google.cloud.gcs.analyticscore.common.telemetry.OperationListener;
@@ -502,7 +503,7 @@ class GcsReadChannelTest {
           public void onOperationEnd(Operation operation, Map<MetricKey, Long> metrics) {
             if (operation.getName().equals("VECTORED_READ")) {
               totalBytesReadFromMetrics.addAndGet(
-                  metrics.get(MetricKey.builder().setName("READ_BYTES").build()));
+                  metrics.get(MetricKey.builder().setMetric(Metric.READ_BYTES).build()));
             }
           }
         };

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/GcsAnalyticsCoreTelemetryConstants.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/GcsAnalyticsCoreTelemetryConstants.java
@@ -22,16 +22,34 @@ public class GcsAnalyticsCoreTelemetryConstants {
     READ_OFFSET;
   }
 
-  public enum Metric {
-    SEEK_DISTANCE,
-    SEEK_DURATION,
-    READ_BYTES,
-    READ_DURATION,
-    OPEN_DURATION,
-    READ_CACHE_HIT,
-    READ_CACHE_MISS,
-    CLOSE_DURATION,
-    GCS_CLIENT_CREATE_DURATION;
+  public enum Metric implements com.google.cloud.gcs.analyticscore.common.telemetry.Metric {
+    SEEK_DISTANCE("gcs.analytics-core.client.seek.size", MetricType.COUNTER),
+    SEEK_DURATION("gcs.analytics-core.client.seek.duration", MetricType.DURATION),
+    READ_BYTES("gcs.analytics-core.client.read.size", MetricType.COUNTER),
+    READ_DURATION("gcs.analytics-core.client.read.duration", MetricType.DURATION),
+    OPEN_DURATION("gcs.analytics-core.client.open.duration", MetricType.DURATION),
+    READ_CACHE_HIT("gcs.analytics-core.client.read.cache.hits", MetricType.COUNTER),
+    READ_CACHE_MISS("gcs.analytics-core.client.read.cache.misses", MetricType.COUNTER),
+    CLOSE_DURATION("gcs.analytics-core.client.close.duration", MetricType.DURATION),
+    GCS_CLIENT_CREATE_DURATION("gcs.analytics-core.client.create.duration", MetricType.DURATION);
+
+    private final String name;
+    private final MetricType type;
+
+    Metric(String name, MetricType type) {
+      this.name = name;
+      this.type = type;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public MetricType getType() {
+      return type;
+    }
   }
 
   public enum Operation {

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/LoggingTelemetryReporter.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/LoggingTelemetryReporter.java
@@ -72,7 +72,7 @@ public class LoggingTelemetryReporter implements OperationListener {
       }
       first = false;
       MetricKey key = entry.getKey();
-      sb.append(key.getName());
+      sb.append(key.getMetric().getName());
       if (key.getAttributes() != null && !key.getAttributes().isEmpty()) {
         sb.append(key.getAttributes());
       }

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/Metric.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/Metric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,14 @@
  */
 package com.google.cloud.gcs.analyticscore.common.telemetry;
 
-import java.util.Map;
+/** Represents a metric to be recorded. */
+public interface Metric {
+  enum MetricType {
+    COUNTER,
+    DURATION
+  }
 
-@FunctionalInterface
-public interface MetricsRecorder {
-  /**
-   * Records a metric value with specific attributes.
-   *
-   * @param metric The metric to record
-   * @param value The value to record
-   * @param attributes Contextual tags for the metric
-   */
-  void record(Metric metric, long value, Map<String, String> attributes);
+  String getName();
+
+  MetricType getType();
 }

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/MetricKey.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/MetricKey.java
@@ -24,30 +24,19 @@ import java.util.Map;
 @AutoValue
 public abstract class MetricKey {
 
-  public enum MetricType {
-    COUNTER,
-    DURATION
-  }
-
-  public abstract String getName();
+  public abstract Metric getMetric();
 
   public abstract ImmutableMap<String, String> getAttributes();
 
-  public abstract MetricType getMetricType();
-
   public static Builder builder() {
-    return new AutoValue_MetricKey.Builder()
-        .setAttributes(Collections.emptyMap())
-        .setMetricType(MetricType.COUNTER);
+    return new AutoValue_MetricKey.Builder().setAttributes(Collections.emptyMap());
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder setName(String name);
+    public abstract Builder setMetric(Metric metric);
 
     public abstract Builder setAttributes(Map<String, String> attributes);
-
-    public abstract Builder setMetricType(MetricType metricType);
 
     public abstract MetricKey build();
   }

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/OpenTelemetryReporter.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/OpenTelemetryReporter.java
@@ -84,15 +84,16 @@ public class OpenTelemetryReporter implements OperationListener {
               .putAll(operationAttributes)
               .putAll(toOpenTelemetryAttributes(metricKey.getAttributes()))
               .build();
-      if (metricKey.getMetricType() == MetricKey.MetricType.DURATION) {
+      if (metricKey.getMetric().getType() == Metric.MetricType.DURATION) {
         LongHistogram histogram =
             histograms.computeIfAbsent(
-                metricKey.getName(), name -> meter.histogramBuilder(name).ofLongs().build());
+                metricKey.getMetric().getName(),
+                name -> meter.histogramBuilder(name).ofLongs().build());
         histogram.record(metricValue, mergedAttributes);
       } else {
         LongCounter counter =
             counters.computeIfAbsent(
-                metricKey.getName(), name -> meter.counterBuilder(name).build());
+                metricKey.getMetric().getName(), name -> meter.counterBuilder(name).build());
         counter.add(metricValue, mergedAttributes);
       }
     }

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/Operation.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/Operation.java
@@ -31,7 +31,7 @@ public abstract class Operation {
 
   public abstract String getOperationId();
 
-  public abstract Optional<String> getDurationMetricName();
+  public abstract Optional<Metric> getDurationMetric();
 
   public static Builder builder() {
     return new AutoValue_Operation.Builder()
@@ -47,7 +47,7 @@ public abstract class Operation {
 
     public abstract Builder setOperationId(String operationId);
 
-    public abstract Builder setDurationMetricName(String durationMetricName);
+    public abstract Builder setDurationMetric(Metric durationMetric);
 
     public abstract Operation build();
   }

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/Telemetry.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/telemetry/Telemetry.java
@@ -23,8 +23,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.cloud.gcs.analyticscore.common.telemetry.MetricKey.MetricType;
-
 public class Telemetry implements AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(Telemetry.class);
 
@@ -39,8 +37,8 @@ public class Telemetry implements AutoCloseable {
       Operation operation, OperationSupplier<T, E> operationSupplier) throws E {
     Map<MetricKey, Long> currentMetrics = new ConcurrentHashMap<>();
     MetricsRecorder recorder =
-        (name, value, attributes) -> {
-          MetricKey key = MetricKey.builder().setName(name).setAttributes(attributes).build();
+        (metric, value, attributes) -> {
+          MetricKey key = MetricKey.builder().setMetric(metric).setAttributes(attributes).build();
           currentMetrics.merge(key, value, Long::sum);
         };
     notifyStart(operation);
@@ -49,11 +47,11 @@ public class Telemetry implements AutoCloseable {
       return operationSupplier.get(recorder);
     } finally {
       long durationNs = System.nanoTime() - startTime;
-      if (operation.getDurationMetricName().isPresent()) {
-        currentMetrics.put(
-            MetricKey.builder().setName(operation.getDurationMetricName().get()).setMetricType(MetricType.DURATION).build(),
-            durationNs);
-      }
+      operation
+          .getDurationMetric()
+          .ifPresent(
+              metric ->
+                  currentMetrics.put(MetricKey.builder().setMetric(metric).build(), durationNs));
       notifyEnd(operation, currentMetrics);
     }
   }
@@ -61,7 +59,7 @@ public class Telemetry implements AutoCloseable {
   public <T, E extends Throwable> T measure(
       String operationId,
       String operationName,
-      String durationMetricName,
+      Metric durationMetric,
       Map<String, String> operationAttributes,
       OperationSupplier<T, E> operationSupplier)
       throws E {
@@ -69,7 +67,7 @@ public class Telemetry implements AutoCloseable {
         Operation.builder()
             .setOperationId(operationId)
             .setName(operationName)
-            .setDurationMetricName(durationMetricName)
+            .setDurationMetric(durationMetric)
             .setAttributes(operationAttributes)
             .build();
     return measure(operation, operationSupplier);
@@ -77,14 +75,14 @@ public class Telemetry implements AutoCloseable {
 
   public <T, E extends Throwable> T measure(
       String operationName,
-      String durationMetricName,
+      Metric durationMetric,
       Map<String, String> operationAttributes,
       OperationSupplier<T, E> operationSupplier)
       throws E {
     Operation operation =
         Operation.builder()
             .setName(operationName)
-            .setDurationMetricName(durationMetricName)
+            .setDurationMetric(durationMetric)
             .setAttributes(operationAttributes)
             .build();
     return measure(operation, operationSupplier);
@@ -94,11 +92,11 @@ public class Telemetry implements AutoCloseable {
    * Records metric that is not associated with any specific operation context. This is useful for
    * interceptors or background processes where no operation scope is available.
    */
-  public void recordMetric(String name, long value, Map<String, String> attributes) {
+  public void recordMetric(Metric metric, long value, Map<String, String> attributes) {
     notifyEnd(
         Operation.builder().setName("UNKNOWN").build(),
         Collections.singletonMap(
-            MetricKey.builder().setName(name).setAttributes(attributes).build(), value));
+            MetricKey.builder().setMetric(metric).setAttributes(attributes).build(), value));
   }
 
   private void notifyStart(Operation operation) {

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/LoggingTelemetryReporterTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/LoggingTelemetryReporterTest.java
@@ -50,7 +50,11 @@ class LoggingTelemetryReporterTest {
     try (LoggingTelemetryReporter reporter =
         new LoggingTelemetryReporter(LoggingTelemetryOptions.builder().build())) {
       Map<MetricKey, Long> metrics =
-          Map.of(MetricKey.builder().setName("TestMetric").build(), 100L);
+          Map.of(
+              MetricKey.builder()
+                  .setMetric(TestMetric.of("TestMetric", Metric.MetricType.COUNTER))
+                  .build(),
+              100L);
 
       String formattedMetrics = reporter.formatMetrics(metrics);
 
@@ -65,7 +69,7 @@ class LoggingTelemetryReporterTest {
       Map<MetricKey, Long> metrics =
           Map.of(
               MetricKey.builder()
-                  .setName("TestMetric")
+                  .setMetric(TestMetric.of("TestMetric", Metric.MetricType.COUNTER))
                   .setAttributes(Map.of("key1", "value1", "key2", "value2"))
                   .build(),
               100L);
@@ -85,9 +89,14 @@ class LoggingTelemetryReporterTest {
         new LoggingTelemetryReporter(LoggingTelemetryOptions.builder().build())) {
       Map<MetricKey, Long> metrics =
           Map.of(
-              MetricKey.builder().setName("Metric1").build(),
+              MetricKey.builder()
+                  .setMetric(TestMetric.of("Metric1", Metric.MetricType.COUNTER))
+                  .build(),
               100L,
-              MetricKey.builder().setName("Metric2").setAttributes(Map.of("key", "value")).build(),
+              MetricKey.builder()
+                  .setMetric(TestMetric.of("Metric2", Metric.MetricType.COUNTER))
+                  .setAttributes(Map.of("key", "value"))
+                  .build(),
               200L);
 
       String formattedMetrics = reporter.formatMetrics(metrics);

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/OpenTelemetryReporterTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/OpenTelemetryReporterTest.java
@@ -80,20 +80,23 @@ class OpenTelemetryReporterTest {
       Operation operation =
           Operation.builder()
               .setName("testOp")
-              .setDurationMetricName("testOp.duration")
+              .setDurationMetric(TestMetric.of("testOp.duration", Metric.MetricType.DURATION))
               .setAttributes(opAttrs)
               .build();
       Map<MetricKey, Long> metrics = new HashMap<>();
       metrics.put(
           MetricKey.builder()
-              .setName("testOp.duration")
-              .setMetricType(MetricKey.MetricType.DURATION)
+              .setMetric(TestMetric.of("testOp.duration", Metric.MetricType.DURATION))
               .build(),
           1500L);
       Map<String, String> metricAttrs = new HashMap<>();
       metricAttrs.put("status", "OK");
       metrics.put(
-          MetricKey.builder().setName("testOp.bytes").setAttributes(metricAttrs).build(), 1024L);
+          MetricKey.builder()
+              .setMetric(TestMetric.of("testOp.bytes", Metric.MetricType.COUNTER))
+              .setAttributes(metricAttrs)
+              .build(),
+          1024L);
 
       reporter.onOperationEnd(operation, metrics);
 

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/TelemetryTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/TelemetryTest.java
@@ -35,13 +35,14 @@ class TelemetryTest {
 
   @Test
   void measure_validOperation_returnsResultAndRecordsMetrics() throws Exception {
+    Metric durationMetric = TestMetric.of("duration", Metric.MetricType.DURATION);
     Operation operation =
-        Operation.builder().setName("READ").setDurationMetricName("duration").build();
+        Operation.builder().setName("READ").setDurationMetric(durationMetric).build();
 
     String result =
         telemetry.measure(
             operation.getName(),
-            operation.getDurationMetricName().orElse(null),
+            operation.getDurationMetric().orElse(null),
             operation.getAttributes(),
             recorder -> "result");
 
@@ -52,30 +53,31 @@ class TelemetryTest {
     assertThat(listener.getStartedOperations()).hasSize(1);
     assertThat(startedOp.getName()).isEqualTo(operation.getName());
     assertThat(startedOp.getAttributes()).isEqualTo(operation.getAttributes());
-    assertThat(startedOp.getDurationMetricName()).isEqualTo(operation.getDurationMetricName());
+    assertThat(startedOp.getDurationMetric()).isEqualTo(operation.getDurationMetric());
     assertThat(listener.getEndedOperations()).hasSize(1);
     assertThat(endedOp.getName()).isEqualTo(operation.getName());
     assertThat(endedOp.getAttributes()).isEqualTo(operation.getAttributes());
-    assertThat(endedOp.getDurationMetricName()).isEqualTo(operation.getDurationMetricName());
+    assertThat(endedOp.getDurationMetric()).isEqualTo(operation.getDurationMetric());
     assertThat(listener.getEndedMetrics()).hasSize(1);
-    assertThat(metrics.keySet().stream().anyMatch(key -> "duration".equals(key.getName())))
+    assertThat(
+            metrics.keySet().stream().anyMatch(key -> "duration".equals(key.getMetric().getName())))
         .isTrue();
   }
 
   @Test
   void recordMetric_validInput_recordsMetricWithTypeNA() {
-    String name = "testMetric";
+    Metric testMetric = TestMetric.of("testMetric", Metric.MetricType.COUNTER);
     long value = 123L;
     Map<String, String> attributes = Collections.emptyMap();
 
-    telemetry.recordMetric(name, value, attributes);
+    telemetry.recordMetric(testMetric, value, attributes);
 
     Map<MetricKey, Long> metrics = listener.getEndedMetrics().get(0);
     MetricKey key = metrics.keySet().iterator().next();
     assertThat(listener.getEndedOperations()).hasSize(1);
     assertThat(listener.getEndedOperations().get(0).getName()).isEqualTo("UNKNOWN");
     assertThat(metrics).hasSize(1);
-    assertThat(key.getName()).isEqualTo(name);
+    assertThat(key.getMetric().getName()).isEqualTo("testMetric");
     assertThat(key.getAttributes()).isEqualTo(attributes);
     assertThat(metrics.get(key)).isEqualTo(value);
   }

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/TestMetric.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/TestMetric.java
@@ -15,46 +15,18 @@
  */
 package com.google.cloud.gcs.analyticscore.common.telemetry;
 
-import java.util.Objects;
+import com.google.auto.value.AutoValue;
 
-public class TestMetric implements Metric {
-  private final String name;
-  private final MetricType type;
-
-  private TestMetric(String name, MetricType type) {
-    this.name = name;
-    this.type = type;
-  }
+@AutoValue
+public abstract class TestMetric implements Metric {
 
   public static TestMetric of(String name, MetricType type) {
-    return new TestMetric(name, type);
+    return new AutoValue_TestMetric(name, type);
   }
 
   @Override
-  public String getName() {
-    return name;
-  }
+  public abstract String getName();
 
   @Override
-  public MetricType getType() {
-    return type;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof Metric)) return false;
-    Metric that = (Metric) o;
-    return Objects.equals(name, that.getName()) && type == that.getType();
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(name, type);
-  }
-
-  @Override
-  public String toString() {
-    return name;
-  }
+  public abstract MetricType getType();
 }

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/TestMetric.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/telemetry/TestMetric.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.gcs.analyticscore.common.telemetry;
+
+import java.util.Objects;
+
+public class TestMetric implements Metric {
+  private final String name;
+  private final MetricType type;
+
+  private TestMetric(String name, MetricType type) {
+    this.name = name;
+    this.type = type;
+  }
+
+  public static TestMetric of(String name, MetricType type) {
+    return new TestMetric(name, type);
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public MetricType getType() {
+    return type;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Metric)) return false;
+    Metric that = (Metric) o;
+    return Objects.equals(name, that.getName()) && type == that.getType();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type);
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+}

--- a/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
+++ b/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemImpl;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsItemId;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants;
 import com.google.cloud.gcs.analyticscore.common.telemetry.MetricKey;
 import com.google.cloud.gcs.analyticscore.common.telemetry.CustomTelemetryOptions;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Operation;
@@ -224,7 +225,7 @@ class GoogleCloudStorageInputStreamIntegrationTest {
     
     MetricKey bytesReadKey =
         capturedReadMetrics.get().keySet().stream()
-            .filter(k -> k.getMetric().getName().equals("READ_BYTES"))
+            .filter(k -> k.getMetric().getName().equals(GcsAnalyticsCoreTelemetryConstants.Metric.READ_BYTES.getName()))
             .findFirst()
             .get();
     assertThat(capturedReadMetrics.get().get(bytesReadKey)).isEqualTo(5L);

--- a/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
+++ b/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
@@ -224,7 +224,7 @@ class GoogleCloudStorageInputStreamIntegrationTest {
     
     MetricKey bytesReadKey =
         capturedReadMetrics.get().keySet().stream()
-            .filter(k -> k.getName().equals("READ_BYTES"))
+            .filter(k -> k.getMetric().getName().equals("READ_BYTES"))
             .findFirst()
             .get();
     assertThat(capturedReadMetrics.get().get(bytesReadKey)).isEqualTo(5L);

--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
@@ -108,13 +108,13 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
         .getTelemetry()
         .measure(
             Operation.SEEK.name(),
-            Metric.SEEK_DURATION.name(),
+            Metric.SEEK_DURATION,
             commonAttributes,
             recorder -> {
               checkArgument(newPos >= 0, "position can't be negative: %s", newPos);
               checkNotClosed("Cannot seek: already closed");
               recorder.record(
-                  Metric.SEEK_DISTANCE.name(), newPos - position, Collections.emptyMap());
+                  Metric.SEEK_DISTANCE, Math.abs(newPos - position), Collections.emptyMap());
               position = newPos;
               channel.position(newPos);
               return null;
@@ -145,7 +145,7 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
         .getTelemetry()
         .measure(
             Operation.READ.name(),
-            Metric.READ_DURATION.name(),
+            Metric.READ_DURATION,
             telemetryAttributes,
             recorder -> {
               checkNotClosed("Cannot read: already closed");
@@ -157,12 +157,12 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
               if (prefetchBuffer != null && (position >= fileSize - prefetchSize)) {
                 int bytesRead = serveFromCache(byteBuffer);
                 if (bytesRead > 0) {
-                  recorder.record(Metric.READ_BYTES.name(), bytesRead, Collections.emptyMap());
-                  recorder.record(Metric.READ_CACHE_HIT.name(), 1, Collections.emptyMap());
+                  recorder.record(Metric.READ_BYTES, bytesRead, Collections.emptyMap());
+                  recorder.record(Metric.READ_CACHE_HIT, 1, Collections.emptyMap());
                 }
                 return bytesRead;
               }
-              recorder.record(Metric.READ_CACHE_MISS.name(), 1, Collections.emptyMap());
+              recorder.record(Metric.READ_CACHE_MISS, 1, Collections.emptyMap());
               long channelPosition = channel.position();
               checkState(
                   channelPosition == position,
@@ -173,7 +173,7 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
               int bytesRead = channel.read(byteBuffer);
               if (bytesRead > 0) {
                 position += bytesRead;
-                recorder.record(Metric.READ_BYTES.name(), bytesRead, Collections.emptyMap());
+                recorder.record(Metric.READ_BYTES, bytesRead, Collections.emptyMap());
               }
               return bytesRead;
             });
@@ -199,7 +199,7 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
         .getTelemetry()
         .measure(
             Operation.CLOSE.name(),
-            Metric.CLOSE_DURATION.name(),
+            Metric.CLOSE_DURATION,
             commonAttributes,
             recorder -> {
               if (!closed) {
@@ -224,7 +224,7 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
         .getTelemetry()
         .measure(
             Operation.READ_FULLY.name(),
-            Metric.READ_DURATION.name(),
+            Metric.READ_DURATION,
             commonAttributes,
             recorder -> {
               try (VectoredSeekableByteChannel byteChannel =
@@ -237,8 +237,7 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
                           + (length - numberOfBytesRead)
                           + " bytes left to read");
                 }
-                recorder.record(
-                    Metric.READ_BYTES.name(), numberOfBytesRead, Collections.emptyMap());
+                recorder.record(Metric.READ_BYTES, numberOfBytesRead, Collections.emptyMap());
               }
               return null;
             });
@@ -250,7 +249,7 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
         .getTelemetry()
         .measure(
             Operation.READ_TAIL.name(),
-            Metric.READ_DURATION.name(),
+            Metric.READ_DURATION,
             commonAttributes,
             recorder -> {
               if (!isMetadataInitialized()) {
@@ -263,7 +262,7 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
                 byteChannel.position(startPosition);
                 int bytesRead = byteChannel.read(ByteBuffer.wrap(buffer, offset, length));
                 if (bytesRead > 0) {
-                  recorder.record(Metric.READ_BYTES.name(), bytesRead, Collections.emptyMap());
+                  recorder.record(Metric.READ_BYTES, bytesRead, Collections.emptyMap());
                 }
                 return bytesRead;
               }
@@ -367,7 +366,7 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
         .getTelemetry()
         .measure(
             Operation.OPEN.name(),
-            Metric.OPEN_DURATION.name(),
+            Metric.OPEN_DURATION,
             buildCommonAttributes(),
             recorder -> {
               if (gcsFileInfo != null) {


### PR DESCRIPTION
1. encapsulate telemetry metric name and type within a new Metric object for better readability
2. Modified seek_distance capturing as absolute value to avoid negative values when there is backward seek.