### PR TITLE
add foundational caching layer for Parquet footer caching [1/4]

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---
-Copyright 2025 Google LLC
+Copyright 2026 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -39,6 +39,10 @@ limitations under the License.
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCache.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCache.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.common.cache;
+
+import java.util.Optional;
+
+/**
+ * A simple, generic interface for an in-memory cache. All implementations of this interface must be
+ * thread-safe.
+ *
+ * @param <K> The type of keys maintained by this cache.
+ * @param <V> The type of mapped values.
+ */
+public interface AnalyticsCache<K, V> {
+
+  /**
+   * Returns the value associated with the {@code key} in this cache, or {@code Optional.empty()} if
+   * there is no cached value for {@code key}.
+   */
+  Optional<V> get(K key);
+
+  /**
+   * Returns the value associated with the {@code key} in this cache, obtaining it from the {@code
+   * mappingFunction} if necessary. This method is atomic; the {@code mappingFunction} will be
+   * applied at most once per key during concurrent access.
+   *
+   * <p>This method supports mapping functions that throw checked exceptions. If the {@code
+   * mappingFunction} throws an exception, it will be propagated to the caller and the result will
+   * not be cached.
+   *
+   * @param <E> The type of the exception that may be thrown by the mapping function.
+   * @throws E if the {@code mappingFunction} throws an exception.
+   * @throws NullPointerException if the {@code mappingFunction} returns {@code null} or if any
+   *     argument is {@code null}.
+   */
+  <E extends Exception> V get(K key, ThrowingFunction<? super K, ? extends V, E> mappingFunction)
+      throws E;
+
+  /**
+   * Associates the {@code value} with the {@code key} in this cache. If the cache previously
+   * contained a value associated with the {@code key}, the old value is replaced by the new {@code
+   * value}.
+   */
+  void put(K key, V value);
+
+  /** Discards any cached value for the {@code key}. */
+  void invalidate(K key);
+
+  /** Discards all entries in the cache. */
+  void invalidateAll();
+
+  /** Returns the approximate number of entries in this cache. */
+  long size();
+
+  /** Performs any pending maintenance operations needed by the cache. */
+  default void cleanUp() {
+    // No-op by default
+  }
+}

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImpl.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImpl.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.common.cache;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Optional;
+
+/**
+ * An {@link AnalyticsCache} implementation backed by a Caffeine {@link Cache}. This implementation
+ * is thread-safe.
+ *
+ * @param <K> The type of keys maintained by this cache.
+ * @param <V> The type of mapped values.
+ */
+public class AnalyticsCacheCaffeineImpl<K, V> implements AnalyticsCache<K, V> {
+
+  private final Cache<K, V> cache;
+
+  private AnalyticsCacheCaffeineImpl(long maxEntries) {
+    checkArgument(maxEntries > 0, "maxEntries must be positive");
+    this.cache = Caffeine.newBuilder().maximumSize(maxEntries).build();
+  }
+
+  /**
+   * Creates a new {@link AnalyticsCacheCaffeineImpl} with the specified maximum number of entries.
+   */
+  public static <K, V> AnalyticsCacheCaffeineImpl<K, V> create(long maxEntries) {
+    return new AnalyticsCacheCaffeineImpl<>(maxEntries);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<V> get(K key) {
+    checkNotNull(key, "key cannot be null");
+    return Optional.ofNullable(cache.getIfPresent(key));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  @SuppressWarnings("unchecked")
+  public <E extends Exception> V get(
+      K key, ThrowingFunction<? super K, ? extends V, E> mappingFunction) throws E {
+    checkNotNull(key, "key cannot be null");
+    checkNotNull(mappingFunction, "mappingFunction cannot be null");
+    try {
+      return cache.get(
+          key,
+          keyToLoad -> {
+            try {
+              V computed = mappingFunction.apply(keyToLoad);
+              if (computed == null) {
+                throw new NullPointerException(
+                    "mappingFunction returned null for key: " + keyToLoad);
+              }
+              return computed;
+            } catch (Exception exception) {
+              throw new ExecutionException(exception);
+            }
+          });
+    } catch (ExecutionException executionException) {
+      Throwable cause = executionException.getCause();
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      throw (E) cause;
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void put(K key, V value) {
+    checkNotNull(key, "key cannot be null");
+    checkNotNull(value, "value cannot be null");
+    cache.put(key, value);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void invalidate(K key) {
+    checkNotNull(key, "key cannot be null");
+    cache.invalidate(key);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void invalidateAll() {
+    cache.invalidateAll();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public long size() {
+    return cache.estimatedSize();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void cleanUp() {
+    cache.cleanUp();
+  }
+
+  /** A private runtime exception used to wrap checked exceptions during cache loading. */
+  private static class ExecutionException extends RuntimeException {
+    ExecutionException(Throwable cause) {
+      super(cause);
+    }
+  }
+}

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheNoOpImpl.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheNoOpImpl.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.common.cache;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Optional;
+
+/**
+ * An {@link AnalyticsCache} implementation that does nothing. All lookups result in a miss, and all
+ * puts are ignored.
+ *
+ * @param <K> The type of keys maintained by this cache.
+ * @param <V> The type of mapped values.
+ */
+public class AnalyticsCacheNoOpImpl<K, V> implements AnalyticsCache<K, V> {
+
+  private static final AnalyticsCacheNoOpImpl<Object, Object> INSTANCE =
+      new AnalyticsCacheNoOpImpl<>();
+
+  private AnalyticsCacheNoOpImpl() {}
+
+  /** Returns the singleton instance of {@link AnalyticsCacheNoOpImpl}. */
+  @SuppressWarnings("unchecked")
+  public static <K, V> AnalyticsCacheNoOpImpl<K, V> getInstance() {
+    return (AnalyticsCacheNoOpImpl<K, V>) INSTANCE;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<V> get(K key) {
+    checkNotNull(key, "key cannot be null");
+    return Optional.empty();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public <E extends Exception> V get(
+      K key, ThrowingFunction<? super K, ? extends V, E> mappingFunction) throws E {
+    checkNotNull(key, "key cannot be null");
+    checkNotNull(mappingFunction, "mappingFunction cannot be null");
+    V value = mappingFunction.apply(key);
+    if (value == null) {
+      throw new NullPointerException("mappingFunction returned null for key: " + key);
+    }
+    return value;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void put(K key, V value) {
+    checkNotNull(key, "key cannot be null");
+    checkNotNull(value, "value cannot be null");
+    // Do nothing
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void invalidate(K key) {
+    checkNotNull(key, "key cannot be null");
+    // Do nothing
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void invalidateAll() {
+    // Do nothing
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public long size() {
+    return 0;
+  }
+}

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/ThrowingFunction.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/ThrowingFunction.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.common.cache;
+
+/**
+ * A functional interface that represents a function that can throw a checked exception.
+ *
+ * @param <K> The type of the input to the function.
+ * @param <V> The type of the result of the function.
+ * @param <E> The type of the exception that may be thrown.
+ */
+@FunctionalInterface
+public interface ThrowingFunction<K, V, E extends Exception> {
+  /** Applies this function to the given argument. */
+  V apply(K key) throws E;
+}

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImplTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImplTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.common.cache;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnalyticsCacheCaffeineImplTest {
+
+  private AnalyticsCacheCaffeineImpl<String, String> cache;
+
+  @BeforeEach
+  void setUp() {
+    cache = AnalyticsCacheCaffeineImpl.create(10);
+  }
+
+  @Test
+  void get_notPresent_returnsEmpty() {
+    assertThat(cache.get("key1")).isEmpty();
+  }
+
+  @Test
+  void get_present_returnsValue() {
+    cache.put("key1", "value1");
+
+    assertThat(cache.get("key1")).hasValue("value1");
+  }
+
+  @Test
+  void get_withMappingFunction_notPresent_computesAndCachesValue() throws Exception {
+    String key = "key1";
+    AtomicInteger callCount = new AtomicInteger(0);
+
+    String value =
+        cache.get(
+            key,
+            keyToLoad -> {
+              callCount.incrementAndGet();
+              return "computed-" + keyToLoad;
+            });
+
+    assertThat(value).isEqualTo("computed-key1");
+    assertThat(callCount.get()).isEqualTo(1);
+
+    String secondValue = cache.get(key, keyToLoad -> "should-not-happen");
+
+    assertThat(secondValue).isEqualTo("computed-key1");
+    assertThat(callCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  void get_withMappingFunction_returnsNull_throwsException() {
+    assertThrows(NullPointerException.class, () -> cache.get("key1", k -> null));
+  }
+
+  @Test
+  void get_withMappingFunction_throwsCheckedException_rethrowsException() {
+    assertThrows(
+        IOException.class,
+        () ->
+            cache.get(
+                "key1",
+                keyToLoad -> {
+                  throw new IOException("test-exception");
+                }));
+  }
+
+  @Test
+  void invalidate_present_removesEntry() {
+    cache.put("key1", "value1");
+
+    cache.invalidate("key1");
+
+    assertThat(cache.get("key1")).isEmpty();
+  }
+
+  @Test
+  void invalidateAll_withEntries_clearsCache() {
+    cache.put("key1", "value1");
+    cache.put("key2", "value2");
+
+    cache.invalidateAll();
+
+    assertThat(cache.get("key1")).isEmpty();
+    assertThat(cache.get("key2")).isEmpty();
+  }
+
+  @Test
+  void size_withEntries_returnsCorrectCount() {
+    cache.put("key1", "value1");
+    cache.put("key2", "value2");
+
+    assertThat(cache.size()).isEqualTo(2);
+  }
+}

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheNoOpImplTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheNoOpImplTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.common.cache;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnalyticsCacheNoOpImplTest {
+
+  private AnalyticsCacheNoOpImpl<String, String> cache;
+
+  @BeforeEach
+  void setUp() {
+    cache = AnalyticsCacheNoOpImpl.getInstance();
+  }
+
+  @Test
+  void get_anyKey_alwaysReturnsEmpty() {
+    cache.put("key1", "value1");
+
+    assertThat(cache.get("key1")).isEmpty();
+  }
+
+  @Test
+  void get_withMappingFunction_anyKey_alwaysComputesButDoesNotCache() throws Exception {
+    AtomicInteger callCount = new AtomicInteger(0);
+
+    String value1 =
+        cache.get(
+            "key1",
+            k -> {
+              callCount.incrementAndGet();
+              return "val1";
+            });
+
+    String value2 =
+        cache.get(
+            "key1",
+            k -> {
+              callCount.incrementAndGet();
+              return "val1";
+            });
+
+    assertThat(value1).isEqualTo("val1");
+    assertThat(value2).isEqualTo("val1");
+    assertThat(callCount.get()).isEqualTo(2);
+    assertThat(cache.get("key1")).isEmpty();
+  }
+
+  @Test
+  void get_withMappingFunction_returnsNull_throwsException() {
+    assertThrows(NullPointerException.class, () -> cache.get("key1", k -> null));
+  }
+
+  @Test
+  void get_withMappingFunction_throwsCheckedException_rethrowsException() {
+    assertThrows(
+        IOException.class,
+        () ->
+            cache.get(
+                "key1",
+                k -> {
+                  throw new IOException("test-exception");
+                }));
+  }
+
+  @Test
+  void size_anyEntries_alwaysReturnsZero() {
+    cache.put("key1", "value1");
+
+    assertThat(cache.size()).isEqualTo(0);
+  }
+
+  @Test
+  void invalidate_anyKey_doesNothing() {
+    cache.put("key1", "value1");
+    cache.invalidate("key1");
+    cache.invalidateAll();
+
+    assertThat(cache.size()).isEqualTo(0);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!---
-Copyright 2025 Google LLC
+Copyright 2026 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ limitations under the License.
         <apache.hadoop.version>3.4.2</apache.hadoop.version>
         <slf4j.version>1.7.36</slf4j.version>
         <opentelemetry.version>1.52.0</opentelemetry.version>
+        <caffeine.version>3.1.8</caffeine.version>
     </properties>
 
     <profiles>
@@ -402,6 +403,11 @@ limitations under the License.
                 <scope>import</scope>
             </dependency>
 
+            <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>${caffeine.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
## Type of Change

- [x] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
- Define AnalyticsCache interface with atomic mapping support.
- Implement AnalyticsCacheCaffeineImpl using Caffeine 3.1.8.
- Add unit tests for CaffeineCache implementation including eviction and atomic compute.
- Update pom.xml and common/pom.xml with Caffeine dependencies.


### Why?
Introduces a thread-safe caching abstraction and its Caffeine-based implementation. This is Phase 1 of the Parquet footer caching plan.

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) [NA]
- [x] All files include the Apache License 2.0 header
- [ ] Documentation has been updated to reflect changes [NA]

---
*Generated/Assisted by Agent? [Yes/No]*

Yes, the code was written using gemini cli based on the design doc.