### PR TITLE
feat(common): add foundational caching infrastructure for Parquet foo…

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -41,6 +41,10 @@ limitations under the License.
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCache.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCache.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.common.cache;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * A simple, generic interface for an in-memory cache. All implementations of this interface must be
+ * thread-safe.
+ *
+ * @param <K> The type of keys maintained by this cache.
+ * @param <V> The type of mapped values.
+ */
+public interface AnalyticsCache<K, V> {
+
+  /**
+   * Returns the value associated with the {@code key} in this cache, or {@code Optional.empty()} if
+   * there is no cached value for {@code key}.
+   *
+   * @param key The key to retrieve.
+   * @return An Optional containing the value, or empty if not found.
+   */
+  Optional<V> get(K key);
+
+  /**
+   * Returns the value associated with the {@code key} in this cache, obtaining it from the {@code
+   * mappingFunction} if necessary. This method is atomic; the {@code mappingFunction} will be
+   * applied at most once per key.
+   *
+   * @param key The key to retrieve.
+   * @param mappingFunction The function to compute the value if it is missing. This function must
+   *     not return {@code null}.
+   * @return The value associated with the key.
+   * @throws NullPointerException if the {@code mappingFunction} returns {@code null}.
+   */
+  V get(K key, Function<? super K, ? extends V> mappingFunction);
+
+  /**
+   * Associates the {@code value} with the {@code key} in this cache. If the cache previously
+   * contained a value associated with the {@code key}, the old value is replaced by the new {@code
+   * value}.
+   *
+   * @param key The key to associate with the value.
+   * @param value The value to cache.
+   */
+  void put(K key, V value);
+
+  /**
+   * Discards any cached value for the {@code key}.
+   *
+   * @param key The key to invalidate.
+   */
+  void invalidate(K key);
+
+  /** Discards all entries in the cache. */
+  void invalidateAll();
+
+  /**
+   * Returns the approximate number of entries in this cache.
+   *
+   * @return The approximate number of entries.
+   */
+  long size();
+}

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImpl.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImpl.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.common.cache;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * An {@link AnalyticsCache} implementation backed by a Caffeine {@link Cache}. This implementation
+ * is thread-safe.
+ *
+ * @param <K> The type of keys maintained by this cache.
+ * @param <V> The type of mapped values.
+ */
+public class AnalyticsCacheCaffeineImpl<K, V> implements AnalyticsCache<K, V> {
+
+  private final Cache<K, V> cache;
+
+  private AnalyticsCacheCaffeineImpl(long maxEntries) {
+    checkArgument(maxEntries > 0, "maxEntries must be positive");
+    this.cache = Caffeine.newBuilder().maximumSize(maxEntries).build();
+  }
+
+  /**
+   * Creates a new {@link AnalyticsCacheCaffeineImpl} with the specified maximum number of entries.
+   *
+   * @param maxEntries The maximum number of entries the cache can hold.
+   * @return A new {@link AnalyticsCacheCaffeineImpl} instance.
+   */
+  public static <K, V> AnalyticsCacheCaffeineImpl<K, V> create(long maxEntries) {
+    return new AnalyticsCacheCaffeineImpl<>(maxEntries);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<V> get(K key) {
+    checkNotNull(key, "key cannot be null");
+    return Optional.ofNullable(cache.getIfPresent(key));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public V get(K key, Function<? super K, ? extends V> mappingFunction) {
+    checkNotNull(key, "key cannot be null");
+    checkNotNull(mappingFunction, "mappingFunction cannot be null");
+    V value =
+        cache.get(
+            key,
+            k -> {
+              V computed = mappingFunction.apply(k);
+              if (computed == null) {
+                throw new NullPointerException("mappingFunction returned null for key: " + k);
+              }
+              return computed;
+            });
+    if (value == null) {
+      throw new NullPointerException("mappingFunction returned null for key: " + key);
+    }
+    return value;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void put(K key, V value) {
+    checkNotNull(key, "key cannot be null");
+    checkNotNull(value, "value cannot be null");
+    cache.put(key, value);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void invalidate(K key) {
+    checkNotNull(key, "key cannot be null");
+    cache.invalidate(key);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void invalidateAll() {
+    cache.invalidateAll();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public long size() {
+    return cache.estimatedSize();
+  }
+
+  /** Performs any pending maintenance operations needed by the cache. */
+  public void cleanUp() {
+    cache.cleanUp();
+  }
+}

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImplTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImplTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.common.cache;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnalyticsCacheCaffeineImplTest {
+
+  private AnalyticsCacheCaffeineImpl<String, String> cache;
+
+  @BeforeEach
+  void setUp() {
+    cache = AnalyticsCacheCaffeineImpl.create(2);
+  }
+
+  @Test
+  void putAndGet_succeeds() {
+    String key = "key1";
+    String value = "value1";
+
+    cache.put(key, value);
+
+    assertThat(cache.get(key)).hasValue(value);
+  }
+
+  @Test
+  void get_nonExistentKey_returnsEmpty() {
+    assertThat(cache.get("non-existent")).isEmpty();
+  }
+
+  @Test
+  void getWithMappingFunction_computesAndCachesValue() {
+    String key = "key1";
+    AtomicInteger callCount = new AtomicInteger(0);
+
+    String value =
+        cache.get(
+            key,
+            k -> {
+              callCount.incrementAndGet();
+              return "computed-" + k;
+            });
+
+    assertThat(value).isEqualTo("computed-key1");
+    assertThat(callCount.get()).isEqualTo(1);
+    assertThat(cache.get(key)).hasValue("computed-key1");
+
+    // Second call should return cached value without calling the function
+    String secondValue =
+        cache.get(
+            key,
+            k -> {
+              callCount.incrementAndGet();
+              return "should-not-happen";
+            });
+    assertThat(secondValue).isEqualTo("computed-key1");
+    assertThat(callCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  void getWithMappingFunction_returnsNull_throwsException() {
+    assertThrows(NullPointerException.class, () -> cache.get("key1", k -> null));
+  }
+
+  @Test
+  void invalidate_removesEntry() {
+    cache.put("key1", "value1");
+
+    cache.invalidate("key1");
+
+    assertThat(cache.get("key1")).isEmpty();
+  }
+
+  @Test
+  void invalidateAll_clearsCache() {
+    cache.put("key1", "value1");
+    cache.put("key2", "value2");
+
+    cache.invalidateAll();
+
+    assertThat(cache.size()).isEqualTo(0);
+    assertThat(cache.get("key1")).isEmpty();
+    assertThat(cache.get("key2")).isEmpty();
+  }
+
+  @Test
+  void lruEviction_succeeds() {
+    cache.put("key1", "value1");
+    cache.put("key2", "value2");
+
+    cache.put("key3", "value3");
+    cache.cleanUp();
+
+    assertThat(cache.size()).isEqualTo(2);
+    // One of them must be empty.
+    boolean anyEmpty =
+        cache.get("key1").isEmpty() || cache.get("key2").isEmpty() || cache.get("key3").isEmpty();
+    assertThat(anyEmpty).isTrue();
+  }
+
+  @Test
+  void create_withInvalidMaxEntries_throwsException() {
+    assertThrows(IllegalArgumentException.class, () -> AnalyticsCacheCaffeineImpl.create(0));
+    assertThrows(IllegalArgumentException.class, () -> AnalyticsCacheCaffeineImpl.create(-1));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@ limitations under the License.
         <apache.hadoop.version>3.4.2</apache.hadoop.version>
         <slf4j.version>1.7.36</slf4j.version>
         <opentelemetry.version>1.52.0</opentelemetry.version>
+        <caffeine.version>3.1.8</caffeine.version>
     </properties>
 
     <profiles>
@@ -402,6 +403,11 @@ limitations under the License.
                 <scope>import</scope>
             </dependency>
 
+            <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>${caffeine.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION




## Type of Change

- [x] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
- Define AnalyticsCache interface with atomic mapping support.
- Implement AnalyticsCacheCaffeineImpl using Caffeine 3.1.8.
- Add unit tests for CaffeineCache implementation including eviction and atomic compute.
- Update pom.xml and common/pom.xml with Caffeine dependencies.

### Why?
Introduces a thread-safe caching abstraction and its Caffeine-based implementation. This is Phase 1 of the Parquet footer caching plan.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [x] All files include the Apache License 2.0 header
- [ ] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? [Yes/No]*

Yes, the code was written using gemini cli based on the design doc.
