### PR TITLE
fix: Update min-range-request size for random read to 128KiB.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -25,4 +25,4 @@ All configuration properties can be prefixed with a common string, e.g., `gcs.`.
 | `analytics-core.read.inplace-seek-limit-bytes`   | In-place seek limit (in bytes).                                                                             | 131072 (128 KB) |
 | `analytics-core.read.file-access-pattern`        | File access pattern. Supported values: `RANDOM`, `SEQUENTIAL`, `AUTO_SEQUENTIAL`, `AUTO_RANDOM`.               | `SEQUENTIAL`   |
 | `analytics-core.adaptive-read.sequential-read-threshold` | Threshold for number of sequential reads to switch to sequential mode.                                     | `3`            |
-| `analytics-core.random-read.min-request-size`              | Minimum request size for random reads. If the requested read size is smaller, it reads up to this size. | `0`            |
+| `analytics-core.random-read.min-request-size`              | Minimum request size for random reads. If the requested read size is smaller, it reads up to this size. | `131072 (128 KB)` |

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptions.java
@@ -41,15 +41,17 @@ public abstract class GcsReadOptions {
   private static final String RANDOM_READ_MIN_REQUEST_SIZE_KEY =
       "analytics-core.random-read.min-request-size";
 
+  private static final int KB = 1024;
+  private static final int MB = 1024 * KB;
+
   private static final boolean DEFAULT_FOOTER_PREFETCH_ENABLED = true;
-  private static final int DEFAULT_INPLACE_SEEK_LIMIT = 128 * 1024; // 128kb
-  private static final int DEFAULT_SMALL_FILE_FOOTER_PREFETCH_SIZE = 100 * 1024; // 100kb
-  private static final int DEFAULT_LARGE_FILE_FOOTER_PREFETCH_SIZE = 1024 * 1024; // 1mb
+  private static final int DEFAULT_INPLACE_SEEK_LIMIT = 128 * KB;
+  private static final int DEFAULT_SMALL_FILE_FOOTER_PREFETCH_SIZE = 100 * KB;
+  private static final int DEFAULT_LARGE_FILE_FOOTER_PREFETCH_SIZE = MB;
   private static final int DEFAULT_SMALL_FILE_CACHE_THRESHOLD = 0; // 0 bytes = disabled
   private static final FileAccessPattern DEFAULT_FILE_ACCESS_PATTERN = FileAccessPattern.SEQUENTIAL;
   private static final int DEFAULT_ADAPTIVE_READ_SEQUENTIAL_READ_THRESHOLD = 3;
-  // TODO: Validate and confirm the optimal min size post e2e benchmarking.
-  private static final int DEFAULT_RANDOM_READ_MIN_REQUEST_SIZE = 0;
+  private static final int DEFAULT_RANDOM_READ_MIN_REQUEST_SIZE = 128 * KB;
 
   public abstract Optional<Integer> getChunkSize();
 

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/AdaptiveReadStrategyTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/AdaptiveReadStrategyTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 
 class AdaptiveReadStrategyTest {
 
+  private static final int KB = 1024;
+
   private final Storage storage = LocalStorageHelper.getOptions().getService();
   private final GcsItemId itemId =
       GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
@@ -61,7 +63,7 @@ class AdaptiveReadStrategyTest {
 
     strategy.getReadChannel(200, 10);
 
-    assertThat(strategy.getLimit()).isEqualTo(210);
+    assertThat(strategy.getLimit()).isEqualTo(128 * KB + 200);
   }
 
   @Test
@@ -73,7 +75,7 @@ class AdaptiveReadStrategyTest {
 
     strategy.getReadChannel(40, 10);
 
-    assertThat(strategy.getLimit()).isEqualTo(50);
+    assertThat(strategy.getLimit()).isEqualTo(128 * KB + 40);
   }
 
   @Test
@@ -84,7 +86,7 @@ class AdaptiveReadStrategyTest {
 
     strategy.getReadChannel(210, 10);
 
-    assertThat(strategy.getLimit()).isEqualTo(220);
+    assertThat(strategy.getLimit()).isEqualTo(128 * KB + 200);
   }
 
   @Test
@@ -97,7 +99,7 @@ class AdaptiveReadStrategyTest {
         new AdaptiveReadStrategy(storage, itemId, randomOptions, itemInfo);
 
     strategy.getReadChannel(0, 10);
-    assertThat(strategy.getLimit()).isEqualTo(10);
+    assertThat(strategy.getLimit()).isEqualTo(128 * KB);
   }
 
   @Test
@@ -136,7 +138,7 @@ class AdaptiveReadStrategyTest {
 
     strategy.getReadChannel(0, 10);
 
-    assertThat(strategy.getLimit()).isEqualTo(10);
+    assertThat(strategy.getLimit()).isEqualTo(128 * KB);
   }
 
   @Test
@@ -154,7 +156,7 @@ class AdaptiveReadStrategyTest {
     strategy.getReadChannel(200, 10);
     strategy.getReadChannel(220, 10);
 
-    assertThat(strategy.getLimit()).isEqualTo(230);
+    assertThat(strategy.getLimit()).isEqualTo(128 * KB + 200);
   }
 
   @Test
@@ -199,7 +201,7 @@ class AdaptiveReadStrategyTest {
     strategy.position(410);
     strategy.getReadChannel(420, 10);
 
-    assertThat(strategy.getLimit()).isEqualTo(430);
+    assertThat(strategy.getLimit()).isEqualTo(128 * KB + 200);
   }
 
   @Test
@@ -220,7 +222,7 @@ class AdaptiveReadStrategyTest {
     strategy.position(30);
     strategy.getReadChannel(10, 10);
 
-    assertThat(strategy.getLimit()).isEqualTo(20);
+    assertThat(strategy.getLimit()).isEqualTo(128 * KB + 10);
 
     strategy.close();
   }
@@ -243,7 +245,7 @@ class AdaptiveReadStrategyTest {
     strategy.position(30);
     strategy.getReadChannel(150, 10);
 
-    assertThat(strategy.getLimit()).isEqualTo(160);
+    assertThat(strategy.getLimit()).isEqualTo(128 * KB);
 
     strategy.close();
   }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptionsTest.java
@@ -28,6 +28,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class GcsReadOptionsTest {
 
+  private static final int KB = 1024;
+  private static final int MB = 1024 * KB;
+
   @Test
   void createFromOptions_withAllProperties_shouldCreateCorrectOptions() {
     Map<String, String> properties =
@@ -85,15 +88,15 @@ class GcsReadOptionsTest {
     assertThat(readOptions.getDecryptionKey()).isEqualTo(Optional.empty());
     assertThat(readOptions.getUserProjectId()).isEqualTo(Optional.empty());
     assertThat(readOptions.isFooterPrefetchEnabled()).isEqualTo(true);
-    assertThat(readOptions.getFooterPrefetchSizeSmallFile()).isEqualTo(100 * 1024);
-    assertThat(readOptions.getFooterPrefetchSizeLargeFile()).isEqualTo(1024 * 1024);
+    assertThat(readOptions.getFooterPrefetchSizeSmallFile()).isEqualTo(100 * KB);
+    assertThat(readOptions.getFooterPrefetchSizeLargeFile()).isEqualTo(MB);
     assertThat(readOptions.getSmallObjectCacheSize()).isEqualTo(0);
-    assertThat(readOptions.getInplaceSeekLimit()).isEqualTo(128 * 1024);
+    assertThat(readOptions.getInplaceSeekLimit()).isEqualTo(128 * KB);
     assertThat(readOptions.getFileAccessPattern()).isEqualTo(FileAccessPattern.SEQUENTIAL);
     assertThat(readOptions.getAdaptiveReadSequentialReadThreshold()).isEqualTo(3);
-    assertThat(readOptions.getRandomReadMinRequestSize()).isEqualTo(0);
-    assertThat(vectoredReadOptions.getMaxMergeGap()).isEqualTo(4 * 1024);
-    assertThat(vectoredReadOptions.getMaxMergeSize()).isEqualTo(8 * 1024 * 1024);
+    assertThat(readOptions.getRandomReadMinRequestSize()).isEqualTo(128 * KB);
+    assertThat(vectoredReadOptions.getMaxMergeGap()).isEqualTo(4 * KB);
+    assertThat(vectoredReadOptions.getMaxMergeSize()).isEqualTo(8 * MB);
   }
 
   @ParameterizedTest

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/RandomReadStrategyTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/RandomReadStrategyTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 
 class RandomReadStrategyTest {
 
+  private static final int KB = 1024;
+
   private static final Storage storage = LocalStorageHelper.getOptions().getService();
   private static final GcsItemId itemId =
       GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
@@ -51,7 +53,7 @@ class RandomReadStrategyTest {
     strategy.getReadChannel(10, 20);
 
     TrackingReadChannel trackingChannel = strategy.getCreatedChannels().get(0);
-    assertThat(trackingChannel.getLastLimit()).isEqualTo(30L);
+    assertThat(trackingChannel.getLastLimit()).isEqualTo(128 * KB + 10);
     assertThat(trackingChannel.getLastChunkSize()).isEqualTo(0);
     assertThat(trackingChannel.getSeekCalls()).isEqualTo(1);
   }
@@ -86,18 +88,19 @@ class RandomReadStrategyTest {
     assertThat(strategy.getCreatedChannels()).hasSize(2);
     assertThat(trackingChannel.getCloseCalls()).isEqualTo(1);
     TrackingReadChannel trackingChannel2 = strategy.getCreatedChannels().get(1);
-    assertThat(trackingChannel2.getLastLimit()).isEqualTo(15L);
+    assertThat(trackingChannel2.getLastLimit()).isEqualTo(128 * KB + 10);
   }
 
   @Test
   void getReadChannel_channelOpen_notReusable_closesOldChannel() throws IOException {
-    StorageTestUtils.createBlobInStorage(storage, itemId, "a".repeat(1000));
+    StorageTestUtils.createBlobInStorage(storage, itemId, "a".repeat(150000));
+    GcsItemInfo localItemInfo = GcsItemInfo.builder().setItemId(itemId).setSize(150000L).build();
     FakeRandomReadStrategy strategy =
-        new FakeRandomReadStrategy(storage, itemId, options, itemInfo);
+        new FakeRandomReadStrategy(storage, itemId, options, localItemInfo);
     strategy.getReadChannel(0, 20);
     TrackingReadChannel trackingChannel = strategy.getCreatedChannels().get(0);
 
-    strategy.getReadChannel(40, 10);
+    strategy.getReadChannel(140000, 10);
 
     assertThat(strategy.getCreatedChannels()).hasSize(2);
     assertThat(trackingChannel.getCloseCalls()).isEqualTo(1);
@@ -105,27 +108,29 @@ class RandomReadStrategyTest {
 
   @Test
   void getReadChannel_recreatesChannel_whenPastLimit() throws IOException {
-    StorageTestUtils.createBlobInStorage(storage, itemId, "a".repeat(1000));
+    StorageTestUtils.createBlobInStorage(storage, itemId, "a".repeat(150000));
+    GcsItemInfo localItemInfo = GcsItemInfo.builder().setItemId(itemId).setSize(150000L).build();
     FakeRandomReadStrategy strategy =
-        new FakeRandomReadStrategy(storage, itemId, options, itemInfo);
+        new FakeRandomReadStrategy(storage, itemId, options, localItemInfo);
     strategy.getReadChannel(10, 20);
 
-    strategy.getReadChannel(40, 10);
+    strategy.getReadChannel(140000, 10);
 
     assertThat(strategy.getCreatedChannels()).hasSize(2);
     TrackingReadChannel trackingChannel2 = strategy.getCreatedChannels().get(1);
-    assertThat(trackingChannel2.getLastLimit()).isEqualTo(50L);
+    assertThat(trackingChannel2.getLastLimit()).isEqualTo(140000 + 128 * KB);
     assertThat(trackingChannel2.getSeekCalls()).isEqualTo(1);
   }
 
   @Test
   void getReadChannel_seekBeyondLimit_closesChannel() throws IOException {
-    StorageTestUtils.createBlobInStorage(storage, itemId, "a".repeat(100));
+    StorageTestUtils.createBlobInStorage(storage, itemId, "a".repeat(150000));
+    GcsItemInfo localItemInfo = GcsItemInfo.builder().setItemId(itemId).setSize(150000L).build();
     FakeRandomReadStrategy strategy =
-        new FakeRandomReadStrategy(storage, itemId, options, itemInfo);
+        new FakeRandomReadStrategy(storage, itemId, options, localItemInfo);
     strategy.getReadChannel(0, 10);
 
-    strategy.getReadChannel(20, 5);
+    strategy.getReadChannel(140000, 5);
 
     TrackingReadChannel trackingChannel = strategy.getCreatedChannels().get(0);
     assertThat(trackingChannel.getCloseCalls()).isEqualTo(1);
@@ -140,7 +145,7 @@ class RandomReadStrategyTest {
 
     long limit = strategy.getLimit();
 
-    assertThat(limit).isEqualTo(30);
+    assertThat(limit).isEqualTo(128 * KB + 10);
   }
 
   @Test
@@ -162,13 +167,14 @@ class RandomReadStrategyTest {
 
   @Test
   void getReadChannel_hitsLimit_opensNewChannel() throws IOException {
-    StorageTestUtils.createBlobInStorage(storage, itemId, "a".repeat(100));
+    StorageTestUtils.createBlobInStorage(storage, itemId, "a".repeat(150000));
+    GcsItemInfo localItemInfo = GcsItemInfo.builder().setItemId(itemId).setSize(150000L).build();
     FakeRandomReadStrategy strategy =
-        new FakeRandomReadStrategy(storage, itemId, options, itemInfo);
-    strategy.getReadChannel(0, 5);
-    strategy.position(5);
+        new FakeRandomReadStrategy(storage, itemId, options, localItemInfo);
+    strategy.getReadChannel(0, 128 * KB);
+    strategy.position(128 * KB);
 
-    strategy.getReadChannel(5, 5);
+    strategy.getReadChannel(128 * KB, 5);
 
     assertThat(strategy.getCreatedChannels()).hasSize(2);
     TrackingReadChannel trackingChannel1 = strategy.getCreatedChannels().get(0);

--- a/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeRandomReadStrategyTest.java
+++ b/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeRandomReadStrategyTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 
 class FakeRandomReadStrategyTest {
 
+  private static final int KB = 1024;
+
   private Storage storage;
   private FakeRandomReadStrategy strategy;
 
@@ -88,12 +90,12 @@ class FakeRandomReadStrategyTest {
     GcsItemId itemId =
         GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
     GcsReadOptions options = GcsReadOptions.builder().build();
-    GcsItemInfo itemInfo = GcsItemInfo.builder().setItemId(itemId).setSize(1000L).build();
-    StorageTestUtils.createBlobInStorage(storage, itemId, "A".repeat(1000));
+    GcsItemInfo itemInfo = GcsItemInfo.builder().setItemId(itemId).setSize(150000L).build();
+    StorageTestUtils.createBlobInStorage(storage, itemId, "A".repeat(150000));
     strategy = new FakeRandomReadStrategy(storage, itemId, options, itemInfo);
-    strategy.getReadChannel(0, 10);
+    strategy.getReadChannel(0, 128 * KB);
 
-    strategy.getReadChannel(5, 6);
+    strategy.getReadChannel(128 * KB, 6);
 
     assertEquals(2, strategy.getCreatedChannels().size());
   }


### PR DESCRIPTION
## Type of Change

- [ ] `feat`: A new feature
- [x] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
Updating min-range-request size default value as 128KiB

### Why?
In e2e benchmarking TPCDS queries, with 128KiB we have seen a better performance improvement compared to 0, 1MiB and 8MiB

<img width="2831" height="367" alt="image" src="https://github.com/user-attachments/assets/61074f99-d219-4097-b568-89525a3837f2" />


## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [x] All files include the Apache License 2.0 header
- [x] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? [Yes/No]*
