### PR TITLE
Add AnalyticsCacheManager and configure it's lifecycle for Parquet footer caching [2/4] 

### DIFF
--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/AnalyticsCacheManager.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/AnalyticsCacheManager.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.client;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.cloud.gcs.analyticscore.common.cache.AnalyticsCache;
+import com.google.cloud.gcs.analyticscore.common.cache.AnalyticsCacheCaffeineImpl;
+import com.google.cloud.gcs.analyticscore.common.cache.AnalyticsCacheNoOpImpl;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Manages the caching layer for GCS objects. This class is thread-safe and acts as a registry for
+ * various specialized caches (e.g., Parquet footer cache).
+ */
+public class AnalyticsCacheManager {
+
+  private final AnalyticsCache<GcsItemId, ByteBuffer> footerCache;
+
+  /**
+   * Creates a new {@link AnalyticsCacheManager} with the specified options.
+   *
+   * @param options The configuration options for the caching layer.
+   */
+  public AnalyticsCacheManager(GcsCacheOptions options) {
+    checkNotNull(options, "options cannot be null");
+    this.footerCache =
+        options.isFooterCacheEnabled()
+            ? AnalyticsCacheCaffeineImpl.create(options.getFooterCacheMaxEntries())
+            : AnalyticsCacheNoOpImpl.getInstance();
+  }
+
+  /**
+   * Returns the cached footer for the given {@code itemId}, obtaining it from the {@code
+   * footerLoader} if necessary. This method is atomic; the {@code footerLoader} will be applied at
+   * most once per itemId during concurrent access.
+   *
+   * <p>If the {@code footerLoader} throws an exception, it will be propagated to the caller and the
+   * result will not be cached.
+   *
+   * @throws IOException if the loader throws an {@link IOException}.
+   */
+  public ByteBuffer getFooter(GcsItemId itemId, FooterLoader footerLoader) throws IOException {
+    checkNotNull(itemId, "itemId cannot be null");
+    checkNotNull(footerLoader, "footerLoader cannot be null");
+
+    return footerCache
+        .get(itemId, cachedItemId -> footerLoader.load(cachedItemId))
+        .asReadOnlyBuffer();
+  }
+
+  /** Invalidates the cached footer for the given {@code itemId}. */
+  public void invalidateFooter(GcsItemId itemId) {
+    checkNotNull(itemId, "itemId cannot be null");
+    footerCache.invalidate(itemId);
+  }
+
+  /** Invalidates all cached entries. */
+  public void invalidateAll() {
+    footerCache.invalidateAll();
+  }
+
+  /** A loader for GCS object footers. */
+  @FunctionalInterface
+  public interface FooterLoader {
+    /** Loads the footer for the given {@code itemId}. */
+    ByteBuffer load(GcsItemId itemId) throws IOException;
+  }
+}

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsCacheOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsCacheOptions.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.client;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.value.AutoValue;
+import java.util.Map;
+
+/** Configuration options for the GCS caching layer. */
+@AutoValue
+public abstract class GcsCacheOptions {
+
+  private static final String FOOTER_CACHE_ENABLED_KEY = "analytics-core.footer.cache.enabled";
+  private static final String FOOTER_CACHE_MAX_ENTRIES_KEY =
+      "analytics-core.footer.cache.max-entries";
+
+  private static final boolean DEFAULT_FOOTER_CACHE_ENABLED = true;
+  private static final int DEFAULT_FOOTER_CACHE_MAX_ENTRIES = 100;
+
+  /** Returns whether the Parquet footer cache is enabled. */
+  public abstract boolean isFooterCacheEnabled();
+
+  /** Returns the maximum number of entries to hold in the Parquet footer cache. */
+  public abstract int getFooterCacheMaxEntries();
+
+  /**
+   * Returns a builder for {@link GcsCacheOptions} with the same property values as this instance.
+   */
+  public abstract Builder toBuilder();
+
+  /** Returns a new builder for {@link GcsCacheOptions} with default values. */
+  public static Builder builder() {
+    return new AutoValue_GcsCacheOptions.Builder()
+        .setFooterCacheEnabled(DEFAULT_FOOTER_CACHE_ENABLED)
+        .setFooterCacheMaxEntries(DEFAULT_FOOTER_CACHE_MAX_ENTRIES);
+  }
+
+  /** Creates a {@link GcsCacheOptions} instance from a map of configuration options. */
+  public static GcsCacheOptions createFromOptions(
+      Map<String, String> analyticsCoreOptions, String prefix) {
+    GcsCacheOptions.Builder optionsBuilder = builder();
+    if (analyticsCoreOptions.containsKey(prefix + FOOTER_CACHE_ENABLED_KEY)) {
+      optionsBuilder.setFooterCacheEnabled(
+          Boolean.parseBoolean(analyticsCoreOptions.get(prefix + FOOTER_CACHE_ENABLED_KEY)));
+    }
+    if (analyticsCoreOptions.containsKey(prefix + FOOTER_CACHE_MAX_ENTRIES_KEY)) {
+      optionsBuilder.setFooterCacheMaxEntries(
+          Integer.parseInt(analyticsCoreOptions.get(prefix + FOOTER_CACHE_MAX_ENTRIES_KEY)));
+    }
+    return optionsBuilder.build();
+  }
+
+  /** Builder for {@link GcsCacheOptions}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    /** Sets whether the Parquet footer cache is enabled. */
+    public abstract Builder setFooterCacheEnabled(boolean footerCacheEnabled);
+
+    /** Sets the maximum number of entries to hold in the Parquet footer cache. */
+    public abstract Builder setFooterCacheMaxEntries(int footerCacheMaxEntries);
+
+    abstract GcsCacheOptions autoBuild();
+
+    /**
+     * Builds the {@link GcsCacheOptions} instance.
+     *
+     * @throws IllegalArgumentException if {@code footerCacheMaxEntries} is non-positive when {@code
+     *     footerCacheEnabled} is {@code true}.
+     */
+    public GcsCacheOptions build() {
+      GcsCacheOptions options = autoBuild();
+      if (options.isFooterCacheEnabled()) {
+        checkArgument(
+            options.getFooterCacheMaxEntries() > 0,
+            "footerCacheMaxEntries must be positive when footerCacheEnabled is true");
+      }
+      return options;
+    }
+  }
+}

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystem.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystem.java
@@ -65,6 +65,9 @@ public interface GcsFileSystem extends AutoCloseable {
   /** Retrieve the telemetry instance used by this file system. */
   Telemetry getTelemetry();
 
+  /** Returns the cache manager used by this file system. */
+  AnalyticsCacheManager getCacheManager();
+
   /** Close the file system. */
   @Override
   void close();

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImpl.java
@@ -48,11 +48,13 @@ public class GcsFileSystemImpl implements GcsFileSystem {
   private final Supplier<ExecutorService> executorServiceSupplier;
 
   private final Telemetry telemetry;
+  private final AnalyticsCacheManager cacheManager;
 
   public GcsFileSystemImpl(GcsFileSystemOptions fileSystemOptions) {
     this.fileSystemOptions = fileSystemOptions;
     this.executorServiceSupplier = initializeExecutionServiceSupplier();
     this.telemetry = createTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions());
+    this.cacheManager = new AnalyticsCacheManager(fileSystemOptions.getGcsCacheOptions());
     this.gcsClient =
         telemetry.measure(
             GcsAnalyticsCoreTelemetryConstants.Operation.GCS_CLIENT_CREATE.name(),
@@ -67,6 +69,7 @@ public class GcsFileSystemImpl implements GcsFileSystem {
     this.fileSystemOptions = fileSystemOptions;
     this.executorServiceSupplier = initializeExecutionServiceSupplier();
     this.telemetry = createTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions());
+    this.cacheManager = new AnalyticsCacheManager(fileSystemOptions.getGcsCacheOptions());
     this.gcsClient =
         telemetry.measure(
             GcsAnalyticsCoreTelemetryConstants.Operation.GCS_CLIENT_CREATE.name(),
@@ -85,16 +88,21 @@ public class GcsFileSystemImpl implements GcsFileSystem {
     this(
         gcsClient,
         fileSystemOptions,
-        createTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions()));
+        createTelemetry(fileSystemOptions.getAnalyticsCoreTelemetryOptions()),
+        new AnalyticsCacheManager(fileSystemOptions.getGcsCacheOptions()));
   }
 
   @VisibleForTesting
   GcsFileSystemImpl(
-      GcsClient gcsClient, GcsFileSystemOptions fileSystemOptions, Telemetry telemetry) {
+      GcsClient gcsClient,
+      GcsFileSystemOptions fileSystemOptions,
+      Telemetry telemetry,
+      AnalyticsCacheManager cacheManager) {
     this.gcsClient = gcsClient;
     this.fileSystemOptions = fileSystemOptions;
     this.executorServiceSupplier = initializeExecutionServiceSupplier();
     this.telemetry = telemetry;
+    this.cacheManager = cacheManager;
   }
 
   @Override
@@ -147,6 +155,11 @@ public class GcsFileSystemImpl implements GcsFileSystem {
   @Override
   public Telemetry getTelemetry() {
     return telemetry;
+  }
+
+  @Override
+  public AnalyticsCacheManager getCacheManager() {
+    return cacheManager;
   }
 
   @Override

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptions.java
@@ -38,6 +38,9 @@ public abstract class GcsFileSystemOptions {
 
   public abstract GcsClientOptions getGcsClientOptions();
 
+  /** Returns the configuration options for the GCS caching layer. */
+  public abstract GcsCacheOptions getGcsCacheOptions();
+
   public abstract TelemetryOptions getAnalyticsCoreTelemetryOptions();
 
   public abstract Builder toBuilder();
@@ -47,6 +50,7 @@ public abstract class GcsFileSystemOptions {
         .setReadThreadCount(16)
         .setClientType(ClientType.HTTP_CLIENT)
         .setGcsClientOptions(GcsClientOptions.builder().build())
+        .setGcsCacheOptions(GcsCacheOptions.builder().build())
         .setAnalyticsCoreTelemetryOptions(TelemetryOptions.builder().build());
   }
 
@@ -63,6 +67,8 @@ public abstract class GcsFileSystemOptions {
     }
     optionsBuilder.setGcsClientOptions(
         GcsClientOptions.createFromOptions(analyticsCoreOptions, prefix));
+    optionsBuilder.setGcsCacheOptions(
+        GcsCacheOptions.createFromOptions(analyticsCoreOptions, prefix));
     // Analytics Core telemetry options are prefixed with "analytics-core."
     optionsBuilder.setAnalyticsCoreTelemetryOptions(
         TelemetryOptions.createFromOptions(analyticsCoreOptions, prefix + "analytics-core."));
@@ -79,6 +85,9 @@ public abstract class GcsFileSystemOptions {
     public abstract Builder setReadThreadCount(int readThreadCount);
 
     public abstract Builder setGcsClientOptions(GcsClientOptions gcsClientOptions);
+
+    /** Sets the configuration options for the GCS caching layer. */
+    public abstract Builder setGcsCacheOptions(GcsCacheOptions gcsCacheOptions);
 
     public abstract Builder setAnalyticsCoreTelemetryOptions(TelemetryOptions telemetryOptions);
 

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/AnalyticsCacheManagerTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/AnalyticsCacheManagerTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.client;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnalyticsCacheManagerTest {
+
+  private static final GcsItemId ITEM_ID =
+      GcsItemId.builder().setBucketName("b").setObjectName("o").build();
+  private static final ByteBuffer FOOTER = ByteBuffer.wrap(new byte[] {1, 2, 3});
+
+  private AnalyticsCacheManager manager;
+
+  @BeforeEach
+  void setUp() {
+    manager = new AnalyticsCacheManager(GcsCacheOptions.builder().build());
+  }
+
+  @Test
+  void getFooter_notPresent_computesAndCachesValue() throws IOException {
+    AtomicInteger callCount = new AtomicInteger(0);
+
+    ByteBuffer footer =
+        manager.getFooter(
+            ITEM_ID,
+            itemId -> {
+              callCount.incrementAndGet();
+              return FOOTER.duplicate();
+            });
+    ByteBuffer secondFooter =
+        manager.getFooter(
+            ITEM_ID,
+            itemId -> {
+              callCount.incrementAndGet();
+              return ByteBuffer.wrap(new byte[] {4, 5, 6});
+            });
+
+    assertThat(footer).isEqualTo(FOOTER);
+    assertThat(callCount.get()).isEqualTo(1);
+    assertThat(secondFooter).isEqualTo(FOOTER);
+    assertThat(secondFooter).isNotSameInstanceAs(FOOTER);
+    assertThat(secondFooter.isReadOnly()).isTrue();
+  }
+
+  @Test
+  void getFooter_loaderThrowsIOException_rethrowsIOException() {
+    assertThrows(
+        IOException.class,
+        () ->
+            manager.getFooter(
+                ITEM_ID,
+                itemId -> {
+                  throw new IOException("test-io-exception");
+                }));
+  }
+
+  @Test
+  void getFooter_cacheDisabled_anyKey_callsLoaderEveryTime() throws IOException {
+    manager =
+        new AnalyticsCacheManager(GcsCacheOptions.builder().setFooterCacheEnabled(false).build());
+    AtomicInteger callCount = new AtomicInteger(0);
+    AnalyticsCacheManager.FooterLoader loader =
+        itemId -> {
+          callCount.incrementAndGet();
+          return FOOTER.duplicate();
+        };
+
+    manager.getFooter(ITEM_ID, loader);
+    manager.getFooter(ITEM_ID, loader);
+
+    assertThat(callCount.get()).isEqualTo(2);
+  }
+
+  @Test
+  void invalidateFooter_cacheDisabled_anyKey_succeeds() {
+    manager =
+        new AnalyticsCacheManager(GcsCacheOptions.builder().setFooterCacheEnabled(false).build());
+
+    manager.invalidateFooter(ITEM_ID);
+  }
+
+  @Test
+  void invalidateAll_cacheDisabled_anyKey_succeeds() {
+    manager =
+        new AnalyticsCacheManager(GcsCacheOptions.builder().setFooterCacheEnabled(false).build());
+
+    manager.invalidateAll();
+  }
+
+  @Test
+  void invalidateFooter_present_removesEntry() throws IOException {
+    manager.getFooter(ITEM_ID, itemId -> FOOTER.duplicate());
+
+    manager.invalidateFooter(ITEM_ID);
+
+    AtomicInteger callCount = new AtomicInteger(0);
+    manager.getFooter(
+        ITEM_ID,
+        itemId -> {
+          callCount.incrementAndGet();
+          return FOOTER.duplicate();
+        });
+    assertThat(callCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  void invalidateAll_withEntries_clearsCache() throws IOException {
+    GcsItemId itemId2 = GcsItemId.builder().setBucketName("b").setObjectName("o2").build();
+    manager.getFooter(ITEM_ID, itemId -> FOOTER.duplicate());
+    manager.getFooter(itemId2, itemId -> ByteBuffer.wrap(new byte[] {2}));
+
+    manager.invalidateAll();
+
+    AtomicInteger callCount = new AtomicInteger(0);
+    manager.getFooter(
+        ITEM_ID,
+        itemId -> {
+          callCount.incrementAndGet();
+          return FOOTER.duplicate();
+        });
+    manager.getFooter(
+        itemId2,
+        itemId -> {
+          callCount.incrementAndGet();
+          return FOOTER.duplicate();
+        });
+    assertThat(callCount.get()).isEqualTo(2);
+  }
+}

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsCacheOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsCacheOptionsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.client;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class GcsCacheOptionsTest {
+
+  @Test
+  void build_defaultValues_succeeds() {
+    GcsCacheOptions options = GcsCacheOptions.builder().build();
+
+    assertThat(options.isFooterCacheEnabled()).isTrue();
+    assertThat(options.getFooterCacheMaxEntries()).isEqualTo(100);
+  }
+
+  @Test
+  void build_disabledCacheNonPositiveEntries_succeeds() {
+    GcsCacheOptions options =
+        GcsCacheOptions.builder().setFooterCacheEnabled(false).setFooterCacheMaxEntries(0).build();
+
+    assertThat(options.isFooterCacheEnabled()).isFalse();
+    assertThat(options.getFooterCacheMaxEntries()).isEqualTo(0);
+  }
+
+  @Test
+  void build_enabledCacheZeroEntries_throwsException() {
+    GcsCacheOptions.Builder builder =
+        GcsCacheOptions.builder().setFooterCacheEnabled(true).setFooterCacheMaxEntries(0);
+
+    assertThrows(IllegalArgumentException.class, builder::build);
+  }
+
+  @Test
+  void build_enabledCacheNegativeEntries_throwsException() {
+    GcsCacheOptions.Builder builder =
+        GcsCacheOptions.builder().setFooterCacheEnabled(true).setFooterCacheMaxEntries(-1);
+
+    assertThrows(IllegalArgumentException.class, builder::build);
+  }
+}

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
@@ -387,6 +387,11 @@ class GcsFileSystemImplTest {
   }
 
   @Test
+  void getCacheManager_default_returnsNonNullInstance() {
+    assertThat(gcsFileSystem.getCacheManager()).isNotNull();
+  }
+
+  @Test
   void initializeTelemetry_registerListenersToTelemetry() {
     OperationListener mockListener = mock(OperationListener.class);
     CustomTelemetryOptions customTelemetryOptions =

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptionsTest.java
@@ -39,6 +39,20 @@ class GcsFileSystemOptionsTest {
   }
 
   @Test
+  void createFromOptions_cacheProperties_createsCorrectOptions() {
+    ImmutableMap<String, String> properties =
+        ImmutableMap.of(
+            "fs.gs.analytics-core.footer.cache.enabled", "false",
+            "fs.gs.analytics-core.footer.cache.max-entries", "500");
+
+    GcsFileSystemOptions options = GcsFileSystemOptions.createFromOptions(properties, "fs.gs.");
+
+    GcsCacheOptions cacheOptions = options.getGcsCacheOptions();
+    assertThat(cacheOptions.isFooterCacheEnabled()).isFalse();
+    assertThat(cacheOptions.getFooterCacheMaxEntries()).isEqualTo(500);
+  }
+
+  @Test
   void createFromOptions_withDefaultProperties_shouldCreateCorrectOptions() {
     ImmutableMap<String, String> properties = ImmutableMap.of();
 
@@ -47,5 +61,9 @@ class GcsFileSystemOptionsTest {
     assertThat(options.getGcsClientOptions().getProjectId().isEmpty()).isTrue();
     assertThat(options.getClientType()).isEqualTo(GcsFileSystemOptions.ClientType.HTTP_CLIENT);
     assertThat(options.getReadThreadCount()).isEqualTo(16);
+
+    GcsCacheOptions cacheOptions = options.getGcsCacheOptions();
+    assertThat(cacheOptions.isFooterCacheEnabled()).isTrue();
+    assertThat(cacheOptions.getFooterCacheMaxEntries()).isEqualTo(100);
   }
 }

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImplTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImplTest.java
@@ -57,14 +57,11 @@ class AnalyticsCacheCaffeineImplTest {
               callCount.incrementAndGet();
               return "computed-" + keyToLoad;
             });
+    String secondValue = cache.get(key, keyToLoad -> "should-not-happen");
 
     assertThat(value).isEqualTo("computed-key1");
     assertThat(callCount.get()).isEqualTo(1);
-
-    String secondValue = cache.get(key, keyToLoad -> "should-not-happen");
-
     assertThat(secondValue).isEqualTo("computed-key1");
-    assertThat(callCount.get()).isEqualTo(1);
   }
 
   @Test

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheNoOpImplTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheNoOpImplTest.java
@@ -51,7 +51,6 @@ class AnalyticsCacheNoOpImplTest {
               callCount.incrementAndGet();
               return "val1";
             });
-
     String value2 =
         cache.get(
             "key1",
@@ -93,6 +92,7 @@ class AnalyticsCacheNoOpImplTest {
   @Test
   void invalidate_anyKey_doesNothing() {
     cache.put("key1", "value1");
+
     cache.invalidate("key1");
     cache.invalidateAll();
 

--- a/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/FakeGcsFileSystemImpl.java
+++ b/test-lib/src/main/java/com/google/cloud/gcs/analyticscore/client/FakeGcsFileSystemImpl.java
@@ -29,7 +29,11 @@ public class FakeGcsFileSystemImpl extends GcsFileSystemImpl {
   }
 
   private FakeGcsFileSystemImpl(GcsFileSystemOptions fileSystemOptions, Telemetry telemetry) {
-    super(initializeGcsClient(fileSystemOptions, telemetry), fileSystemOptions, telemetry);
+    super(
+        initializeGcsClient(fileSystemOptions, telemetry),
+        fileSystemOptions,
+        telemetry,
+        new AnalyticsCacheManager(fileSystemOptions.getGcsCacheOptions()));
   }
 
   private static GcsClient initializeGcsClient(GcsFileSystemOptions options, Telemetry telemetry) {


### PR DESCRIPTION
## Type of Change

- [ ] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
- Implement GcsCacheOptions for global caching configuration.
- Add footerCacheEnabled to GcsReadOptions for read-level control.
- Implement AnalyticsCacheManager as a registry for format-specific caches.
- Update GcsFileSystem and GcsFileSystemImpl to manage the AnalyticsCacheManager lifecycle.
- Update FakeGcsFileSystemImpl to support new constructor.
- Add unit tests for AnalyticsCacheManager.

### Why?
This is change 2 out of 4 for parquet footer cache.

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [x] All files include the Apache License 2.0 header
- [ ] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? [Yes/No]*
Gemini CLI was used to generate the initial code based on original design doc.
