### PR TITLE
refactor: Expose parquet footer cache size on place of number of entries as config flag.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -29,7 +29,7 @@ These settings control how aggressively the library prefetches and caches metada
 | `analytics-core.small-file.footer.prefetch.size-bytes` | Footer prefetch size (in bytes) for files up to 1 GB. | 51200 (50 KB) |
 | `analytics-core.large-file.footer.prefetch.size-bytes` | Footer prefetch size (in bytes) for files larger than 1 GB. | 1048576 (1 MB) |
 | `analytics-core.footer.cache.enabled` | Controls whether the Parquet footer cache is enabled. | `true` |
-| `analytics-core.footer.cache.max-entries` | The maximum number of entries to hold in the Parquet footer cache. | `100` |
+| `analytics-core.footer.cache.max-size-bytes`                 | The maximum capacity (in bytes) to hold in the Parquet footer cache.                        | `104857600` (100 MB) |
 | `analytics-core.small-file.cache.threshold-bytes` | Threshold (in bytes) below which small files are cached entirely. | 1048576 (1 MB) |
 
 ### Read Performance and I/O Tuning

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/AnalyticsCacheManager.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/AnalyticsCacheManager.java
@@ -18,6 +18,7 @@ package com.google.cloud.gcs.analyticscore.client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.github.benmanes.caffeine.cache.Weigher;
 import com.google.cloud.gcs.analyticscore.common.cache.AnalyticsCache;
 import com.google.cloud.gcs.analyticscore.common.cache.AnalyticsCacheCaffeineImpl;
 import com.google.cloud.gcs.analyticscore.common.cache.AnalyticsCacheNoOpImpl;
@@ -39,9 +40,10 @@ public class AnalyticsCacheManager {
    */
   public AnalyticsCacheManager(GcsCacheOptions options) {
     checkNotNull(options, "options cannot be null");
+    Weigher<GcsItemId, ByteBuffer> weigher = (key, value) -> value.remaining();
     this.footerCache =
         options.isFooterCacheEnabled()
-            ? AnalyticsCacheCaffeineImpl.create(options.getFooterCacheMaxEntries())
+            ? AnalyticsCacheCaffeineImpl.create(options.getFooterCacheMaxSizeBytes(), weigher)
             : AnalyticsCacheNoOpImpl.getInstance();
   }
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsCacheOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsCacheOptions.java
@@ -26,17 +26,20 @@ import java.util.Map;
 public abstract class GcsCacheOptions {
 
   private static final String FOOTER_CACHE_ENABLED_KEY = "analytics-core.footer.cache.enabled";
-  private static final String FOOTER_CACHE_MAX_ENTRIES_KEY =
-      "analytics-core.footer.cache.max-entries";
+  private static final String FOOTER_CACHE_MAX_SIZE_BYTES_KEY =
+      "analytics-core.footer.cache.max-size-bytes";
+
+  private static final long KB = 1024L;
+  private static final long MB = 1024L * KB;
 
   private static final boolean DEFAULT_FOOTER_CACHE_ENABLED = true;
-  private static final int DEFAULT_FOOTER_CACHE_MAX_ENTRIES = 100;
+  private static final long DEFAULT_FOOTER_CACHE_MAX_SIZE_BYTES = 100 * MB;
 
   /** Returns whether the Parquet footer cache is enabled. */
   public abstract boolean isFooterCacheEnabled();
 
-  /** Returns the maximum number of entries to hold in the Parquet footer cache. */
-  public abstract int getFooterCacheMaxEntries();
+  /** Returns the maximum capacity (in bytes) to hold in the Parquet footer cache. */
+  public abstract long getFooterCacheMaxSizeBytes();
 
   /**
    * Returns a builder for {@link GcsCacheOptions} with the same property values as this instance.
@@ -47,7 +50,7 @@ public abstract class GcsCacheOptions {
   public static Builder builder() {
     return new AutoValue_GcsCacheOptions.Builder()
         .setFooterCacheEnabled(DEFAULT_FOOTER_CACHE_ENABLED)
-        .setFooterCacheMaxEntries(DEFAULT_FOOTER_CACHE_MAX_ENTRIES);
+        .setFooterCacheMaxSizeBytes(DEFAULT_FOOTER_CACHE_MAX_SIZE_BYTES);
   }
 
   /** Creates a {@link GcsCacheOptions} instance from a map of configuration options. */
@@ -58,9 +61,9 @@ public abstract class GcsCacheOptions {
       optionsBuilder.setFooterCacheEnabled(
           Boolean.parseBoolean(analyticsCoreOptions.get(prefix + FOOTER_CACHE_ENABLED_KEY)));
     }
-    if (analyticsCoreOptions.containsKey(prefix + FOOTER_CACHE_MAX_ENTRIES_KEY)) {
-      optionsBuilder.setFooterCacheMaxEntries(
-          Integer.parseInt(analyticsCoreOptions.get(prefix + FOOTER_CACHE_MAX_ENTRIES_KEY)));
+    if (analyticsCoreOptions.containsKey(prefix + FOOTER_CACHE_MAX_SIZE_BYTES_KEY)) {
+      optionsBuilder.setFooterCacheMaxSizeBytes(
+          Long.parseLong(analyticsCoreOptions.get(prefix + FOOTER_CACHE_MAX_SIZE_BYTES_KEY)));
     }
     return optionsBuilder.build();
   }
@@ -71,23 +74,23 @@ public abstract class GcsCacheOptions {
     /** Sets whether the Parquet footer cache is enabled. */
     public abstract Builder setFooterCacheEnabled(boolean footerCacheEnabled);
 
-    /** Sets the maximum number of entries to hold in the Parquet footer cache. */
-    public abstract Builder setFooterCacheMaxEntries(int footerCacheMaxEntries);
+    /** Sets the maximum capacity (in bytes) to hold in the Parquet footer cache. */
+    public abstract Builder setFooterCacheMaxSizeBytes(long footerCacheMaxSizeBytes);
 
     abstract GcsCacheOptions autoBuild();
 
     /**
      * Builds the {@link GcsCacheOptions} instance.
      *
-     * @throws IllegalArgumentException if {@code footerCacheMaxEntries} is non-positive when {@code
-     *     footerCacheEnabled} is {@code true}.
+     * @throws IllegalArgumentException if {@code footerCacheMaxSizeBytes} is non-positive when
+     *     {@code footerCacheEnabled} is {@code true}.
      */
     public GcsCacheOptions build() {
       GcsCacheOptions options = autoBuild();
       if (options.isFooterCacheEnabled()) {
         checkArgument(
-            options.getFooterCacheMaxEntries() > 0,
-            "footerCacheMaxEntries must be positive when footerCacheEnabled is true");
+            options.getFooterCacheMaxSizeBytes() > 0,
+            "footerCacheMaxSizeBytes must be positive when footerCacheEnabled is true");
       }
       return options;
     }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsCacheOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsCacheOptionsTest.java
@@ -23,35 +23,41 @@ import org.junit.jupiter.api.Test;
 
 class GcsCacheOptionsTest {
 
+  private static final long KB = 1024L;
+  private static final long MB = 1024L * KB;
+
   @Test
   void build_defaultValues_succeeds() {
     GcsCacheOptions options = GcsCacheOptions.builder().build();
 
     assertThat(options.isFooterCacheEnabled()).isTrue();
-    assertThat(options.getFooterCacheMaxEntries()).isEqualTo(100);
+    assertThat(options.getFooterCacheMaxSizeBytes()).isEqualTo(100 * MB);
   }
 
   @Test
-  void build_disabledCacheNonPositiveEntries_succeeds() {
+  void build_disabledCacheNonPositiveSizeBytes_succeeds() {
     GcsCacheOptions options =
-        GcsCacheOptions.builder().setFooterCacheEnabled(false).setFooterCacheMaxEntries(0).build();
+        GcsCacheOptions.builder()
+            .setFooterCacheEnabled(false)
+            .setFooterCacheMaxSizeBytes(0)
+            .build();
 
     assertThat(options.isFooterCacheEnabled()).isFalse();
-    assertThat(options.getFooterCacheMaxEntries()).isEqualTo(0);
+    assertThat(options.getFooterCacheMaxSizeBytes()).isEqualTo(0);
   }
 
   @Test
-  void build_enabledCacheZeroEntries_throwsException() {
+  void build_enabledCacheZeroSizeBytes_throwsException() {
     GcsCacheOptions.Builder builder =
-        GcsCacheOptions.builder().setFooterCacheEnabled(true).setFooterCacheMaxEntries(0);
+        GcsCacheOptions.builder().setFooterCacheEnabled(true).setFooterCacheMaxSizeBytes(0);
 
     assertThrows(IllegalArgumentException.class, builder::build);
   }
 
   @Test
-  void build_enabledCacheNegativeEntries_throwsException() {
+  void build_enabledCacheNegativeSizeBytes_throwsException() {
     GcsCacheOptions.Builder builder =
-        GcsCacheOptions.builder().setFooterCacheEnabled(true).setFooterCacheMaxEntries(-1);
+        GcsCacheOptions.builder().setFooterCacheEnabled(true).setFooterCacheMaxSizeBytes(-1);
 
     assertThrows(IllegalArgumentException.class, builder::build);
   }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptionsTest.java
@@ -23,6 +23,9 @@ import org.junit.jupiter.api.Test;
 
 class GcsFileSystemOptionsTest {
 
+  private static final long KB = 1024L;
+  private static final long MB = 1024L * KB;
+
   @Test
   void createFromOptions_withValidProperties_shouldCreateCorrectOptions() {
     ImmutableMap<String, String> properties =
@@ -42,14 +45,16 @@ class GcsFileSystemOptionsTest {
   void createFromOptions_cacheProperties_createsCorrectOptions() {
     ImmutableMap<String, String> properties =
         ImmutableMap.of(
-            "fs.gs.analytics-core.footer.cache.enabled", "false",
-            "fs.gs.analytics-core.footer.cache.max-entries", "500");
+            "fs.gs.analytics-core.footer.cache.enabled",
+            "false",
+            "fs.gs.analytics-core.footer.cache.max-size-bytes",
+            String.valueOf(500 * MB));
 
     GcsFileSystemOptions options = GcsFileSystemOptions.createFromOptions(properties, "fs.gs.");
 
     GcsCacheOptions cacheOptions = options.getGcsCacheOptions();
     assertThat(cacheOptions.isFooterCacheEnabled()).isFalse();
-    assertThat(cacheOptions.getFooterCacheMaxEntries()).isEqualTo(500);
+    assertThat(cacheOptions.getFooterCacheMaxSizeBytes()).isEqualTo(500 * MB);
   }
 
   @Test
@@ -64,6 +69,6 @@ class GcsFileSystemOptionsTest {
 
     GcsCacheOptions cacheOptions = options.getGcsCacheOptions();
     assertThat(cacheOptions.isFooterCacheEnabled()).isTrue();
-    assertThat(cacheOptions.getFooterCacheMaxEntries()).isEqualTo(100);
+    assertThat(cacheOptions.getFooterCacheMaxSizeBytes()).isEqualTo(100 * MB);
   }
 }

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImpl.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImpl.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Weigher;
 import java.util.Optional;
 
 /**
@@ -34,16 +35,17 @@ public class AnalyticsCacheCaffeineImpl<K, V> implements AnalyticsCache<K, V> {
 
   private final Cache<K, V> cache;
 
-  private AnalyticsCacheCaffeineImpl(long maxEntries) {
-    checkArgument(maxEntries > 0, "maxEntries must be positive");
-    this.cache = Caffeine.newBuilder().maximumSize(maxEntries).build();
+  private AnalyticsCacheCaffeineImpl(long maxWeight, Weigher<K, V> weigher) {
+    checkArgument(maxWeight > 0, "maxWeight must be positive");
+    this.cache = Caffeine.newBuilder().maximumWeight(maxWeight).weigher(weigher).build();
   }
 
   /**
-   * Creates a new {@link AnalyticsCacheCaffeineImpl} with the specified maximum number of entries.
+   * Creates a new {@link AnalyticsCacheCaffeineImpl} with the specified maximum weight and weigher.
    */
-  public static <K, V> AnalyticsCacheCaffeineImpl<K, V> create(long maxEntries) {
-    return new AnalyticsCacheCaffeineImpl<>(maxEntries);
+  public static <K, V> AnalyticsCacheCaffeineImpl<K, V> create(
+      long maxWeight, Weigher<K, V> weigher) {
+    return new AnalyticsCacheCaffeineImpl<>(maxWeight, weigher);
   }
 
   /** {@inheritDoc} */

--- a/common/src/test/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImplTest.java
+++ b/common/src/test/java/com/google/cloud/gcs/analyticscore/common/cache/AnalyticsCacheCaffeineImplTest.java
@@ -30,7 +30,7 @@ class AnalyticsCacheCaffeineImplTest {
 
   @BeforeEach
   void setUp() {
-    cache = AnalyticsCacheCaffeineImpl.create(10);
+    cache = AnalyticsCacheCaffeineImpl.create(10, (key, value) -> 1);
   }
 
   @Test

--- a/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
+++ b/core/src/integrationTest/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStreamIntegrationTest.java
@@ -180,7 +180,7 @@ class GoogleCloudStorageInputStreamIntegrationTest {
   void forSampleParquetFiles_footerCacheEnabled_readsFileSuccessfully(String fileName) {
     GcsFileSystemOptions gcsFileSystemOptions = GcsFileSystemOptions.createFromOptions(
             Map.of("gcs.analytics-core.footer.cache.enabled", "true",
-                   "gcs.analytics-core.footer.cache.max-entries", "500"), "gcs.");
+                   "gcs.analytics-core.footer.cache.max-size-bytes", "52428800"), "gcs.");
     URI uri = IntegrationTestHelper.getGcsObjectUriForFile(fileName);
     ParquetHelper.readParquetObjectRecords(uri, /* readVectoredEnabled= */ true, gcsFileSystemOptions);
   }


### PR DESCRIPTION
## Type of Change

- [ ] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [x] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
Expose parquet footer cache size on place of number of entries as config flag

### Why?
Configuring cache size is more predictable setting than number of items in cache. 

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [x] All files include the Apache License 2.0 header
- [x] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? [Yes/No]* Yes
