### PR TITLE
feat(client): support content-type/encoding in write options and fix overwrite behavior

### DIFF
--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -36,11 +36,14 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,7 +122,7 @@ class GcsClientImpl implements GcsClient {
       throws IOException {
     checkNotNull(itemId, "itemId should not be null");
 
-    BlobInfo blobInfo = createBlobInfo(itemId);
+    BlobInfo blobInfo = createBlobInfo(itemId, writeOptions);
 
     try {
       BlobWriteOption[] sdkWriteOptions =
@@ -239,7 +242,15 @@ class GcsClientImpl implements GcsClient {
     }
   }
 
-  private BlobInfo createBlobInfo(GcsItemId itemId) {
+  private static Map<String, String> encodeMetadata(Map<String, byte[]> metadata) {
+    return metadata.entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                e -> e.getValue() == null ? null : BaseEncoding.base64().encode(e.getValue())));
+  }
+
+  private BlobInfo createBlobInfo(GcsItemId itemId, GcsWriteOptions writeOptions) {
     checkNotNull(itemId, "itemId should not be null");
     String objectName =
         itemId
@@ -250,6 +261,17 @@ class GcsClientImpl implements GcsClient {
             .getContentGeneration()
             .map(generation -> BlobId.of(itemId.getBucketName(), objectName, generation))
             .orElseGet(() -> BlobId.of(itemId.getBucketName(), objectName));
-    return BlobInfo.newBuilder(blobId).build();
+
+    BlobInfo.Builder blobInfoBuilder = BlobInfo.newBuilder(blobId);
+
+    if (writeOptions != null) {
+      writeOptions.getContentType().ifPresent(blobInfoBuilder::setContentType);
+      writeOptions.getContentEncoding().ifPresent(blobInfoBuilder::setContentEncoding);
+      if (writeOptions.getMetadata() != null && !writeOptions.getMetadata().isEmpty()) {
+        blobInfoBuilder.setMetadata(encodeMetadata(writeOptions.getMetadata()));
+      }
+    }
+
+    return blobInfoBuilder.build();
   }
 }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -39,11 +39,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -243,11 +243,9 @@ class GcsClientImpl implements GcsClient {
   }
 
   private static Map<String, String> encodeMetadata(Map<String, byte[]> metadata) {
-    return metadata.entrySet().stream()
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                e -> e.getValue() == null ? null : BaseEncoding.base64().encode(e.getValue())));
+    Map<String, String> encoded = new HashMap<>();
+    metadata.forEach((k, v) -> encoded.put(k, v == null ? null : BaseEncoding.base64().encode(v)));
+    return encoded;
   }
 
   private BlobInfo createBlobInfo(GcsItemId itemId, GcsWriteOptions writeOptions) {
@@ -264,13 +262,17 @@ class GcsClientImpl implements GcsClient {
 
     BlobInfo.Builder blobInfoBuilder = BlobInfo.newBuilder(blobId);
 
-    if (writeOptions != null) {
-      writeOptions.getContentType().ifPresent(blobInfoBuilder::setContentType);
-      writeOptions.getContentEncoding().ifPresent(blobInfoBuilder::setContentEncoding);
-      if (writeOptions.getMetadata() != null && !writeOptions.getMetadata().isEmpty()) {
-        blobInfoBuilder.setMetadata(encodeMetadata(writeOptions.getMetadata()));
-      }
-    }
+    Optional.ofNullable(writeOptions)
+        .ifPresent(
+            options -> {
+              options.getContentType().ifPresent(blobInfoBuilder::setContentType);
+              options.getContentEncoding().ifPresent(blobInfoBuilder::setContentEncoding);
+
+              Optional.ofNullable(options.getMetadata())
+                  .filter(metadata -> !metadata.isEmpty())
+                  .map(metadata -> encodeMetadata(metadata))
+                  .ifPresent(blobInfoBuilder::setMetadata);
+            });
 
     return blobInfoBuilder.build();
   }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -39,9 +39,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
@@ -242,10 +240,11 @@ class GcsClientImpl implements GcsClient {
     }
   }
 
-  private static Map<String, String> encodeMetadata(Map<String, byte[]> metadata) {
-    Map<String, String> encoded = new HashMap<>();
-    metadata.forEach((k, v) -> encoded.put(k, v == null ? null : BaseEncoding.base64().encode(v)));
-    return encoded;
+  private static ImmutableMap<String, String> encodeMetadata(
+      ImmutableMap<String, byte[]> metadata) {
+    ImmutableMap.Builder<String, String> encoded = ImmutableMap.builder();
+    metadata.forEach((k, v) -> encoded.put(k, BaseEncoding.base64().encode(v)));
+    return encoded.build();
   }
 
   private BlobInfo createBlobInfo(GcsItemId itemId, GcsWriteOptions writeOptions) {
@@ -267,11 +266,10 @@ class GcsClientImpl implements GcsClient {
             options -> {
               options.getContentType().ifPresent(blobInfoBuilder::setContentType);
               options.getContentEncoding().ifPresent(blobInfoBuilder::setContentEncoding);
-
-              Optional.ofNullable(options.getMetadata())
-                  .filter(metadata -> !metadata.isEmpty())
-                  .map(metadata -> encodeMetadata(metadata))
-                  .ifPresent(blobInfoBuilder::setMetadata);
+              ImmutableMap<String, byte[]> metadata = options.getMetadata();
+              if (!metadata.isEmpty()) {
+                blobInfoBuilder.setMetadata(encodeMetadata(metadata));
+              }
             });
 
     return blobInfoBuilder.build();

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsExceptionUtil.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsExceptionUtil.java
@@ -93,13 +93,12 @@ class GcsExceptionUtil {
                 // a doesNotExist() (generation = 0L) constraint and the object already exists on
                 // GCS.
                 if (blobId.getGeneration() == null || blobId.getGeneration() <= 0L) {
-                  FileAlreadyExistsException faee =
+                  return (FileAlreadyExistsException)
                       new FileAlreadyExistsException(
-                          String.format(
-                              "Object gs://%s/%s already exists.",
-                              blobId.getBucket(), blobId.getName()));
-                  faee.initCause(se);
-                  return faee;
+                              String.format(
+                                  "Object gs://%s/%s already exists.",
+                                  blobId.getBucket(), blobId.getName()))
+                          .initCause(se);
                 }
               }
               return translateCommon(se, context, blobId, position, errorType);
@@ -112,22 +111,20 @@ class GcsExceptionUtil {
       StorageException e, String context, BlobId blobId, long position, ErrorType errorType) {
     switch (errorType) {
       case NOT_FOUND:
-        FileNotFoundException fnfe =
+        return (FileNotFoundException)
             new FileNotFoundException(
-                String.format(
-                    "Location does not exist or generation not found: gs://%s/%s",
-                    blobId.getBucket(), blobId.getName()));
-        fnfe.initCause(e);
-        return fnfe;
+                    String.format(
+                        "Location does not exist or generation not found: gs://%s/%s",
+                        blobId.getBucket(), blobId.getName()))
+                .initCause(e);
 
       case ACCESS_DENIED:
-        AccessDeniedException ade =
+        return (AccessDeniedException)
             new AccessDeniedException(
-                String.format("gs://%s/%s", blobId.getBucket(), blobId.getName()),
-                null,
-                String.format("Access denied to object during %s: %s", context, e.getMessage()));
-        ade.initCause(e);
-        return ade;
+                    String.format("gs://%s/%s", blobId.getBucket(), blobId.getName()),
+                    null,
+                    String.format("Access denied to object during %s: %s", context, e.getMessage()))
+                .initCause(e);
 
       case PRECONDITION_FAILED:
         // A generation mismatch represents a concurrent modification ONLY if a specific,

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsExceptionUtil.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsExceptionUtil.java
@@ -87,18 +87,22 @@ class GcsExceptionUtil {
     return getStorageException(e)
         .map(
             se -> {
-              if (!overwrite) {
-                ErrorType errorType = getErrorType(se);
-                if (errorType == ErrorType.PRECONDITION_FAILED && blobId.getGeneration() == null) {
-                  return (FileAlreadyExistsException)
+              ErrorType errorType = getErrorType(se);
+              if (!overwrite && errorType == ErrorType.PRECONDITION_FAILED) {
+                // If overwrite is disabled, a PRECONDITION_FAILED occurs because we enforced
+                // a doesNotExist() (generation = 0L) constraint and the object already exists on
+                // GCS.
+                if (blobId.getGeneration() == null || blobId.getGeneration() <= 0L) {
+                  FileAlreadyExistsException faee =
                       new FileAlreadyExistsException(
-                              String.format(
-                                  "Object gs://%s/%s already exists.",
-                                  blobId.getBucket(), blobId.getName()))
-                          .initCause(se);
+                          String.format(
+                              "Object gs://%s/%s already exists.",
+                              blobId.getBucket(), blobId.getName()));
+                  faee.initCause(se);
+                  return faee;
                 }
               }
-              return translateCommon(se, context, blobId, position, getErrorType(se));
+              return translateCommon(se, context, blobId, position, errorType);
             })
         .orElseGet(() -> translateGenericException(e, context, blobId, position));
   }
@@ -108,23 +112,27 @@ class GcsExceptionUtil {
       StorageException e, String context, BlobId blobId, long position, ErrorType errorType) {
     switch (errorType) {
       case NOT_FOUND:
-        return (FileNotFoundException)
+        FileNotFoundException fnfe =
             new FileNotFoundException(
-                    String.format(
-                        "Location does not exist or generation not found: gs://%s/%s",
-                        blobId.getBucket(), blobId.getName()))
-                .initCause(e);
+                String.format(
+                    "Location does not exist or generation not found: gs://%s/%s",
+                    blobId.getBucket(), blobId.getName()));
+        fnfe.initCause(e);
+        return fnfe;
 
       case ACCESS_DENIED:
-        return (AccessDeniedException)
+        AccessDeniedException ade =
             new AccessDeniedException(
-                    String.format("gs://%s/%s", blobId.getBucket(), blobId.getName()),
-                    null,
-                    String.format("Access denied to object during %s: %s", context, e.getMessage()))
-                .initCause(e);
+                String.format("gs://%s/%s", blobId.getBucket(), blobId.getName()),
+                null,
+                String.format("Access denied to object during %s: %s", context, e.getMessage()));
+        ade.initCause(e);
+        return ade;
 
       case PRECONDITION_FAILED:
-        if (blobId.getGeneration() != null) {
+        // A generation mismatch represents a concurrent modification ONLY if a specific,
+        // positive target version (generation > 0L) was targeted and failed to match.
+        if (blobId.getGeneration() != null && blobId.getGeneration() > 0L) {
           return new IOException(
               String.format(
                   "Generation mismatch for object gs://%s/%s. Concurrent modification detected.",

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptions.java
@@ -21,8 +21,6 @@ import com.google.auto.value.AutoValue;
 import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,7 +62,11 @@ public abstract class GcsWriteOptions {
   public abstract Optional<String> getContentEncoding();
 
   @Nullable
-  public abstract Map<String, byte[]> getMetadata();
+  abstract ImmutableMap<String, byte[]> getNullableMetadata();
+
+  public ImmutableMap<String, byte[]> getMetadata() {
+    return getNullableMetadata() == null ? ImmutableMap.of() : getNullableMetadata();
+  }
 
   public abstract Builder toBuilder();
 
@@ -118,19 +120,17 @@ public abstract class GcsWriteOptions {
 
     public abstract Builder setContentEncoding(String contentEncoding);
 
-    public abstract Builder setMetadata(@Nullable Map<String, byte[]> metadata);
+    abstract Builder setNullableMetadata(@Nullable ImmutableMap<String, byte[]> metadata);
 
-    @Nullable
-    abstract Map<String, byte[]> getMetadata();
+    public Builder setMetadata(@Nullable Map<String, byte[]> metadata) {
+      return setNullableMetadata(metadata == null ? null : ImmutableMap.copyOf(metadata));
+    }
 
     abstract GcsWriteOptions autoBuild();
 
     public GcsWriteOptions build() {
-      Map<String, byte[]> metadata = getMetadata();
-      setMetadata(metadata == null ? null : Collections.unmodifiableMap(new HashMap<>(metadata)));
-
       GcsWriteOptions options = autoBuild();
-      if (options.getMetadata() != null) {
+      if (!options.getMetadata().isEmpty()) {
         boolean hasContentEncoding =
             options.getMetadata().keySet().stream()
                 .anyMatch(key -> key.equalsIgnoreCase("Content-Encoding"));

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptions.java
@@ -21,6 +21,8 @@ import com.google.auto.value.AutoValue;
 import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -60,7 +62,7 @@ public abstract class GcsWriteOptions {
 
   public abstract Optional<String> getContentEncoding();
 
-  public abstract ImmutableMap<String, byte[]> getMetadata();
+  public abstract Map<String, byte[]> getMetadata();
 
   public abstract Builder toBuilder();
 
@@ -116,9 +118,14 @@ public abstract class GcsWriteOptions {
 
     public abstract Builder setMetadata(Map<String, byte[]> metadata);
 
+    abstract Map<String, byte[]> getMetadata();
+
     abstract GcsWriteOptions autoBuild();
 
     public GcsWriteOptions build() {
+      Map<String, byte[]> metadata = getMetadata();
+      setMetadata(metadata == null ? null : Collections.unmodifiableMap(new HashMap<>(metadata)));
+
       GcsWriteOptions options = autoBuild();
       boolean hasContentEncoding =
           options.getMetadata().keySet().stream()

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptions.java
@@ -17,6 +17,7 @@ package com.google.cloud.gcs.analyticscore.client;
 
 import com.google.auto.value.AutoValue;
 import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +54,12 @@ public abstract class GcsWriteOptions {
 
   public abstract Optional<String> getEncryptionKey();
 
+  public abstract Optional<String> getContentType();
+
+  public abstract Optional<String> getContentEncoding();
+
+  public abstract ImmutableMap<String, byte[]> getMetadata();
+
   public abstract Builder toBuilder();
 
   public static GcsWriteOptions createFromOptions(
@@ -80,7 +87,9 @@ public abstract class GcsWriteOptions {
     return new AutoValue_GcsWriteOptions.Builder()
         .setChecksumValidationEnabled(false)
         .setDisableGzipContent(true)
-        .setOverwriteExisting(true);
+        .setOverwriteExisting(true)
+        .setContentType("application/octet-stream")
+        .setMetadata(ImmutableMap.of());
   }
 
   /** Builder for {@link GcsWriteOptions}. */
@@ -99,16 +108,43 @@ public abstract class GcsWriteOptions {
 
     public abstract Builder setEncryptionKey(String key);
 
-    public abstract GcsWriteOptions build();
+    public abstract Builder setContentType(String contentType);
+
+    public abstract Builder setContentEncoding(String contentEncoding);
+
+    public abstract Builder setMetadata(Map<String, byte[]> metadata);
+
+    abstract GcsWriteOptions autoBuild();
+
+    public GcsWriteOptions build() {
+      GcsWriteOptions options = autoBuild();
+      com.google.common.base.Preconditions.checkArgument(
+          !options.getMetadata().containsKey("Content-Encoding"),
+          "The Content-Encoding must be provided explicitly via the 'contentEncoding' parameter");
+      com.google.common.base.Preconditions.checkArgument(
+          !options.getMetadata().containsKey("Content-Type"),
+          "The Content-Type must be provided explicitly via the 'contentType' parameter");
+      return options;
+    }
   }
 
   public BlobWriteOption[] generateWriteOptions(GcsItemId itemId) {
     List<BlobWriteOption> sdkWriteOptions = new ArrayList<>();
 
-    itemId
-        .getContentGeneration()
-        .ifPresent(generation -> sdkWriteOptions.add(BlobWriteOption.generationMatch(generation)));
+    // 1. Transactional Precondition Check (Safety First)
+    if (!this.isOverwriteExisting()) {
+      // If overwrite is disabled, the target MUST NOT exist over the wire.
+      // This maps to an over-the-wire ifGenerationMatch = 0L.
+      sdkWriteOptions.add(BlobWriteOption.doesNotExist());
+    } else {
+      // Only if overwrite is enabled do we conditionally match a targeted generation.
+      itemId
+          .getContentGeneration()
+          .ifPresent(
+              generation -> sdkWriteOptions.add(BlobWriteOption.generationMatch(generation)));
+    }
 
+    // 2. Secondary configuration mappings
     if (this.isDisableGzipContent()) {
       sdkWriteOptions.add(BlobWriteOption.disableGzipContent());
     }
@@ -118,10 +154,6 @@ public abstract class GcsWriteOptions {
     this.getKmsKeyName().map(BlobWriteOption::kmsKeyName).ifPresent(sdkWriteOptions::add);
     this.getEncryptionKey().map(BlobWriteOption::encryptionKey).ifPresent(sdkWriteOptions::add);
     this.getUserProject().map(BlobWriteOption::userProject).ifPresent(sdkWriteOptions::add);
-
-    if (!itemId.getContentGeneration().isPresent() && !this.isOverwriteExisting()) {
-      sdkWriteOptions.add(BlobWriteOption.doesNotExist());
-    }
 
     return sdkWriteOptions.toArray(new BlobWriteOption[0]);
   }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptions.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.gcs.analyticscore.client;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.auto.value.AutoValue;
 import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.common.collect.ImmutableMap;
@@ -118,11 +120,17 @@ public abstract class GcsWriteOptions {
 
     public GcsWriteOptions build() {
       GcsWriteOptions options = autoBuild();
-      com.google.common.base.Preconditions.checkArgument(
-          !options.getMetadata().containsKey("Content-Encoding"),
+      boolean hasContentEncoding =
+          options.getMetadata().keySet().stream()
+              .anyMatch(key -> key.equalsIgnoreCase("Content-Encoding"));
+      checkArgument(
+          !hasContentEncoding,
           "The Content-Encoding must be provided explicitly via the 'contentEncoding' parameter");
-      com.google.common.base.Preconditions.checkArgument(
-          !options.getMetadata().containsKey("Content-Type"),
+      boolean hasContentType =
+          options.getMetadata().keySet().stream()
+              .anyMatch(key -> key.equalsIgnoreCase("Content-Type"));
+      checkArgument(
+          !hasContentType,
           "The Content-Type must be provided explicitly via the 'contentType' parameter");
       return options;
     }
@@ -131,20 +139,14 @@ public abstract class GcsWriteOptions {
   public BlobWriteOption[] generateWriteOptions(GcsItemId itemId) {
     List<BlobWriteOption> sdkWriteOptions = new ArrayList<>();
 
-    // 1. Transactional Precondition Check (Safety First)
-    if (!this.isOverwriteExisting()) {
-      // If overwrite is disabled, the target MUST NOT exist over the wire.
-      // This maps to an over-the-wire ifGenerationMatch = 0L.
-      sdkWriteOptions.add(BlobWriteOption.doesNotExist());
-    } else {
-      // Only if overwrite is enabled do we conditionally match a targeted generation.
-      itemId
-          .getContentGeneration()
-          .ifPresent(
-              generation -> sdkWriteOptions.add(BlobWriteOption.generationMatch(generation)));
-    }
+    // If overwrite is disabled, the target MUST NOT exist over the wire (ifGenerationMatch = 0L).
+    // Otherwise, we conditionally match a targeted generation if present.
+    Optional<BlobWriteOption> preconditionOption =
+        !this.isOverwriteExisting()
+            ? Optional.of(BlobWriteOption.doesNotExist())
+            : itemId.getContentGeneration().map(BlobWriteOption::generationMatch);
+    preconditionOption.ifPresent(sdkWriteOptions::add);
 
-    // 2. Secondary configuration mappings
     if (this.isDisableGzipContent()) {
       sdkWriteOptions.add(BlobWriteOption.disableGzipContent());
     }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptions.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Configuration options for writing objects to Google Cloud Storage.
@@ -62,6 +63,7 @@ public abstract class GcsWriteOptions {
 
   public abstract Optional<String> getContentEncoding();
 
+  @Nullable
   public abstract Map<String, byte[]> getMetadata();
 
   public abstract Builder toBuilder();
@@ -116,8 +118,9 @@ public abstract class GcsWriteOptions {
 
     public abstract Builder setContentEncoding(String contentEncoding);
 
-    public abstract Builder setMetadata(Map<String, byte[]> metadata);
+    public abstract Builder setMetadata(@Nullable Map<String, byte[]> metadata);
 
+    @Nullable
     abstract Map<String, byte[]> getMetadata();
 
     abstract GcsWriteOptions autoBuild();
@@ -127,18 +130,20 @@ public abstract class GcsWriteOptions {
       setMetadata(metadata == null ? null : Collections.unmodifiableMap(new HashMap<>(metadata)));
 
       GcsWriteOptions options = autoBuild();
-      boolean hasContentEncoding =
-          options.getMetadata().keySet().stream()
-              .anyMatch(key -> key.equalsIgnoreCase("Content-Encoding"));
-      checkArgument(
-          !hasContentEncoding,
-          "The Content-Encoding must be provided explicitly via the 'contentEncoding' parameter");
-      boolean hasContentType =
-          options.getMetadata().keySet().stream()
-              .anyMatch(key -> key.equalsIgnoreCase("Content-Type"));
-      checkArgument(
-          !hasContentType,
-          "The Content-Type must be provided explicitly via the 'contentType' parameter");
+      if (options.getMetadata() != null) {
+        boolean hasContentEncoding =
+            options.getMetadata().keySet().stream()
+                .anyMatch(key -> key.equalsIgnoreCase("Content-Encoding"));
+        checkArgument(
+            !hasContentEncoding,
+            "The Content-Encoding must be provided explicitly via the 'contentEncoding' parameter");
+        boolean hasContentType =
+            options.getMetadata().keySet().stream()
+                .anyMatch(key -> key.equalsIgnoreCase("Content-Type"));
+        checkArgument(
+            !hasContentType,
+            "The Content-Type must be provided explicitly via the 'contentType' parameter");
+      }
       return options;
     }
   }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -585,6 +585,7 @@ class GcsClientImplTest {
 
     java.util.Map<String, byte[]> customMetadata = new java.util.HashMap<>();
     customMetadata.put("key1", "value1".getBytes(StandardCharsets.UTF_8));
+    customMetadata.put("key2", null);
 
     GcsWriteOptions options = GcsWriteOptions.builder().setMetadata(customMetadata).build();
 
@@ -595,6 +596,7 @@ class GcsClientImplTest {
 
     BlobInfo capturedBlobInfo = blobInfoCaptor.getValue();
     assertThat(capturedBlobInfo.getMetadata()).containsEntry("key1", "dmFsdWUx");
+    assertThat(capturedBlobInfo.getMetadata()).containsEntry("key2", null);
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -63,6 +63,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.FileAlreadyExistsException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -582,21 +584,26 @@ class GcsClientImplTest {
     BlobWriteSession mockSession = mockBlobWriteSession(mockStorage);
     when(mockSession.open()).thenReturn(mock(WritableByteChannel.class));
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
-
-    java.util.Map<String, byte[]> customMetadata = new java.util.HashMap<>();
+    Map<String, byte[]> customMetadata = new HashMap<>();
     customMetadata.put("key1", "value1".getBytes(StandardCharsets.UTF_8));
-    customMetadata.put("key2", null);
+    customMetadata.put("key2", new byte[] {0, 1, 2, 3});
 
-    GcsWriteOptions options = GcsWriteOptions.builder().setMetadata(customMetadata).build();
+    GcsWriteOptions options =
+        GcsWriteOptions.builder()
+            .setMetadata(customMetadata)
+            .setContentType("text/plain")
+            .setContentEncoding("gzip")
+            .build();
+    ArgumentCaptor<BlobInfo> blobInfoCaptor = ArgumentCaptor.forClass(BlobInfo.class);
 
     clientWithMock.createWriteChannel(TEST_ITEM_ID, options);
 
-    ArgumentCaptor<BlobInfo> blobInfoCaptor = ArgumentCaptor.forClass(BlobInfo.class);
     verify(mockStorage).blobWriteSession(blobInfoCaptor.capture(), any());
-
     BlobInfo capturedBlobInfo = blobInfoCaptor.getValue();
     assertThat(capturedBlobInfo.getMetadata()).containsEntry("key1", "dmFsdWUx");
-    assertThat(capturedBlobInfo.getMetadata()).containsEntry("key2", null);
+    assertThat(capturedBlobInfo.getMetadata()).containsEntry("key2", "AAECAw==");
+    assertThat(capturedBlobInfo.getContentType()).isEqualTo("text/plain");
+    assertThat(capturedBlobInfo.getContentEncoding()).isEqualTo("gzip");
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -91,7 +91,9 @@ class GcsClientImplTest {
   private static final GcsItemId TEST_ITEM_ID =
       GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_OBJECT).build();
   private static final BlobInfo TEST_BLOB_INFO =
-      BlobInfo.newBuilder(BlobId.of(TEST_BUCKET, TEST_OBJECT)).build();
+      BlobInfo.newBuilder(BlobId.of(TEST_BUCKET, TEST_OBJECT))
+          .setContentType("application/octet-stream")
+          .build();
   private static final GcsWriteOptions DEFAULT_WRITE_OPTIONS = GcsWriteOptions.builder().build();
 
   private final Storage storage = LocalStorageHelper.getOptions().getService();
@@ -482,7 +484,9 @@ class GcsClientImplTest {
             .setContentGeneration(12345L)
             .build();
     BlobInfo blobInfoWithGen =
-        BlobInfo.newBuilder(BlobId.of(TEST_BUCKET, TEST_OBJECT, 12345L)).build();
+        BlobInfo.newBuilder(BlobId.of(TEST_BUCKET, TEST_OBJECT, 12345L))
+            .setContentType("application/octet-stream")
+            .build();
     StorageException e412 = new StorageException(412, "Precondition Failed");
     when(mockStorage.blobWriteSession(eq(blobInfoWithGen), any(Storage.BlobWriteOption[].class)))
         .thenThrow(e412);
@@ -506,7 +510,9 @@ class GcsClientImplTest {
             .setObjectName("test-object")
             .build();
     BlobInfo blobInfo =
-        BlobInfo.newBuilder(BlobId.of("non-existent-bucket", "test-object")).build();
+        BlobInfo.newBuilder(BlobId.of("non-existent-bucket", "test-object"))
+            .setContentType("application/octet-stream")
+            .build();
     StorageException e404 = new StorageException(404, "Not Found");
     when(mockStorage.blobWriteSession(eq(blobInfo), any(Storage.BlobWriteOption[].class)))
         .thenThrow(e404);
@@ -571,6 +577,40 @@ class GcsClientImplTest {
   }
 
   @Test
+  void create_withMetadata_base64EncodesMetadata() throws Exception {
+    Storage mockStorage = mock(Storage.class);
+    BlobWriteSession mockSession = mockBlobWriteSession(mockStorage);
+    when(mockSession.open()).thenReturn(mock(WritableByteChannel.class));
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
+
+    java.util.Map<String, byte[]> customMetadata = new java.util.HashMap<>();
+    customMetadata.put("key1", "value1".getBytes(StandardCharsets.UTF_8));
+
+    GcsWriteOptions options = GcsWriteOptions.builder().setMetadata(customMetadata).build();
+
+    clientWithMock.createWriteChannel(TEST_ITEM_ID, options);
+
+    ArgumentCaptor<BlobInfo> blobInfoCaptor = ArgumentCaptor.forClass(BlobInfo.class);
+    verify(mockStorage).blobWriteSession(blobInfoCaptor.capture(), any());
+
+    BlobInfo capturedBlobInfo = blobInfoCaptor.getValue();
+    assertThat(capturedBlobInfo.getMetadata()).containsEntry("key1", "dmFsdWUx");
+  }
+
+  @Test
+  void create_withoutObjectName_throwsIllegalArgumentException() {
+    GcsClientImpl client =
+        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry);
+    GcsItemId itemIdWithoutName = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> client.createWriteChannel(itemIdWithoutName, DEFAULT_WRITE_OPTIONS));
+    assertThat(e).hasMessageThat().contains("Object name must be present");
+  }
+
+  @Test
   void create_allWriteOptionsEnabled_generatesCorrectBlobWriteOptions() throws Exception {
     Storage mockStorage = mock(Storage.class);
     BlobWriteSession mockSession = mockBlobWriteSession(mockStorage);
@@ -622,7 +662,9 @@ class GcsClientImplTest {
             .setContentGeneration(12345L)
             .build();
     BlobInfo blobInfoWithGen =
-        BlobInfo.newBuilder(BlobId.of(TEST_BUCKET, TEST_OBJECT, 12345L)).build();
+        BlobInfo.newBuilder(BlobId.of(TEST_BUCKET, TEST_OBJECT, 12345L))
+            .setContentType("application/octet-stream")
+            .build();
 
     clientWithMock.createWriteChannel(itemIdWithGen, DEFAULT_WRITE_OPTIONS);
 
@@ -847,7 +889,9 @@ class GcsClientImplTest {
     Storage mockStorage = mock(Storage.class);
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
     StorageException e412 = new StorageException(412, "Precondition Failed");
-    when(mockStorage.blobWriteSession(eq(TEST_BLOB_INFO), any(Storage.BlobWriteOption[].class)))
+    BlobInfo nullOptionsBlobInfo = BlobInfo.newBuilder(BlobId.of(TEST_BUCKET, TEST_OBJECT)).build();
+    when(mockStorage.blobWriteSession(
+            eq(nullOptionsBlobInfo), any(Storage.BlobWriteOption[].class)))
         .thenThrow(e412);
 
     IOException exception =

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsExceptionUtilTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsExceptionUtilTest.java
@@ -137,6 +137,21 @@ class GcsExceptionUtilTest {
   }
 
   @Test
+  void translateException_when412AndZeroGeneration_returnsGenericError() {
+    StorageException se = new StorageException(412, "Precondition Failed");
+
+    IOException exception =
+        GcsExceptionUtil.translateException(se, CONTEXT, BlobId.of(BUCKET, NAME, 0L), POSITION);
+
+    assertThat(exception).isNotInstanceOf(FileAlreadyExistsException.class);
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            String.format(
+                "Error during %s to GCS for gs://%s/%s at position %d",
+                CONTEXT, BUCKET, NAME, POSITION));
+  }
+
+  @Test
   void
       translateWriteException_when412WithoutOverwriteAndNoGeneration_throwsFileAlreadyExistsException() {
     StorageException se = new StorageException(412, "Precondition Failed");
@@ -146,6 +161,24 @@ class GcsExceptionUtilTest {
             se,
             CONTEXT,
             BlobId.of(BUCKET, NAME),
+            POSITION,
+            GcsWriteOptions.builder().setOverwriteExisting(false).build());
+
+    assertThat(exception).isInstanceOf(FileAlreadyExistsException.class);
+    assertThat(exception.getMessage())
+        .isEqualTo(String.format("Object gs://%s/%s already exists.", BUCKET, NAME));
+  }
+
+  @Test
+  void
+      translateWriteException_when412WithoutOverwriteAndZeroGeneration_throwsFileAlreadyExistsException() {
+    StorageException se = new StorageException(412, "Precondition Failed");
+
+    IOException exception =
+        GcsExceptionUtil.translateWriteException(
+            se,
+            CONTEXT,
+            BlobId.of(BUCKET, NAME, 0L),
             POSITION,
             GcsWriteOptions.builder().setOverwriteExisting(false).build());
 

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsExceptionUtilTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsExceptionUtilTest.java
@@ -358,6 +358,7 @@ class GcsExceptionUtilTest {
             GcsWriteOptions.builder().setOverwriteExisting(false).build());
 
     assertThat(exception).isNotInstanceOf(FileAlreadyExistsException.class);
+    assertThat(exception).isInstanceOf(IOException.class);
     assertThat(exception.getMessage())
         .isEqualTo(
             String.format(
@@ -374,6 +375,7 @@ class GcsExceptionUtilTest {
             se, CONTEXT, BlobId.of(BUCKET, NAME), POSITION, null);
 
     assertThat(exception).isNotInstanceOf(FileAlreadyExistsException.class);
+    assertThat(exception).isInstanceOf(IOException.class);
     assertThat(exception.getMessage())
         .contains(
             String.format(

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsExceptionUtilTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsExceptionUtilTest.java
@@ -330,6 +330,58 @@ class GcsExceptionUtilTest {
   }
 
   @Test
+  void translateWriteException_when404WithoutOverwrite_throwsFileNotFoundException() {
+    StorageException se = new StorageException(404, "Not Found");
+
+    IOException exception =
+        GcsExceptionUtil.translateWriteException(
+            se,
+            CONTEXT,
+            BlobId.of(BUCKET, NAME),
+            POSITION,
+            GcsWriteOptions.builder().setOverwriteExisting(false).build());
+
+    assertThat(exception).isInstanceOf(FileNotFoundException.class);
+  }
+
+  @Test
+  void
+      translateWriteException_when412WithoutOverwriteAndPositiveGeneration_throwsGenerationMismatch() {
+    StorageException se = new StorageException(412, "Precondition Failed");
+
+    IOException exception =
+        GcsExceptionUtil.translateWriteException(
+            se,
+            CONTEXT,
+            BlobId.of(BUCKET, NAME, 12345L),
+            POSITION,
+            GcsWriteOptions.builder().setOverwriteExisting(false).build());
+
+    assertThat(exception).isNotInstanceOf(FileAlreadyExistsException.class);
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            String.format(
+                "Generation mismatch for object gs://%s/%s. Concurrent modification detected.",
+                BUCKET, NAME));
+  }
+
+  @Test
+  void translateWriteException_whenWriteOptionsIsNullAnd412_returnsGenericError() {
+    StorageException se = new StorageException(412, "Precondition Failed");
+
+    IOException exception =
+        GcsExceptionUtil.translateWriteException(
+            se, CONTEXT, BlobId.of(BUCKET, NAME), POSITION, null);
+
+    assertThat(exception).isNotInstanceOf(FileAlreadyExistsException.class);
+    assertThat(exception.getMessage())
+        .contains(
+            String.format(
+                "Error during %s to GCS for gs://%s/%s at position %d",
+                CONTEXT, BUCKET, NAME, POSITION));
+  }
+
+  @Test
   void constructor_isPrivate() throws Exception {
     Constructor<GcsExceptionUtil> constructor = GcsExceptionUtil.class.getDeclaredConstructor();
 

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptionsTest.java
@@ -47,7 +47,7 @@ class GcsWriteOptionsTest {
   void builder_withNullMetadata_buildsSuccessfully() {
     GcsWriteOptions options = GcsWriteOptions.builder().setMetadata(null).build();
 
-    assertThat(options.getMetadata()).isNull();
+    assertThat(options.getMetadata()).isEmpty();
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptionsTest.java
@@ -17,8 +17,12 @@
 package com.google.cloud.gcs.analyticscore.client;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +38,9 @@ class GcsWriteOptionsTest {
     assertThat(options.getKmsKeyName().isPresent()).isFalse();
     assertThat(options.getUserProject().isPresent()).isFalse();
     assertThat(options.getEncryptionKey().isPresent()).isFalse();
+    assertThat(options.getContentType()).hasValue("application/octet-stream");
+    assertThat(options.getContentEncoding().isPresent()).isFalse();
+    assertThat(options.getMetadata()).isEmpty();
   }
 
   @Test
@@ -46,6 +53,9 @@ class GcsWriteOptionsTest {
             .setKmsKeyName("kms-key")
             .setUserProject("project-123")
             .setEncryptionKey("enc-key")
+            .setContentType("text/plain")
+            .setContentEncoding("gzip")
+            .setMetadata(ImmutableMap.of("custom-key", new byte[] {1, 2, 3}))
             .build();
 
     assertThat(options.isChecksumValidationEnabled()).isTrue();
@@ -54,6 +64,10 @@ class GcsWriteOptionsTest {
     assertThat(options.getKmsKeyName()).hasValue("kms-key");
     assertThat(options.getUserProject()).hasValue("project-123");
     assertThat(options.getEncryptionKey()).hasValue("enc-key");
+    assertThat(options.getContentType()).hasValue("text/plain");
+    assertThat(options.getContentEncoding()).hasValue("gzip");
+    assertThat(options.getMetadata()).containsKey("custom-key");
+    assertThat(options.getMetadata().get("custom-key")).isEqualTo(new byte[] {1, 2, 3});
   }
 
   @Test
@@ -76,5 +90,77 @@ class GcsWriteOptionsTest {
     assertThat(options.getKmsKeyName()).hasValue("kms-key");
     assertThat(options.getUserProject()).hasValue("project-123");
     assertThat(options.getEncryptionKey()).hasValue("enc-key");
+  }
+
+  @Test
+  void builder_withContentTypeInMetadata_throwsIllegalArgumentException() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                GcsWriteOptions.builder()
+                    .setMetadata(ImmutableMap.of("Content-Type", new byte[] {}))
+                    .build());
+    assertThat(exception).hasMessageThat().contains("explicitly via the 'contentType' parameter");
+  }
+
+  @Test
+  void builder_withContentEncodingInMetadata_throwsIllegalArgumentException() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                GcsWriteOptions.builder()
+                    .setMetadata(ImmutableMap.of("Content-Encoding", new byte[] {}))
+                    .build());
+    assertThat(exception)
+        .hasMessageThat()
+        .contains("explicitly via the 'contentEncoding' parameter");
+  }
+
+  @Test
+  void generateWriteOptions_whenOverwriteExistingIsFalse_addsDoesNotExistOption() {
+    GcsWriteOptions options = GcsWriteOptions.builder().setOverwriteExisting(false).build();
+    GcsItemId itemId = GcsItemId.builder().setBucketName("bucket").setObjectName("object").build();
+
+    BlobWriteOption[] sdkOptions = options.generateWriteOptions(itemId);
+
+    List<BlobWriteOption> optionList = Arrays.asList(sdkOptions);
+    assertThat(optionList).contains(BlobWriteOption.doesNotExist());
+  }
+
+  @Test
+  void
+      generateWriteOptions_whenOverwriteExistingIsFalseWithGeneration_addsDoesNotExistOptionAndIgnoresGeneration() {
+    GcsWriteOptions options = GcsWriteOptions.builder().setOverwriteExisting(false).build();
+    GcsItemId itemId =
+        GcsItemId.builder()
+            .setBucketName("bucket")
+            .setObjectName("object")
+            .setContentGeneration(12345L)
+            .build();
+
+    BlobWriteOption[] sdkOptions = options.generateWriteOptions(itemId);
+
+    List<BlobWriteOption> optionList = Arrays.asList(sdkOptions);
+    assertThat(optionList).contains(BlobWriteOption.doesNotExist());
+    assertThat(optionList).doesNotContain(BlobWriteOption.generationMatch(12345L));
+  }
+
+  @Test
+  void generateWriteOptions_whenOverwriteExistingIsTrueWithGeneration_addsGenerationMatchOption() {
+    GcsWriteOptions options = GcsWriteOptions.builder().setOverwriteExisting(true).build();
+    GcsItemId itemId =
+        GcsItemId.builder()
+            .setBucketName("bucket")
+            .setObjectName("object")
+            .setContentGeneration(12345L)
+            .build();
+
+    BlobWriteOption[] sdkOptions = options.generateWriteOptions(itemId);
+
+    List<BlobWriteOption> optionList = Arrays.asList(sdkOptions);
+    assertThat(optionList).contains(BlobWriteOption.generationMatch(12345L));
+    assertThat(optionList).doesNotContain(BlobWriteOption.doesNotExist());
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsWriteOptionsTest.java
@@ -44,6 +44,13 @@ class GcsWriteOptionsTest {
   }
 
   @Test
+  void builder_withNullMetadata_buildsSuccessfully() {
+    GcsWriteOptions options = GcsWriteOptions.builder().setMetadata(null).build();
+
+    assertThat(options.getMetadata()).isNull();
+  }
+
+  @Test
   void builder_withCustomValues_setsAllProperties() {
     GcsWriteOptions options =
         GcsWriteOptions.builder()


### PR DESCRIPTION
## Type of Change

- [x] `feat`: A new feature
- [x] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [x] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
- Added support for `contentType`, `contentEncoding`, and custom `metadata` configuration options in `GcsWriteOptions`.
- Added validation in `GcsWriteOptions` builder to explicitly reject `Content-Type` and `Content-Encoding` if they are passed in the generic `metadata` map.
- Fixed write overwrite behavior to correctly apply `BlobWriteOption.doesNotExist()` when `overwriteExisting` is set to `false`, while safely ignoring any generation conditions. This behavior is similar to [hadoop-connector behavior.](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/2dd981a5001d7ebb38b5cd707a78820d52a95f42/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/CreateFileOptions.java#L111)
- Updated `GcsExceptionUtil` to correctly translate HTTP 412 (Precondition Failed) errors into `FileAlreadyExistsException` when `overwriteExisting` is false or the content generation was expected to be 0.
- Added unit tests in `GcsWriteOptionsTest` and `GcsExceptionUtilTest`, and updated `GcsClientImplTest` to cover the new behaviors.

### Why?
- Being able to explicitly set object metadata (like content type and encoding) is a common requirement when writing files to GCS.
- Validating the metadata map ensures users do not accidentally provide conflicting metadata configurations (e.g., setting content type natively vs. through the generic map).
- The overwrite prevention logic needed a fix to correctly translate precondition failures from the GCS API into familiar Java exceptions (`FileAlreadyExistsException`), preventing accidental data loss when `overwriteExisting` is set to `false`.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(client): add missing configs to write options and fix overwrite behavior`)
- [x] All files include the Apache License 2.0 header
- [x] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? Yes*
