### PR TITLE
feat(client): Add fast-fail option when opening read channels - Part 1

### DIFF
--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -30,6 +30,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -92,6 +93,10 @@ class GcsClientImpl implements GcsClient {
       GcsItemId gcsItemId, GcsReadOptions readOptions) throws IOException {
     checkNotNull(gcsItemId, "gcsItemId should not be null");
     checkNotNull(readOptions, "readOptions should not be null");
+    if (readOptions.isFastFailEnabled()) {
+      GcsItemInfo itemInfo = getGcsItemInfo(gcsItemId);
+      return openReadChannel(itemInfo, readOptions);
+    }
     return new GcsReadChannel(storage, gcsItemId, readOptions, executorServiceSupplier, telemetry) {
       @Override
       public long size() throws IOException {
@@ -151,7 +156,7 @@ class GcsClientImpl implements GcsClient {
     checkArgument(itemId.isGcsObject(), String.format("Expected gcs object got %s", itemId));
     Blob blob = getBlob(itemId.getBucketName(), itemId.getObjectName().get());
     if (blob == null) {
-      throw new IOException("Object not found:" + itemId);
+      throw new FileNotFoundException("Object not found:" + itemId);
     }
     GcsItemId itemIdWithGeneration =
         GcsItemId.builder()

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptions.java
@@ -40,6 +40,7 @@ public abstract class GcsReadOptions {
       "analytics-core.adaptive-read.sequential-read-threshold";
   private static final String RANDOM_READ_MIN_REQUEST_SIZE_KEY =
       "analytics-core.random-read.min-request-size";
+  private static final String FAST_FAIL_ENABLED_KEY = "analytics-core.fast.fail.enabled";
 
   private static final int KB = 1024;
   private static final int MB = 1024 * KB;
@@ -53,6 +54,7 @@ public abstract class GcsReadOptions {
       FileAccessPattern.AUTO_SEQUENTIAL;
   private static final int DEFAULT_ADAPTIVE_READ_SEQUENTIAL_READ_THRESHOLD = 3;
   private static final int DEFAULT_RANDOM_READ_MIN_REQUEST_SIZE = 128 * KB;
+  private static final boolean DEFAULT_FAST_FAIL_ENABLED = false;
 
   public abstract Optional<Integer> getChunkSize();
 
@@ -80,6 +82,8 @@ public abstract class GcsReadOptions {
 
   public abstract int getRandomReadMinRequestSize();
 
+  public abstract boolean isFastFailEnabled();
+
   public static Builder builder() {
     return new AutoValue_GcsReadOptions.Builder()
         .setGcsVectoredReadOptions(GcsVectoredReadOptions.builder().build())
@@ -90,7 +94,8 @@ public abstract class GcsReadOptions {
         .setInplaceSeekLimit(DEFAULT_INPLACE_SEEK_LIMIT)
         .setFileAccessPattern(DEFAULT_FILE_ACCESS_PATTERN)
         .setAdaptiveReadSequentialReadThreshold(DEFAULT_ADAPTIVE_READ_SEQUENTIAL_READ_THRESHOLD)
-        .setRandomReadMinRequestSize(DEFAULT_RANDOM_READ_MIN_REQUEST_SIZE);
+        .setRandomReadMinRequestSize(DEFAULT_RANDOM_READ_MIN_REQUEST_SIZE)
+        .setFastFailEnabled(DEFAULT_FAST_FAIL_ENABLED);
   }
 
   public static GcsReadOptions createFromOptions(
@@ -140,6 +145,10 @@ public abstract class GcsReadOptions {
       optionsBuilder.setRandomReadMinRequestSize(
           safeParseInteger(analyticsCoreOptions, prefix + RANDOM_READ_MIN_REQUEST_SIZE_KEY));
     }
+    if (analyticsCoreOptions.containsKey(prefix + FAST_FAIL_ENABLED_KEY)) {
+      optionsBuilder.setFastFailEnabled(
+          Boolean.parseBoolean(analyticsCoreOptions.get(prefix + FAST_FAIL_ENABLED_KEY)));
+    }
 
     optionsBuilder.setGcsVectoredReadOptions(
         GcsVectoredReadOptions.createFromOptions(analyticsCoreOptions, prefix));
@@ -185,6 +194,8 @@ public abstract class GcsReadOptions {
     public abstract Builder setAdaptiveReadSequentialReadThreshold(int threshold);
 
     public abstract Builder setRandomReadMinRequestSize(int minRequestSize);
+
+    public abstract Builder setFastFailEnabled(boolean fastFailEnabled);
 
     public abstract GcsReadOptions build();
   }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -27,6 +27,7 @@ import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
@@ -242,5 +243,45 @@ class GcsClientImplTest {
             executorServiceSupplier,
             telemetry);
     assertThat(client.storage.getOptions().getCredentials()).isEqualTo(NoCredentials.getInstance());
+  }
+
+  @Test
+  void openReadChannel_fastFailEnabled_blobNotFound_throwsFileNotFoundException() {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket-id").setObjectName("non-existent").build();
+    GcsReadOptions readOptions = GcsReadOptions.builder().setFastFailEnabled(true).build();
+
+    FileNotFoundException e =
+        assertThrows(
+            FileNotFoundException.class, () -> gcsClient.openReadChannel(itemId, readOptions));
+
+    assertThat(e).hasMessageThat().contains("Object not found:" + itemId);
+  }
+
+  @Test
+  void openReadChannel_fastFailEnabled_blobFound_succeedsAndLoadsMetadata() throws IOException {
+    String objectData = "hello world";
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket-id").setObjectName("test-object-id").build();
+    StorageTestUtils.createBlobInStorage(
+        storage, BlobId.of(itemId.getBucketName(), itemId.getObjectName().get(), 0L), objectData);
+    GcsReadOptions readOptions = GcsReadOptions.builder().setFastFailEnabled(true).build();
+
+    SeekableByteChannel channel = gcsClient.openReadChannel(itemId, readOptions);
+
+    assertThat(channel.size()).isEqualTo(objectData.length());
+  }
+
+  @Test
+  void openReadChannel_fastFailDisabled_doesNotQueryGcs() throws IOException {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName("test-bucket-id").setObjectName("non-existent").build();
+    GcsReadOptions readOptions = GcsReadOptions.builder().setFastFailEnabled(false).build();
+
+    // Since fast fail is disabled, opening the channel should succeed immediately even if the
+    // blob does not exist in storage.
+    SeekableByteChannel channel = gcsClient.openReadChannel(itemId, readOptions);
+
+    assertThat(channel).isNotNull();
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptionsTest.java
@@ -65,13 +65,16 @@ class GcsReadOptionsTest {
     assertThat(readOptions.getFileAccessPattern()).isEqualTo(FileAccessPattern.RANDOM);
     assertThat(readOptions.getAdaptiveReadSequentialReadThreshold()).isEqualTo(5);
     assertThat(readOptions.getRandomReadMinRequestSize()).isEqualTo(65536);
+    assertThat(readOptions.isFastFailEnabled()).isEqualTo(false);
     properties =
         ImmutableMap.<String, String>builder()
             .put("gcs.analytics-core.read.file-access-pattern", "auto_sequential")
+            .put("gcs.analytics-core.fast.fail.enabled", "true")
             .build();
     readOptions = GcsReadOptions.createFromOptions(properties, prefix);
 
     assertThat(readOptions.getFileAccessPattern()).isEqualTo(FileAccessPattern.AUTO_SEQUENTIAL);
+    assertThat(readOptions.isFastFailEnabled()).isEqualTo(true);
     assertThat(vectoredReadOptions.getMaxMergeGap()).isEqualTo(1024);
     assertThat(vectoredReadOptions.getMaxMergeSize()).isEqualTo(2048);
   }
@@ -95,6 +98,7 @@ class GcsReadOptionsTest {
     assertThat(readOptions.getFileAccessPattern()).isEqualTo(FileAccessPattern.AUTO_SEQUENTIAL);
     assertThat(readOptions.getAdaptiveReadSequentialReadThreshold()).isEqualTo(3);
     assertThat(readOptions.getRandomReadMinRequestSize()).isEqualTo(128 * KB);
+    assertThat(readOptions.isFastFailEnabled()).isEqualTo(false);
     assertThat(vectoredReadOptions.getMaxMergeGap()).isEqualTo(4 * KB);
     assertThat(vectoredReadOptions.getMaxMergeSize()).isEqualTo(8 * MB);
   }


### PR DESCRIPTION
## Type of Change

- [x] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
* Added `analytics-core.fast.fail.enabled` config option in [GcsReadOptions](file:///Users/singhaniash/Code/gcs-analytics-core-fork/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptions.java#L43) (default: `false`).
* Updated `GcsClientImpl.openReadChannel` to verify object existence upfront and throw `FileNotFoundException` if missing.
* Added unit tests in [GcsClientImplTest](file:///Users/singhaniash/Code/gcs-analytics-core-fork/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java#L248) and [GcsReadOptionsTest](file:///Users/singhaniash/Code/gcs-analytics-core-fork/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptionsTest.java#L68).

### Why?
By default, read channels fail lazily upon the first read. Enabling fast-fail allows consumers to validate object existence immediately during channel initialization, providing fail-fast behavior when files are missing.
## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [x] All files include the Apache License 2.0 header
- [ ] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? [Yes/No]*
