### PR TITLE
Configure dependabot to club version upgrade PRs into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,25 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: maven
     directory: /
     schedule:
       interval: daily
+    groups:
+      maven-dependencies:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "com.google.errorprone:error_prone_core"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # Hadoop 3.5+ requires Java 17; keep at 3.4.x for Java 11 compatibility
       - dependency-name: "org.apache.hadoop:*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Spotless plugin updates cause compatibility errors with Java 11
+      - dependency-name: "com.diffplug.spotless:spotless-maven-plugin"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Type of Change

- [ ] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [x] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
Configure dependabot to group version upgrade PRs into single PR.

### Why?
Huge number of version bump PRs are piling up.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [x] All files include the Apache License 2.0 header
- [x] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? [Yes/No]*
Yes