### PR TITLE
Implement in-place seeking i.e. read the data and discard for smaller…

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -22,3 +22,4 @@ All configuration properties can be prefixed with a common string, e.g., `gcs.`.
 | `analytics-core.read.thread.count`                         | Number of threads for parallel read operations like vectored IO.                                            | 16            |
 | `analytics-core.read.vectored.range.merge-gap.max-bytes`   | Maximum gap (in bytes) between ranges to merge in vectored reads.                                           | 4096 (4 KB)   |
 | `analytics-core.read.vectored.range.merged-size.max-bytes` | Maximum size (in bytes) of a merged range in vectored reads.                                                | 8388608 (8 MB)  |
+| `analytics-core.read.inplace-seek-limit-bytes`   | In-place seek limit (in bytes).                                                                             | 131072 (128 KB) |

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -84,5 +84,28 @@ limitations under the License.
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>../test-lib/src/main/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -127,8 +127,7 @@ class GcsClientImpl implements GcsClient {
   protected Storage createStorage(Optional<Credentials> credentials) {
     StorageOptions.Builder builder = StorageOptions.newBuilder();
     String userAgent = getUserAgent();
-    builder.setHeaderProvider(
-        FixedHeaderProvider.create(ImmutableMap.of("User-Agent", userAgent)));
+    builder.setHeaderProvider(FixedHeaderProvider.create(ImmutableMap.of("User-Agent", userAgent)));
     clientOptions.getProjectId().ifPresent(builder::setProjectId);
     clientOptions.getClientLibToken().ifPresent(builder::setClientLibToken);
     clientOptions.getServiceHost().ifPresent(builder::setHost);
@@ -143,7 +142,8 @@ class GcsClientImpl implements GcsClient {
 
   @VisibleForTesting
   String getUserAgent() {
-    return USER_AGENT_PREFIX + getVersion()
+    return USER_AGENT_PREFIX
+        + getVersion()
         + clientOptions.getUserAgent().map(agent -> " " + agent).orElse("");
   }
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannel.java
@@ -42,15 +42,18 @@ import java.util.function.IntFunction;
 class GcsReadChannel implements VectoredSeekableByteChannel {
   private Storage storage;
   private GcsReadOptions readOptions;
-  private ReadChannel readChannel;
+  private ReadChannel sdkReadChannel;
   protected GcsItemInfo itemInfo;
   protected GcsItemId itemId;
-  private long position = 0;
+  private long gcsReadChannelPosition = 0;
   private Supplier<ExecutorService> executorServiceSupplier;
   private static final ImmutableMap<String, String> COMMON_ATTRIBUTES =
       ImmutableMap.of(Attribute.CLASS_NAME.name(), GcsReadChannel.class.getName());
-
   private final Telemetry telemetry;
+  private long sdkReadChannelPosition = -1;
+  private static final int SKIP_BUFFER_SIZE = 128 * 1024; // 128 KiB
+  private static final ThreadLocal<ByteBuffer> SKIP_BUFFER_HOLDER =
+      ThreadLocal.withInitial(() -> ByteBuffer.allocate(SKIP_BUFFER_SIZE));
 
   GcsReadChannel(
       Storage storage,
@@ -96,13 +99,21 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
     this.itemId = itemId;
     this.executorServiceSupplier = executorServiceSupplier;
     this.telemetry = telemetry;
-    this.readChannel = openReadChannel(itemId, readOptions);
+    this.sdkReadChannel = openSdkReadChannel(itemId, readOptions);
+    this.sdkReadChannelPosition = 0;
   }
 
   @Override
   public int read(ByteBuffer dst) throws IOException {
-    int bytesRead = readChannel.read(dst);
-    position += bytesRead;
+    if (dst.remaining() == 0) {
+      return 0;
+    }
+    performPendingSeeks();
+    int bytesRead = sdkReadChannel.read(dst);
+    if (bytesRead > 0) {
+      gcsReadChannelPosition += bytesRead;
+      sdkReadChannelPosition += bytesRead;
+    }
 
     return bytesRead;
   }
@@ -114,14 +125,13 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
 
   @Override
   public long position() throws IOException {
-    return position;
+    return gcsReadChannelPosition;
   }
 
   @Override
   public SeekableByteChannel position(long newPosition) throws IOException {
     validatePosition(newPosition);
-    readChannel.seek(newPosition);
-    position = newPosition;
+    gcsReadChannelPosition = newPosition;
 
     return this;
   }
@@ -141,13 +151,49 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
 
   @Override
   public boolean isOpen() {
-    return readChannel.isOpen();
+    return sdkReadChannel.isOpen();
   }
 
   @Override
   public void close() throws IOException {
-    if (readChannel.isOpen()) {
-      readChannel.close();
+    if (sdkReadChannel.isOpen()) {
+      sdkReadChannel.close();
+    }
+  }
+
+  private void performPendingSeeks() throws IOException {
+    if (gcsReadChannelPosition == sdkReadChannelPosition) {
+      return;
+    }
+    if (canSeekInPlace()) {
+      skipInPlace();
+      return;
+    }
+    sdkReadChannel.seek(gcsReadChannelPosition);
+    sdkReadChannelPosition = gcsReadChannelPosition;
+  }
+
+  private boolean canSeekInPlace() {
+    long seekDistance = gcsReadChannelPosition - sdkReadChannelPosition;
+    return seekDistance > 0 && seekDistance <= readOptions.getInplaceSeekLimit();
+  }
+
+  private void skipInPlace() throws IOException {
+    ByteBuffer skipBuffer = SKIP_BUFFER_HOLDER.get();
+    long seekDistance = gcsReadChannelPosition - sdkReadChannelPosition;
+    while (seekDistance > 0) {
+      int bufferSize = (int) Math.min((long) skipBuffer.capacity(), seekDistance);
+      skipBuffer.clear();
+      skipBuffer.limit(bufferSize);
+      int bytesRead = sdkReadChannel.read(skipBuffer);
+      if (bytesRead <= 0) {
+        // EOF, fallback to seek
+        sdkReadChannel.seek(gcsReadChannelPosition);
+        sdkReadChannelPosition = gcsReadChannelPosition;
+        return;
+      }
+      seekDistance -= bytesRead;
+      sdkReadChannelPosition += bytesRead;
     }
   }
 
@@ -185,7 +231,7 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
     telemetry.measure(
         operation,
         recorder -> {
-          try (ReadChannel channel = openReadChannel(itemId, readOptions)) {
+          try (ReadChannel channel = openSdkReadChannel(itemId, readOptions)) {
             validatePosition(combinedObjectRange.getOffset());
             channel.seek(combinedObjectRange.getOffset());
             channel.limit(combinedObjectRange.getOffset() + combinedObjectRange.getLength());
@@ -260,7 +306,7 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
     }
   }
 
-  protected ReadChannel openReadChannel(GcsItemId gcsItemId, GcsReadOptions readOptions)
+  protected ReadChannel openSdkReadChannel(GcsItemId gcsItemId, GcsReadOptions readOptions)
       throws IOException {
     checkArgument(gcsItemId.isGcsObject(), "Expected Gcs Object but got %s", gcsItemId);
     String bucketName = gcsItemId.getBucketName();
@@ -277,11 +323,11 @@ class GcsReadChannel implements VectoredSeekableByteChannel {
     readOptions
         .getDecryptionKey()
         .ifPresent(key -> sourceOptions.add(Storage.BlobSourceOption.decryptionKey(key)));
-    ReadChannel readChannel =
+    ReadChannel sdkReadChannel =
         storage.reader(blobId, sourceOptions.toArray(new Storage.BlobSourceOption[0]));
-    readOptions.getChunkSize().ifPresent(readChannel::setChunkSize);
+    readOptions.getChunkSize().ifPresent(sdkReadChannel::setChunkSize);
 
-    return readChannel;
+    return sdkReadChannel;
   }
 
   private void validatePosition(long position) throws IOException {

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptions.java
@@ -33,8 +33,11 @@ public abstract class GcsReadOptions {
   private static final String LARGE_FILE_FOOTER_PREFETCH_SIZE_KEY =
       "analytics-core.large-file.footer.prefetch.size-bytes";
   private static final String USER_PROJECT_KEY = "user-project";
+  private static final String INPLACE_SEEK_LIMIT_KEY =
+      "analytics-core.read.inplace-seek-limit-bytes";
 
   private static final boolean DEFAULT_FOOTER_PREFETCH_ENABLED = true;
+  private static final int DEFAULT_INPLACE_SEEK_LIMIT = 128 * 1024; // 128kb
   private static final int DEFAULT_SMALL_FILE_FOOTER_PREFETCH_SIZE = 100 * 1024; // 100kb
   private static final int DEFAULT_LARGE_FILE_FOOTER_PREFETCH_SIZE = 1024 * 1024; // 1mb
   private static final int DEFAULT_SMALL_FILE_CACHE_THRESHOLD = 0; // 0 bytes = disabled
@@ -55,13 +58,16 @@ public abstract class GcsReadOptions {
 
   public abstract GcsVectoredReadOptions getGcsVectoredReadOptions();
 
+  public abstract int getInplaceSeekLimit();
+
   public static Builder builder() {
     return new AutoValue_GcsReadOptions.Builder()
         .setGcsVectoredReadOptions(GcsVectoredReadOptions.builder().build())
         .setFooterPrefetchEnabled(DEFAULT_FOOTER_PREFETCH_ENABLED)
         .setFooterPrefetchSizeSmallFile(DEFAULT_SMALL_FILE_FOOTER_PREFETCH_SIZE)
         .setFooterPrefetchSizeLargeFile(DEFAULT_LARGE_FILE_FOOTER_PREFETCH_SIZE)
-        .setSmallObjectCacheSize(DEFAULT_SMALL_FILE_CACHE_THRESHOLD);
+        .setSmallObjectCacheSize(DEFAULT_SMALL_FILE_CACHE_THRESHOLD)
+        .setInplaceSeekLimit(DEFAULT_INPLACE_SEEK_LIMIT);
   }
 
   public static GcsReadOptions createFromOptions(
@@ -92,6 +98,10 @@ public abstract class GcsReadOptions {
     if (analyticsCoreOptions.containsKey(prefix + SMALL_FILE_CACHE_THRESHOLD_KEY)) {
       optionsBuilder.setSmallObjectCacheSize(
           safeParseInteger(analyticsCoreOptions, prefix + SMALL_FILE_CACHE_THRESHOLD_KEY));
+    }
+    if (analyticsCoreOptions.containsKey(prefix + INPLACE_SEEK_LIMIT_KEY)) {
+      optionsBuilder.setInplaceSeekLimit(
+          safeParseInteger(analyticsCoreOptions, prefix + INPLACE_SEEK_LIMIT_KEY));
     }
     optionsBuilder.setGcsVectoredReadOptions(
         GcsVectoredReadOptions.createFromOptions(analyticsCoreOptions, prefix));
@@ -129,6 +139,8 @@ public abstract class GcsReadOptions {
     public abstract Builder setFooterPrefetchSizeLargeFile(int footerPrefetchSizeLargeFile);
 
     public abstract Builder setSmallObjectCacheSize(int smallObjectCacheSize);
+
+    public abstract Builder setInplaceSeekLimit(int inplaceSeekLimit);
 
     public abstract GcsReadOptions build();
   }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/VersionHelper.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/VersionHelper.java
@@ -15,21 +15,20 @@
  */
 package com.google.cloud.gcs.analyticscore.client;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.google.common.annotations.VisibleForTesting;
 
 final class VersionHelper {
   private static final Logger LOG = LoggerFactory.getLogger(VersionHelper.class);
 
   static final String PACKAGE_POM_PATH =
       "/META-INF/maven/com.google.cloud.gcs.analytics/client/pom.properties";
-  
-  @VisibleForTesting
-  static final String DEFAULT_VERSION = "unknown";
+
+  @VisibleForTesting static final String DEFAULT_VERSION = "unknown";
 
   static final String VERSION = loadVersion();
 

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -212,9 +212,11 @@ class GcsClientImplTest {
         .hasMessageThat()
         .isEqualTo("Expected GCS object to be provided. But got: " + directoryItemId);
   }
+
   @Test
   void getUserAgent_noOptionalUserAgent() {
-    GcsClientImpl client = new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry);
+    GcsClientImpl client =
+        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry);
     String userAgent = client.getUserAgent();
     assertThat(userAgent).isEqualTo("gcs-analytics-core/" + VersionHelper.VERSION);
   }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelTest.java
@@ -262,10 +262,7 @@ class GcsReadChannelTest {
 
   @Test
   void read_emptyBuffer_returnsZero() throws IOException {
-    GcsItemId itemId =
-        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
-    GcsItemInfo itemInfo =
-        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
+    GcsItemInfo itemInfo = createItemInfoWith(100);
     try (GcsReadChannel gcsReadChannel =
         new GcsReadChannel(
             storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
@@ -279,10 +276,7 @@ class GcsReadChannelTest {
 
   @Test
   void read_eof_doesNotAdvancePosition() throws IOException {
-    GcsItemId itemId =
-        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
-    GcsItemInfo itemInfo =
-        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
+    GcsItemInfo itemInfo = createItemInfoWith(100);
     Storage mockStorage = Mockito.mock(Storage.class);
     ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
     Mockito.when(
@@ -719,10 +713,7 @@ class GcsReadChannelTest {
 
   @Test
   void position_doesNotSeekImmediately() throws IOException {
-    GcsItemId itemId =
-        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
-    GcsItemInfo itemInfo =
-        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
+    GcsItemInfo itemInfo = createItemInfoWith(100);
     Storage mockStorage = Mockito.mock(Storage.class);
     ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
     Mockito.when(
@@ -742,203 +733,139 @@ class GcsReadChannelTest {
 
   @Test
   void read_inPlaceSeek_readsBytes() throws IOException {
-    GcsItemId itemId =
-        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
-    GcsItemInfo itemInfo =
-        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
-    Storage mockStorage = Mockito.mock(Storage.class);
-    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
-    Mockito.when(
-            mockStorage.reader(
-                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
-        .thenReturn(mockSdkReadChannel);
-    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true);
-    Mockito.when(mockSdkReadChannel.read(Mockito.any(ByteBuffer.class)))
-        .thenAnswer(
-            invocation -> {
-              ByteBuffer buffer = invocation.getArgument(0);
-              int remaining = buffer.remaining();
-              buffer.position(buffer.position() + remaining);
-              return remaining;
-            });
+    GcsItemInfo itemInfo = createItemInfoWith(100);
+    createBlobInStorage(
+        BlobId.of(
+            itemInfo.getItemId().getBucketName(), itemInfo.getItemId().getObjectName().get(), 0L),
+        "a".repeat(100));
+    try (FakeGcsReadChannel gcsReadChannel =
+        new FakeGcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
+      TrackingReadChannel trackingReadChannel = gcsReadChannel.getTrackingReadChannel();
 
-    try (GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(
-            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
       gcsReadChannel.read(ByteBuffer.allocate(5));
       gcsReadChannel.position(10);
       gcsReadChannel.read(ByteBuffer.allocate(5));
       gcsReadChannel.position(20);
       gcsReadChannel.read(ByteBuffer.allocate(5));
 
-      Mockito.verify(mockSdkReadChannel, Mockito.times(5)).read(Mockito.any(ByteBuffer.class));
-      Mockito.verify(mockSdkReadChannel, Mockito.never()).seek(Mockito.anyLong());
+      assertThat(trackingReadChannel.getReadCalls()).isEqualTo(5);
+      assertThat(trackingReadChannel.getSeekCalls()).isEqualTo(0);
     }
   }
 
   @Test
   void read_largeSeek_fallsBackToSeek() throws IOException {
-    GcsItemId itemId =
-        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
-    GcsItemInfo itemInfo =
-        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
-    Storage mockStorage = Mockito.mock(Storage.class);
-    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
-    Mockito.when(
-            mockStorage.reader(
-                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
-        .thenReturn(mockSdkReadChannel);
-    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true);
-    Mockito.when(mockSdkReadChannel.read(Mockito.any(ByteBuffer.class))).thenReturn(5);
-
-    try (GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(
-            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
+    GcsItemInfo itemInfo = createItemInfoWith(100);
+    createBlobInStorage(
+        BlobId.of(
+            itemInfo.getItemId().getBucketName(), itemInfo.getItemId().getObjectName().get(), 0L),
+        "a".repeat(100));
+    try (FakeGcsReadChannel gcsReadChannel =
+        new FakeGcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
+      TrackingReadChannel trackingReadChannel = gcsReadChannel.getTrackingReadChannel();
       long largeSeek = 5 + 9 * 1024 * 1024;
 
       gcsReadChannel.position(largeSeek);
       gcsReadChannel.read(ByteBuffer.allocate(5));
 
-      Mockito.verify(mockSdkReadChannel).seek(largeSeek);
+      assertThat(trackingReadChannel.getSeekCalls()).isEqualTo(1);
     }
   }
 
   @Test
   void read_inPlaceSeek_EOF_fallsBackToSeek() throws IOException {
-    GcsItemId itemId =
-        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
-    GcsItemInfo itemInfo =
-        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
-    Storage mockStorage = Mockito.mock(Storage.class);
-    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
-    Mockito.when(
-            mockStorage.reader(
-                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
-        .thenReturn(mockSdkReadChannel);
-    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true);
-    AtomicInteger callCount = new AtomicInteger(0);
-    Mockito.when(mockSdkReadChannel.read(Mockito.any(ByteBuffer.class)))
-        .thenAnswer(
-            invocation -> {
-              ByteBuffer buffer = invocation.getArgument(0);
-              int count = callCount.incrementAndGet();
-              if (count == 1) {
-                int remaining = buffer.remaining();
-                buffer.position(buffer.position() + remaining);
-                return remaining;
-              } else if (count == 2) {
-                return -1; // Simulate EOF during skipInPlace
-              } else {
-                int remaining = buffer.remaining();
-                buffer.position(buffer.position() + remaining);
-                return remaining;
-              }
-            });
+    GcsItemInfo itemInfo = createItemInfoWith(100);
+    createBlobInStorage(
+        BlobId.of(
+            itemInfo.getItemId().getBucketName(), itemInfo.getItemId().getObjectName().get(), 0L),
+        "a".repeat(100));
+    try (FakeGcsReadChannel gcsReadChannel =
+        new FakeGcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
+      TrackingReadChannel trackingReadChannel = gcsReadChannel.getTrackingReadChannel();
+      trackingReadChannel.setEofAtCall(2); // Simulate EOF during skipInPlace
 
-    try (GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(
-            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
       gcsReadChannel.read(ByteBuffer.allocate(5));
       gcsReadChannel.position(10);
       gcsReadChannel.read(ByteBuffer.allocate(5));
 
-      Mockito.verify(mockSdkReadChannel).seek(10);
-      Mockito.verify(mockSdkReadChannel, Mockito.times(3)).read(Mockito.any(ByteBuffer.class));
+      assertThat(trackingReadChannel.getSeekCalls()).isEqualTo(1);
+      assertThat(trackingReadChannel.getReadCalls()).isEqualTo(3);
     }
   }
 
   @Test
   void read_inPlaceSeek_largerThanSkipBufferSize_loopsAndReads() throws IOException {
-    GcsItemId itemId =
-        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
-    GcsItemInfo itemInfo =
-        GcsItemInfo.builder()
-            .setItemId(itemId)
-            .setSize(500 * 1024)
-            .setContentGeneration(0L)
-            .build();
-    Storage mockStorage = Mockito.mock(Storage.class);
-    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
-    Mockito.when(
-            mockStorage.reader(
-                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
-        .thenReturn(mockSdkReadChannel);
-    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true);
-    Mockito.when(mockSdkReadChannel.read(Mockito.any(ByteBuffer.class)))
-        .thenAnswer(
-            invocation -> {
-              ByteBuffer buffer = invocation.getArgument(0);
-              int remaining = buffer.remaining();
-              buffer.position(buffer.position() + remaining);
-              return remaining;
-            });
-
+    GcsItemInfo itemInfo = createItemInfoWith(500 * 1024);
+    createBlobInStorage(
+        BlobId.of(
+            itemInfo.getItemId().getBucketName(), itemInfo.getItemId().getObjectName().get(), 0L),
+        "a".repeat(500 * 1024));
     GcsReadOptions customOptions =
         GcsReadOptions.builder()
             .setUserProjectId(TEST_PROJECT_ID)
             .setInplaceSeekLimit(500 * 1024)
             .build();
-    try (GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(
-            mockStorage, itemInfo, customOptions, executorServiceSupplier, telemetry)) {
+    try (FakeGcsReadChannel gcsReadChannel =
+        new FakeGcsReadChannel(
+            storage, itemInfo, customOptions, executorServiceSupplier, telemetry)) {
+      TrackingReadChannel trackingReadChannel = gcsReadChannel.getTrackingReadChannel();
+
       gcsReadChannel.read(ByteBuffer.allocate(5));
       long newPosition = 300 * 1024;
       gcsReadChannel.position(newPosition);
 
       gcsReadChannel.read(ByteBuffer.allocate(5));
 
-      Mockito.verify(mockSdkReadChannel, Mockito.times(5)).read(Mockito.any(ByteBuffer.class));
-      Mockito.verify(mockSdkReadChannel, Mockito.never()).seek(Mockito.anyLong());
+      assertThat(trackingReadChannel.getReadCalls()).isEqualTo(5);
+      assertThat(trackingReadChannel.getSeekCalls()).isEqualTo(0);
     }
   }
 
   @Test
   void read_backwardSeek_fallsBackToSeek() throws IOException {
-    GcsItemId itemId =
-        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
-    GcsItemInfo itemInfo =
-        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
-    Storage mockStorage = Mockito.mock(Storage.class);
-    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
-    Mockito.when(
-            mockStorage.reader(
-                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
-        .thenReturn(mockSdkReadChannel);
-    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true);
-    Mockito.when(mockSdkReadChannel.read(Mockito.any(ByteBuffer.class))).thenReturn(5);
+    GcsItemInfo itemInfo = createItemInfoWith(100);
+    createBlobInStorage(
+        BlobId.of(
+            itemInfo.getItemId().getBucketName(), itemInfo.getItemId().getObjectName().get(), 0L),
+        "a".repeat(100));
+    try (FakeGcsReadChannel gcsReadChannel =
+        new FakeGcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
+      TrackingReadChannel trackingReadChannel = gcsReadChannel.getTrackingReadChannel();
 
-    try (GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(
-            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
       gcsReadChannel.read(ByteBuffer.allocate(5));
       gcsReadChannel.position(2);
       gcsReadChannel.read(ByteBuffer.allocate(2));
 
-      Mockito.verify(mockSdkReadChannel).seek(2);
+      assertThat(trackingReadChannel.getSeekCalls()).isEqualTo(1);
     }
   }
 
   @Test
   void close_calledTwice_closesOnlyOnce() throws IOException {
-    Storage mockStorage = Mockito.mock(Storage.class);
-    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
-    Mockito.when(
-            mockStorage.reader(
-                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
-        .thenReturn(mockSdkReadChannel);
-    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true).thenReturn(false);
+    GcsItemInfo itemInfo = createItemInfoWith(100);
+    createBlobInStorage(
+        BlobId.of(
+            itemInfo.getItemId().getBucketName(), itemInfo.getItemId().getObjectName().get(), 0L),
+        "a".repeat(100));
+    FakeGcsReadChannel gcsReadChannel =
+        new FakeGcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
+    TrackingReadChannel trackingReadChannel = gcsReadChannel.getTrackingReadChannel();
+
+    gcsReadChannel.close();
+    gcsReadChannel.close();
+
+    assertThat(trackingReadChannel.getCloseCalls()).isEqualTo(1);
+  }
+
+  private GcsItemInfo createItemInfoWith(long size) {
     GcsItemId itemId =
         GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
-    GcsItemInfo itemInfo =
-        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
-    GcsReadChannel gcsReadChannel =
-        new GcsReadChannel(
-            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
-
-    gcsReadChannel.close();
-    gcsReadChannel.close();
-
-    Mockito.verify(mockSdkReadChannel, Mockito.times(1)).close();
+    return GcsItemInfo.builder().setItemId(itemId).setSize(size).setContentGeneration(0L).build();
   }
 
   private GcsObjectRange createRange(long offset, int length) {

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelTest.java
@@ -261,6 +261,50 @@ class GcsReadChannelTest {
   }
 
   @Test
+  void read_emptyBuffer_returnsZero() throws IOException {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
+    try (GcsReadChannel gcsReadChannel =
+        new GcsReadChannel(
+            storage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
+
+      ByteBuffer emptyBuffer = ByteBuffer.allocate(0);
+      int bytesRead = gcsReadChannel.read(emptyBuffer);
+
+      assertThat(bytesRead).isEqualTo(0);
+    }
+  }
+
+  @Test
+  void read_eof_doesNotAdvancePosition() throws IOException {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
+    Storage mockStorage = Mockito.mock(Storage.class);
+    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
+    Mockito.when(
+            mockStorage.reader(
+                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
+        .thenReturn(mockSdkReadChannel);
+    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true);
+    Mockito.when(mockSdkReadChannel.read(Mockito.any(ByteBuffer.class))).thenReturn(-1);
+
+    try (GcsReadChannel gcsReadChannel =
+        new GcsReadChannel(
+            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
+      ByteBuffer buffer = ByteBuffer.allocate(10);
+
+      int bytesRead = gcsReadChannel.read(buffer);
+
+      assertThat(bytesRead).isEqualTo(-1);
+      assertThat(gcsReadChannel.position()).isEqualTo(0L);
+    }
+  }
+
+  @Test
   void position_negative_throwsEOFException() throws IOException {
     GcsItemId itemId =
         GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
@@ -671,6 +715,230 @@ class GcsReadChannelTest {
     assertThat(e.getCause().getCause())
         .hasMessageThat()
         .contains("EOF reached while reading combinedObjectRange");
+  }
+
+  @Test
+  void position_doesNotSeekImmediately() throws IOException {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
+    Storage mockStorage = Mockito.mock(Storage.class);
+    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
+    Mockito.when(
+            mockStorage.reader(
+                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
+        .thenReturn(mockSdkReadChannel);
+    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true);
+
+    try (GcsReadChannel gcsReadChannel =
+        new GcsReadChannel(
+            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
+      gcsReadChannel.position(10);
+
+      Mockito.verify(mockSdkReadChannel, Mockito.never()).seek(Mockito.anyLong());
+    }
+  }
+
+  @Test
+  void read_inPlaceSeek_readsBytes() throws IOException {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
+    Storage mockStorage = Mockito.mock(Storage.class);
+    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
+    Mockito.when(
+            mockStorage.reader(
+                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
+        .thenReturn(mockSdkReadChannel);
+    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true);
+    Mockito.when(mockSdkReadChannel.read(Mockito.any(ByteBuffer.class)))
+        .thenAnswer(
+            invocation -> {
+              ByteBuffer buffer = invocation.getArgument(0);
+              int remaining = buffer.remaining();
+              buffer.position(buffer.position() + remaining);
+              return remaining;
+            });
+
+    try (GcsReadChannel gcsReadChannel =
+        new GcsReadChannel(
+            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
+      gcsReadChannel.read(ByteBuffer.allocate(5));
+      gcsReadChannel.position(10);
+      gcsReadChannel.read(ByteBuffer.allocate(5));
+      gcsReadChannel.position(20);
+      gcsReadChannel.read(ByteBuffer.allocate(5));
+
+      Mockito.verify(mockSdkReadChannel, Mockito.times(5)).read(Mockito.any(ByteBuffer.class));
+      Mockito.verify(mockSdkReadChannel, Mockito.never()).seek(Mockito.anyLong());
+    }
+  }
+
+  @Test
+  void read_largeSeek_fallsBackToSeek() throws IOException {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
+    Storage mockStorage = Mockito.mock(Storage.class);
+    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
+    Mockito.when(
+            mockStorage.reader(
+                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
+        .thenReturn(mockSdkReadChannel);
+    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true);
+    Mockito.when(mockSdkReadChannel.read(Mockito.any(ByteBuffer.class))).thenReturn(5);
+
+    try (GcsReadChannel gcsReadChannel =
+        new GcsReadChannel(
+            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
+      long largeSeek = 5 + 9 * 1024 * 1024;
+
+      gcsReadChannel.position(largeSeek);
+      gcsReadChannel.read(ByteBuffer.allocate(5));
+
+      Mockito.verify(mockSdkReadChannel).seek(largeSeek);
+    }
+  }
+
+  @Test
+  void read_inPlaceSeek_EOF_fallsBackToSeek() throws IOException {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
+    Storage mockStorage = Mockito.mock(Storage.class);
+    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
+    Mockito.when(
+            mockStorage.reader(
+                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
+        .thenReturn(mockSdkReadChannel);
+    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true);
+    AtomicInteger callCount = new AtomicInteger(0);
+    Mockito.when(mockSdkReadChannel.read(Mockito.any(ByteBuffer.class)))
+        .thenAnswer(
+            invocation -> {
+              ByteBuffer buffer = invocation.getArgument(0);
+              int count = callCount.incrementAndGet();
+              if (count == 1) {
+                int remaining = buffer.remaining();
+                buffer.position(buffer.position() + remaining);
+                return remaining;
+              } else if (count == 2) {
+                return -1; // Simulate EOF during skipInPlace
+              } else {
+                int remaining = buffer.remaining();
+                buffer.position(buffer.position() + remaining);
+                return remaining;
+              }
+            });
+
+    try (GcsReadChannel gcsReadChannel =
+        new GcsReadChannel(
+            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
+      gcsReadChannel.read(ByteBuffer.allocate(5));
+      gcsReadChannel.position(10);
+      gcsReadChannel.read(ByteBuffer.allocate(5));
+
+      Mockito.verify(mockSdkReadChannel).seek(10);
+      Mockito.verify(mockSdkReadChannel, Mockito.times(3)).read(Mockito.any(ByteBuffer.class));
+    }
+  }
+
+  @Test
+  void read_inPlaceSeek_largerThanSkipBufferSize_loopsAndReads() throws IOException {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder()
+            .setItemId(itemId)
+            .setSize(500 * 1024)
+            .setContentGeneration(0L)
+            .build();
+    Storage mockStorage = Mockito.mock(Storage.class);
+    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
+    Mockito.when(
+            mockStorage.reader(
+                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
+        .thenReturn(mockSdkReadChannel);
+    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true);
+    Mockito.when(mockSdkReadChannel.read(Mockito.any(ByteBuffer.class)))
+        .thenAnswer(
+            invocation -> {
+              ByteBuffer buffer = invocation.getArgument(0);
+              int remaining = buffer.remaining();
+              buffer.position(buffer.position() + remaining);
+              return remaining;
+            });
+
+    GcsReadOptions customOptions =
+        GcsReadOptions.builder()
+            .setUserProjectId(TEST_PROJECT_ID)
+            .setInplaceSeekLimit(500 * 1024)
+            .build();
+    try (GcsReadChannel gcsReadChannel =
+        new GcsReadChannel(
+            mockStorage, itemInfo, customOptions, executorServiceSupplier, telemetry)) {
+      gcsReadChannel.read(ByteBuffer.allocate(5));
+      long newPosition = 300 * 1024;
+      gcsReadChannel.position(newPosition);
+
+      gcsReadChannel.read(ByteBuffer.allocate(5));
+
+      Mockito.verify(mockSdkReadChannel, Mockito.times(5)).read(Mockito.any(ByteBuffer.class));
+      Mockito.verify(mockSdkReadChannel, Mockito.never()).seek(Mockito.anyLong());
+    }
+  }
+
+  @Test
+  void read_backwardSeek_fallsBackToSeek() throws IOException {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
+    Storage mockStorage = Mockito.mock(Storage.class);
+    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
+    Mockito.when(
+            mockStorage.reader(
+                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
+        .thenReturn(mockSdkReadChannel);
+    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true);
+    Mockito.when(mockSdkReadChannel.read(Mockito.any(ByteBuffer.class))).thenReturn(5);
+
+    try (GcsReadChannel gcsReadChannel =
+        new GcsReadChannel(
+            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry)) {
+      gcsReadChannel.read(ByteBuffer.allocate(5));
+      gcsReadChannel.position(2);
+      gcsReadChannel.read(ByteBuffer.allocate(2));
+
+      Mockito.verify(mockSdkReadChannel).seek(2);
+    }
+  }
+
+  @Test
+  void close_calledTwice_closesOnlyOnce() throws IOException {
+    Storage mockStorage = Mockito.mock(Storage.class);
+    ReadChannel mockSdkReadChannel = Mockito.mock(ReadChannel.class);
+    Mockito.when(
+            mockStorage.reader(
+                Mockito.any(BlobId.class), Mockito.any(Storage.BlobSourceOption[].class)))
+        .thenReturn(mockSdkReadChannel);
+    Mockito.when(mockSdkReadChannel.isOpen()).thenReturn(true).thenReturn(false);
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder().setItemId(itemId).setSize(100).setContentGeneration(0L).build();
+    GcsReadChannel gcsReadChannel =
+        new GcsReadChannel(
+            mockStorage, itemInfo, TEST_GCS_READ_OPTIONS, executorServiceSupplier, telemetry);
+
+    gcsReadChannel.close();
+    gcsReadChannel.close();
+
+    Mockito.verify(mockSdkReadChannel, Mockito.times(1)).close();
   }
 
   private GcsObjectRange createRange(long offset, int length) {

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptionsTest.java
@@ -41,6 +41,7 @@ class GcsReadOptionsTest {
             .put("gcs.analytics-core.large-file.footer.prefetch.size-bytes", "4194304")
             .put("gcs.analytics-core.small-file.footer.prefetch.size-bytes", "41943")
             .put("gcs.analytics-core.small-file.cache.threshold-bytes", "102400")
+            .put("gcs.analytics-core.read.inplace-seek-limit-bytes", "16777216")
             .build();
     String prefix = "gcs.";
 
@@ -54,6 +55,7 @@ class GcsReadOptionsTest {
     assertThat(readOptions.getFooterPrefetchSizeSmallFile()).isEqualTo(41943);
     assertThat(readOptions.getFooterPrefetchSizeLargeFile()).isEqualTo(4194304);
     assertThat(readOptions.getSmallObjectCacheSize()).isEqualTo(102400);
+    assertThat(readOptions.getInplaceSeekLimit()).isEqualTo(16777216);
     assertThat(vectoredReadOptions.getMaxMergeGap()).isEqualTo(1024);
     assertThat(vectoredReadOptions.getMaxMergeSize()).isEqualTo(2048);
   }
@@ -73,6 +75,7 @@ class GcsReadOptionsTest {
     assertThat(readOptions.getFooterPrefetchSizeSmallFile()).isEqualTo(100 * 1024);
     assertThat(readOptions.getFooterPrefetchSizeLargeFile()).isEqualTo(1024 * 1024);
     assertThat(readOptions.getSmallObjectCacheSize()).isEqualTo(0);
+    assertThat(readOptions.getInplaceSeekLimit()).isEqualTo(128 * 1024);
     assertThat(vectoredReadOptions.getMaxMergeGap()).isEqualTo(4 * 1024);
     assertThat(vectoredReadOptions.getMaxMergeSize()).isEqualTo(8 * 1024 * 1024);
   }
@@ -83,6 +86,7 @@ class GcsReadOptionsTest {
         "gcs.analytics-core.small-file.footer.prefetch.size-bytes",
         "gcs.analytics-core.small-file.cache.threshold-bytes",
         "gcs.analytics-core.large-file.footer.prefetch.size-bytes",
+        "gcs.analytics-core.read.inplace-seek-limit-bytes",
       })
   void createFromOptions_integerValuesGreaterThanIntegerMax_throwsIllegalArgumentException(
       String propertyKey) {

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/VersionHelperTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/VersionHelperTest.java
@@ -58,10 +58,12 @@ class VersionHelperTest {
     try (MockedStatic<VersionHelper> mockedVersionHelper = mockStatic(VersionHelper.class)) {
       InputStream mockStream = mock(InputStream.class);
       doThrow(new IOException("test close exception")).when(mockStream).close();
-      
+
       mockedVersionHelper.when(() -> VersionHelper.openPomFileInputStream()).thenReturn(mockStream);
       mockedVersionHelper.when(() -> VersionHelper.loadVersion()).thenCallRealMethod();
-      mockedVersionHelper.when(() -> VersionHelper.loadVersion(any(InputStream.class))).thenCallRealMethod();
+      mockedVersionHelper
+          .when(() -> VersionHelper.loadVersion(any(InputStream.class)))
+          .thenCallRealMethod();
 
       String version = VersionHelper.loadVersion();
       assertThat(version).isEqualTo(VersionHelper.DEFAULT_VERSION);

--- a/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/IntegrationTestHelper.java
+++ b/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/IntegrationTestHelper.java
@@ -121,7 +121,7 @@ public class IntegrationTestHelper {
         }
     }
 
-    private static String getFolderName() {
+    public static String getFolderName() {
         String folderName = System.getProperty("gcs.integration.test.bucket.folder");
         if (folderName == null) { return "test/"; }
         return folderName.endsWith("/") ? folderName : folderName + "/";

--- a/core/src/jmh/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelBenchmark.java
+++ b/core/src/jmh/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelBenchmark.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.client;
+
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageInputStream;
+import com.google.cloud.gcs.analyticscore.core.IntegrationTestHelper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class GcsReadChannelBenchmark {
+
+    private GcsItemId itemId;
+    private byte[] buffer;
+    private GoogleCloudStorageInputStream stream;
+    private GcsFileSystem gcsFileSystem;
+    private GcsReadOptions options;
+
+    @Setup(Level.Trial)
+    public void setup(GcsReadChannelBenchmarkState state) throws IOException {
+        IntegrationTestHelper.uploadSampleParquetFilesIfNotExists();
+        itemId = GcsItemId.builder()
+                .setBucketName(IntegrationTestHelper.BUCKET_NAME)
+                .setObjectName(IntegrationTestHelper.getFolderName() + IntegrationTestHelper.TPCDS_CUSTOMER_MEDIUM_FILE)
+                .build();
+        buffer = new byte[1024];
+
+        options = GcsReadOptions.builder()
+                .setInplaceSeekLimit(state.scenario.getInplaceSeekLimit())
+                .build();
+        GcsFileSystemOptions fileSystemOptions = GcsFileSystemOptions.builder()
+                .setGcsClientOptions(GcsClientOptions.builder()
+                        .setGcsReadOptions(options)
+                        .build())
+                .build();
+        gcsFileSystem = new GcsFileSystemImpl(fileSystemOptions);
+    }
+
+    @Setup(Level.Invocation)
+    public void setupInvocation() throws IOException {
+        stream = GoogleCloudStorageInputStream.create(gcsFileSystem, itemId);
+        stream.read(buffer);
+    }
+
+    @TearDown(Level.Invocation)
+    public void tearDownInvocation() throws IOException {
+        if (stream != null) {
+            stream.close();
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    @Warmup(iterations = 3, time = 1)
+    @Measurement(iterations = 5, time = 1)
+    @Fork(value = 1, warmups = 0)
+    public void seek(GcsReadChannelBenchmarkState state) throws IOException {
+        stream.seek(state.scenario.getSeekDistance());
+        stream.read(buffer);
+    }
+}

--- a/core/src/jmh/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelBenchmarkState.java
+++ b/core/src/jmh/java/com/google/cloud/gcs/analyticscore/client/GcsReadChannelBenchmarkState.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.client;
+
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class GcsReadChannelBenchmarkState {
+
+    public enum SeekScenario {
+        SEEK_128K_LIMIT_0(128 * 1024, 0),
+        SEEK_128K_LIMIT_128K(128 * 1024, 128 * 1024),
+        SEEK_512K_LIMIT_0(512 * 1024, 0),
+        SEEK_512K_LIMIT_512K(512 * 1024, 512 * 1024),
+        SEEK_1M_LIMIT_0(1024 * 1024, 0),
+        SEEK_1M_LIMIT_1M(1024 * 1024, 1024 * 1024);
+
+        private final int seekDistance;
+        private final int inplaceSeekLimit;
+
+        SeekScenario(int seekDistance, int inplaceSeekLimit) {
+            this.seekDistance = seekDistance;
+            this.inplaceSeekLimit = inplaceSeekLimit;
+        }
+
+        public int getSeekDistance() {
+            return seekDistance;
+        }
+
+        public int getInplaceSeekLimit() {
+            return inplaceSeekLimit;
+        }
+    }
+
+    @Param({
+        "SEEK_128K_LIMIT_0",
+        "SEEK_128K_LIMIT_128K",
+        "SEEK_512K_LIMIT_0",
+        "SEEK_512K_LIMIT_512K",
+        "SEEK_1M_LIMIT_0",
+        "SEEK_1M_LIMIT_1M"
+    })
+    public SeekScenario scenario;
+}

--- a/test-lib/pom.xml
+++ b/test-lib/pom.xml
@@ -53,6 +53,11 @@
             <artifactId>truth</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannel.java
+++ b/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannel.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 
 public class FakeGcsReadChannel extends GcsReadChannel {
   private static int openReadChannelCount = 0;
+  private TrackingReadChannel trackingReadChannel;
 
   public FakeGcsReadChannel(
       Storage storage,
@@ -40,7 +41,13 @@ public class FakeGcsReadChannel extends GcsReadChannel {
   protected ReadChannel openSdkReadChannel(GcsItemId itemId, GcsReadOptions readOptions)
       throws IOException {
     openReadChannelCount++;
-    return super.openSdkReadChannel(itemId, readOptions);
+    ReadChannel delegate = super.openSdkReadChannel(itemId, readOptions);
+    trackingReadChannel = new TrackingReadChannel(delegate);
+    return trackingReadChannel;
+  }
+
+  public TrackingReadChannel getTrackingReadChannel() {
+    return trackingReadChannel;
   }
 
   public static int getOpenReadChannelCount() {

--- a/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannel.java
+++ b/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannel.java
@@ -37,10 +37,10 @@ public class FakeGcsReadChannel extends GcsReadChannel {
   }
 
   @Override
-  protected ReadChannel openReadChannel(GcsItemId itemId, GcsReadOptions readOptions)
+  protected ReadChannel openSdkReadChannel(GcsItemId itemId, GcsReadOptions readOptions)
       throws IOException {
     openReadChannelCount++;
-    return super.openReadChannel(itemId, readOptions);
+    return super.openSdkReadChannel(itemId, readOptions);
   }
 
   public static int getOpenReadChannelCount() {

--- a/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/TrackingReadChannel.java
+++ b/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/TrackingReadChannel.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.client;
+
+import com.google.cloud.ReadChannel;
+import com.google.cloud.RestorableState;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class TrackingReadChannel implements ReadChannel {
+  private final ReadChannel delegate;
+  private int readCalls = 0;
+  private int seekCalls = 0;
+  private int eofAtCall = -1;
+  private int closeCalls = 0;
+
+  public TrackingReadChannel(ReadChannel delegate) {
+    this.delegate = delegate;
+  }
+
+  public void setEofAtCall(int callNumber) {
+    this.eofAtCall = callNumber;
+  }
+
+  @Override
+  public int read(ByteBuffer dst) throws IOException {
+    readCalls++;
+    if (readCalls == eofAtCall) {
+      return -1;
+    }
+    return delegate.read(dst);
+  }
+
+  @Override
+  public void seek(long position) throws IOException {
+    seekCalls++;
+    delegate.seek(position);
+  }
+
+  @Override
+  public void close() {
+    closeCalls++;
+    delegate.close();
+  }
+
+  @Override
+  public boolean isOpen() {
+    return delegate.isOpen();
+  }
+
+  @Override
+  public void setChunkSize(int chunkSize) {
+    delegate.setChunkSize(chunkSize);
+  }
+
+  @Override
+  public ReadChannel limit(long limit) {
+    delegate.limit(limit);
+    return this;
+  }
+
+  @Override
+  public RestorableState<ReadChannel> capture() {
+    return delegate.capture();
+  }
+
+  public int getReadCalls() {
+    return readCalls;
+  }
+
+  public int getSeekCalls() {
+    return seekCalls;
+  }
+
+  public int getCloseCalls() {
+    return closeCalls;
+  }
+}

--- a/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannelTest.java
+++ b/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannelTest.java
@@ -56,8 +56,8 @@ class FakeGcsReadChannelTest {
   }
 
   @Test
-  void openReadChannel_incrementsOpenReadChannelCount() throws Exception {
-    fakeGcsReadChannel.openReadChannel(itemInfo.getItemId(), readOptions);
+  void openSdkReadChannel_incrementsOpenReadChannelCount() throws Exception {
+    fakeGcsReadChannel.openSdkReadChannel(itemInfo.getItemId(), readOptions);
 
     assertEquals(1, FakeGcsReadChannel.getOpenReadChannelCount());
   }

--- a/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannelTest.java
+++ b/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannelTest.java
@@ -72,7 +72,7 @@ class FakeGcsReadChannelTest {
   void openSdkReadChannel_createsTrackingReadChannelThatReadsFromStorage() throws Exception {
     TrackingReadChannel tracking = fakeGcsReadChannel.getTrackingReadChannel();
     ByteBuffer dst = ByteBuffer.allocate(100);
-    
+
     int bytesRead = tracking.read(dst);
 
     assertThat(bytesRead).isEqualTo(100);

--- a/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannelTest.java
+++ b/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeGcsReadChannelTest.java
@@ -16,13 +16,15 @@
 
 package com.google.cloud.gcs.analyticscore.client;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import java.nio.ByteBuffer;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +34,7 @@ class FakeGcsReadChannelTest {
   private FakeGcsReadChannel fakeGcsReadChannel;
   private GcsItemInfo itemInfo;
   private GcsReadOptions readOptions;
+  private Storage storage;
 
   @BeforeEach
   void createDefaultInstances() throws Exception {
@@ -40,14 +43,12 @@ class FakeGcsReadChannelTest {
     itemInfo = GcsItemInfo.builder().setItemId(itemId).setSize(100L).build();
     readOptions = GcsReadOptions.builder().build();
     byte[] data = TestDataGenerator.generateSeededRandomBytes(100, 1);
-    LocalStorageHelper.getOptions()
-        .getService()
-        .create(
-            BlobInfo.newBuilder(itemId.getBucketName(), itemId.getObjectName().get()).build(),
-            data);
+    storage = LocalStorageHelper.getOptions().getService();
+    storage.create(
+        BlobInfo.newBuilder(itemId.getBucketName(), itemId.getObjectName().get()).build(), data);
     fakeGcsReadChannel =
         new FakeGcsReadChannel(
-            LocalStorageHelper.getOptions().getService(),
+            storage,
             itemInfo,
             readOptions,
             Suppliers.ofInstance(Executors.newSingleThreadExecutor()),
@@ -59,6 +60,21 @@ class FakeGcsReadChannelTest {
   void openSdkReadChannel_incrementsOpenReadChannelCount() throws Exception {
     fakeGcsReadChannel.openSdkReadChannel(itemInfo.getItemId(), readOptions);
 
-    assertEquals(1, FakeGcsReadChannel.getOpenReadChannelCount());
+    assertThat(FakeGcsReadChannel.getOpenReadChannelCount()).isEqualTo(1);
+  }
+
+  @Test
+  void getTrackingReadChannel_returnsAutoCreatedWrapper() {
+    assertThat(fakeGcsReadChannel.getTrackingReadChannel()).isNotNull();
+  }
+
+  @Test
+  void openSdkReadChannel_createsTrackingReadChannelThatReadsFromStorage() throws Exception {
+    TrackingReadChannel tracking = fakeGcsReadChannel.getTrackingReadChannel();
+    ByteBuffer dst = ByteBuffer.allocate(100);
+    
+    int bytesRead = tracking.read(dst);
+
+    assertThat(bytesRead).isEqualTo(100);
   }
 }

--- a/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/TrackingReadChannelTest.java
+++ b/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/TrackingReadChannelTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.client;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.ReadChannel;
+import com.google.cloud.RestorableState;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TrackingReadChannelTest {
+
+  private ReadChannel delegate;
+  private TrackingReadChannel trackingReadChannel;
+
+  @BeforeEach
+  void setUp() {
+    delegate = mock(ReadChannel.class);
+    trackingReadChannel = new TrackingReadChannel(delegate);
+  }
+
+  @Test
+  void read_delegatesAndIncrementsCounter() throws IOException {
+    ByteBuffer dst = ByteBuffer.allocate(10);
+    when(delegate.read(dst)).thenReturn(1);
+
+    int bytesRead = trackingReadChannel.read(dst);
+
+    assertThat(bytesRead).isEqualTo(1);
+    assertThat(trackingReadChannel.getReadCalls()).isEqualTo(1);
+    verify(delegate).read(dst);
+  }
+
+  @Test
+  void read_returnsEofWhenSimulated() throws IOException {
+    ByteBuffer dst = ByteBuffer.allocate(10);
+    trackingReadChannel.setEofAtCall(1);
+
+    int bytesRead = trackingReadChannel.read(dst);
+
+    assertThat(bytesRead).isEqualTo(-1);
+    assertThat(trackingReadChannel.getReadCalls()).isEqualTo(1);
+  }
+
+  @Test
+  void seek_delegatesAndIncrementsCounter() throws IOException {
+    long position = 100L;
+
+    trackingReadChannel.seek(position);
+
+    assertThat(trackingReadChannel.getSeekCalls()).isEqualTo(1);
+    verify(delegate).seek(position);
+  }
+
+  @Test
+  void close_delegatesAndIncrementsCounter() {
+    trackingReadChannel.close();
+
+    assertThat(trackingReadChannel.getCloseCalls()).isEqualTo(1);
+    verify(delegate).close();
+  }
+
+  @Test
+  void isOpen_delegates() {
+    when(delegate.isOpen()).thenReturn(true);
+
+    boolean open = trackingReadChannel.isOpen();
+
+    assertThat(open).isTrue();
+    verify(delegate).isOpen();
+  }
+
+  @Test
+  void setChunkSize_delegates() {
+    int chunkSize = 1024;
+
+    trackingReadChannel.setChunkSize(chunkSize);
+
+    verify(delegate).setChunkSize(chunkSize);
+  }
+
+  @Test
+  void limit_delegates() {
+    long limit = 500L;
+    when(delegate.limit(limit)).thenReturn(delegate);
+
+    ReadChannel result = trackingReadChannel.limit(limit);
+
+    assertThat(result).isEqualTo(trackingReadChannel);
+    verify(delegate).limit(limit);
+  }
+
+  @Test
+  void capture_delegates() {
+    when(delegate.capture()).thenReturn(null);
+
+    RestorableState<ReadChannel> state = trackingReadChannel.capture();
+
+    assertThat(state).isNull();
+    verify(delegate).capture();
+  }
+}


### PR DESCRIPTION
The implementation defers the seek operation to the read stage. If the read involves a small forward seek, the implementation reads and discards the data, which is more efficient than calling seek on gcsSdkReadChannel.

Testing:
Added a Jmh benchmark, to evaluate in place seeking. 
<img width="2962" height="682" alt="image" src="https://github.com/user-attachments/assets/88e62667-3b09-4dac-b5ce-a7943550118b" />

A separate microbenchmark was performed to determine the optimal sizes for the skip buffer and the in-place seek limit. The optimal skip buffer is 128KiB and the optimal in-place seek limit is 128KiB.
[skipBufferFinalize.md](https://github.com/user-attachments/files/26671850/skipBufferFinalize.md)



