### PR TITLE
refactor: change vectored read default threadpool size to be function…

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -41,7 +41,7 @@ These parameters fine-tune the low-level data streaming behavior. They allow you
 | Property | Description | Default Value |
 | :--- | :--- | :--- |
 | `channel.read.chunk-size-bytes` | Chunk size for GCS channel reads. | - |
-| `analytics-core.read.thread.count` | Number of threads for parallel read operations like vectored IO. | `16` |
+| `analytics-core.read.thread.count` | Number of threads for parallel read operations like vectored IO. | `Max(16, 4 * Available Cores)` |
 | `analytics-core.read.vectored.range.merge-gap.max-bytes` | Maximum gap (in bytes) between ranges to merge in vectored reads. | `4096` (4 KB) |
 | `analytics-core.read.vectored.range.merged-size.max-bytes` | Maximum size (in bytes) of a merged range in vectored reads. | `8388608` (8 MB) |
 | `analytics-core.read.inplace-seek-limit-bytes` | In-place seek limit (in bytes). | `131072` (128 KB) |

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptions.java
@@ -17,6 +17,7 @@ package com.google.cloud.gcs.analyticscore.client;
 
 import com.google.auto.value.AutoValue;
 import com.google.cloud.gcs.analyticscore.common.telemetry.TelemetryOptions;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 
 /** Configuration options for the GCS File System. */
@@ -45,9 +46,15 @@ public abstract class GcsFileSystemOptions {
 
   public abstract Builder toBuilder();
 
+  @VisibleForTesting
+  static int getAvailableProcessors() {
+    return Runtime.getRuntime().availableProcessors();
+  }
+
   public static Builder builder() {
+    int defaultThreadCount = Math.max(16, getAvailableProcessors() * 4);
     return new AutoValue_GcsFileSystemOptions.Builder()
-        .setReadThreadCount(16)
+        .setReadThreadCount(defaultThreadCount)
         .setClientType(ClientType.HTTP_CLIENT)
         .setGcsClientOptions(GcsClientOptions.builder().build())
         .setGcsCacheOptions(GcsCacheOptions.builder().build())

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
@@ -307,7 +307,7 @@ class GcsFileSystemImplTest {
     assertThat(executorServiceSupplier.get()).isNotNull();
     assertThat(executorServiceSupplier.get()).isInstanceOf(ThreadPoolExecutor.class);
     assertThat(((ThreadPoolExecutor) executorServiceSupplier.get()).getCorePoolSize())
-        .isEqualTo(16);
+        .isEqualTo(TEST_GCS_FILESYSTEM_OPTIONS.getReadThreadCount());
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptionsTest.java
@@ -17,9 +17,12 @@
 package com.google.cloud.gcs.analyticscore.client;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 class GcsFileSystemOptionsTest {
 
@@ -61,5 +64,29 @@ class GcsFileSystemOptionsTest {
     assertThat(cacheOptions.getFooterCacheMaxSizeBytes()).isEqualTo(500 * MB);
     assertThat(cacheOptions.isSmallObjectCacheEnabled()).isTrue();
     assertThat(cacheOptions.getSmallObjectCacheMaxSizeBytes()).isEqualTo(200 * MB);
+  }
+
+  @Test
+  void builder_withFewProcessors_setsDefaultThreadCountTo16() {
+    try (MockedStatic<GcsFileSystemOptions> mockedStatic =
+        mockStatic(GcsFileSystemOptions.class, CALLS_REAL_METHODS)) {
+      mockedStatic.when(GcsFileSystemOptions::getAvailableProcessors).thenReturn(2);
+
+      GcsFileSystemOptions options = GcsFileSystemOptions.builder().build();
+
+      assertThat(options.getReadThreadCount()).isEqualTo(16);
+    }
+  }
+
+  @Test
+  void builder_withManyProcessors_scalesDefaultThreadCount() {
+    try (MockedStatic<GcsFileSystemOptions> mockedStatic =
+        mockStatic(GcsFileSystemOptions.class, CALLS_REAL_METHODS)) {
+      mockedStatic.when(GcsFileSystemOptions::getAvailableProcessors).thenReturn(10);
+
+      GcsFileSystemOptions options = GcsFileSystemOptions.builder().build();
+
+      assertThat(options.getReadThreadCount()).isEqualTo(40);
+    }
   }
 }


### PR DESCRIPTION
… of available vcpus

## Type of Change

- [ ] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [x] `refactor`: A code change that neither fixes a bug nor adds a feature
- [x] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
Updated the default thread pool size for vectored reads to scale based on available vCPUs, using a formula of Max(16, 4 * Available Cores).

### Why?
With default 16, vectored read could bottleneck on the thread-pool, in primitive benchmarks we have observed 72 threads can improve IO performance by multiple folds even with 16vcpus.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [x] All files include the Apache License 2.0 header
- [x] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? [Yes/No]*
