### PR TITLE
fix : Remove READ_OFFSET and READ_LENGTH from metric attributes.

### DIFF
--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/GcsAnalyticsCoreTelemetryConstants.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/GcsAnalyticsCoreTelemetryConstants.java
@@ -17,9 +17,7 @@ package com.google.cloud.gcs.analyticscore.common;
 
 public class GcsAnalyticsCoreTelemetryConstants {
   public enum Attribute {
-    CLASS_NAME,
-    READ_LENGTH,
-    READ_OFFSET;
+    CLASS_NAME
   }
 
   public enum Metric implements com.google.cloud.gcs.analyticscore.common.telemetry.Metric {

--- a/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
+++ b/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
@@ -177,7 +177,7 @@ class GoogleCloudStorageInputStreamIntegrationTest {
       strings = {
         IntegrationTestHelper.TPCDS_CUSTOMER_SMALL_FILE,
       })
-  void read_capturesTelemetryAttributes_withCorrectReadLength(String fileName) throws IOException {
+  void read_capturesTelemetryAttributes(String fileName) throws IOException {
     AtomicReference<Map<MetricKey, Long>> capturedReadMetrics = new AtomicReference<>();
     AtomicReference<Operation> capturedReadOperation = new AtomicReference<>();
     OperationListener listener =
@@ -229,6 +229,6 @@ class GoogleCloudStorageInputStreamIntegrationTest {
             .findFirst()
             .get();
     assertThat(capturedReadMetrics.get().get(bytesReadKey)).isEqualTo(5L);
-    assertThat(capturedReadOperation.get().getAttributes().get("READ_LENGTH")).isEqualTo("5");
+
   }
 }

--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
@@ -29,7 +29,6 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.function.IntFunction;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -135,18 +134,12 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
 
   @Override
   public int read(ByteBuffer byteBuffer) throws IOException {
-    Map<String, String> telemetryAttributes =
-        ImmutableMap.<String, String>builder()
-            .putAll(commonAttributes)
-            .put(Attribute.READ_LENGTH.name(), String.valueOf(byteBuffer.remaining()))
-            .put(Attribute.READ_OFFSET.name(), String.valueOf(byteBuffer.position()))
-            .build();
     return gcsFileSystem
         .getTelemetry()
         .measure(
             Operation.READ.name(),
             Metric.READ_DURATION,
-            telemetryAttributes,
+            commonAttributes,
             recorder -> {
               checkNotClosed("Cannot read: already closed");
               if (isMetadataInitialized()


### PR DESCRIPTION
## Type of Change

- [ ] `feat`: A new feature
- [x] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
Remove READ_OFFSET and READ_LENGTH from attributes.

### Why?
These should be part of tracing, not metric attributes. Adding to metrics will cause fan out when exporting to cloud monitoring.
## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [x] All files include the Apache License 2.0 header
- [x] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? [Yes/No]* Yes