### PR TITLE
chore: Configure JDK compiler exports to fix Java 17 compile issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,18 @@ limitations under the License.
                             <compilerArgs>
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>-Xplugin:ErrorProne</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                             </compilerArgs>
+                            <fork>true</fork>
                             <annotationProcessorPaths>
                                 <path>
                                     <groupId>com.google.errorprone</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -510,7 +510,18 @@ limitations under the License.
                         <compilerArgs>
                             <arg>-XDcompilePolicy=simple</arg>
                             <arg>-Xplugin:ErrorProne</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                         </compilerArgs>
+                        <fork>true</fork>
                         <annotationProcessorPaths>
                             <path>
                                 <groupId>com.google.errorprone</groupId>


### PR DESCRIPTION
## Type of Change

- [ ] `feat`: A new feature
- [x] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [x] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
- Updated the `maven-compiler-plugin` configuration in parent `pom.xml` under `pluginManagement`.
- Enabled `<fork>true</fork>` for compilation executions.
- Added required `-J--add-exports` and `-J--add-opens` JVM flags for `jdk.compiler` modules to `<compilerArgs>`.

### Why?
- When building with JDK 17 (and JDK 16+), compilation fails with `java.lang.IllegalAccessError` because internal Java compiler APIs in `jdk.compiler` are strongly encapsulated by default (JEP 403).
- The Error Prone static analysis plugin requires access to these internal `javac` APIs (`com.sun.tools.javac.*`) to inspect the AST.
- Enabling `<fork>true</fork>` spawns a separate `javac` JVM process, allowing the `-J` flags to successfully export and open the required `jdk.compiler` packages to Error Prone during build execution.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [x] All files include the Apache License 2.0 header
- [ ] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? [Yes/No]* - Yes
