### PR TITLE
fix: post-submit failures in ParquetRecordReadBenchmark.java

### DIFF
--- a/core/src/jmh/java/com/google/cloud/gcs/analyticscore/core/ParquetRecordReadBenchmark.java
+++ b/core/src/jmh/java/com/google/cloud/gcs/analyticscore/core/ParquetRecordReadBenchmark.java
@@ -43,7 +43,7 @@ public class ParquetRecordReadBenchmark {
       GcsFileSystemOptions gcsFileSystemOptions = GcsFileSystemOptions.createFromOptions(
               Map.of("gcs.analytics-core.small-file.footer.prefetch.size-bytes", state.footerPrefetchSize,
                       "gcs.analytics-core.large-file.footer.prefetch.size-bytes", state.footerPrefetchSize,
-                      "gcs.analytics-core.small-file.cache.max-size-bytes", "1048576"
+                      "gcs.analytics-core.small-file.cache.max-size-bytes", "1048576",
                       "gcs.analytics-core.read.bidi.enabled", String.valueOf(state.enableBidiRead)), "gcs.");
         String requestedSchema = "message requested_schema {\n"
                 + "required binary c_customer_id (STRING);\n"


### PR DESCRIPTION
## Type of Change

- [ ] `feat`: A new feature
- [x] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
Fixed a syntax error (missing comma) in `ParquetRecordReadBenchmark.java`. This resulted in post submit failures. ([link/])(https://screenshot.googleplex.com/73BQdmwzeS2uzAm)
### Why?
The missing comma resulted in a post submit failures. The code is in jmh micro-benchmarks. During the usual presubmit run, the microbenchmarks are not run, they are only run during pos

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `fix(core): fix syntax error in ParquetRecordReadBenchmark`)
- [x] All files include the Apache License 2.0 header
- [x] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? [Yes]*