### PR TITLE
feat(core): Integrate telemetry for the write path

### DIFF
--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/GcsAnalyticsCoreTelemetryConstants.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/GcsAnalyticsCoreTelemetryConstants.java
@@ -34,7 +34,11 @@ public class GcsAnalyticsCoreTelemetryConstants {
     SMALL_OBJECT_CACHE_HIT("gcs.analytics-core.client.small.object.cache.hits", MetricType.COUNTER),
     SMALL_OBJECT_CACHE_MISS(
         "gcs.analytics-core.client.small.object.cache.misses", MetricType.COUNTER),
-    CLOSE_DURATION("gcs.analytics-core.client.close.duration", MetricType.DURATION),
+    READ_CLOSE_DURATION("gcs.analytics-core.client.read.close.duration", MetricType.DURATION),
+    WRITE_BYTES("gcs.analytics-core.client.write.size", MetricType.COUNTER),
+    WRITE_DURATION("gcs.analytics-core.client.write.duration", MetricType.DURATION),
+    WRITE_CREATE_DURATION("gcs.analytics-core.client.write.create.duration", MetricType.DURATION),
+    WRITE_CLOSE_DURATION("gcs.analytics-core.client.write.close.duration", MetricType.DURATION),
     GCS_CLIENT_CREATE_DURATION("gcs.analytics-core.client.create.duration", MetricType.DURATION);
 
     private final String name;
@@ -59,11 +63,14 @@ public class GcsAnalyticsCoreTelemetryConstants {
   public enum Operation {
     SEEK,
     READ,
-    CLOSE,
+    READ_CLOSE,
     READ_FULLY,
     READ_TAIL,
     OPEN,
     VECTORED_READ,
+    WRITE,
+    CREATE,
+    WRITE_CLOSE,
     GCS_CLIENT_CREATE;
   }
 }

--- a/common/src/main/java/com/google/cloud/gcs/analyticscore/common/GcsAnalyticsCoreTelemetryConstants.java
+++ b/common/src/main/java/com/google/cloud/gcs/analyticscore/common/GcsAnalyticsCoreTelemetryConstants.java
@@ -37,7 +37,7 @@ public class GcsAnalyticsCoreTelemetryConstants {
     READ_CLOSE_DURATION("gcs.analytics-core.client.read.close.duration", MetricType.DURATION),
     WRITE_BYTES("gcs.analytics-core.client.write.size", MetricType.COUNTER),
     WRITE_DURATION("gcs.analytics-core.client.write.duration", MetricType.DURATION),
-    WRITE_CREATE_DURATION("gcs.analytics-core.client.write.create.duration", MetricType.DURATION),
+    CREATE_DURATION("gcs.analytics-core.client.write.create.duration", MetricType.DURATION),
     WRITE_CLOSE_DURATION("gcs.analytics-core.client.write.close.duration", MetricType.DURATION),
     GCS_CLIENT_CREATE_DURATION("gcs.analytics-core.client.create.duration", MetricType.DURATION);
 

--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageInputStream.java
@@ -171,8 +171,8 @@ public class GoogleCloudStorageInputStream extends SeekableInputStream {
     gcsFileSystem
         .getTelemetry()
         .measure(
-            Operation.CLOSE.name(),
-            Metric.CLOSE_DURATION,
+            Operation.READ_CLOSE.name(),
+            Metric.READ_CLOSE_DURATION,
             commonAttributes,
             recorder -> {
               if (!closed) {

--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStream.java
@@ -106,7 +106,7 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
         .getTelemetry()
         .measure(
             Operation.CREATE.name(),
-            Metric.WRITE_CREATE_DURATION,
+            Metric.CREATE_DURATION,
             COMMON_ATTRIBUTES,
             recorder -> {
               GcsWriteOptions writeOptions =

--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStream.java
@@ -22,12 +22,17 @@ import com.google.cloud.gcs.analyticscore.client.GcsFileInfo;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsItemId;
 import com.google.cloud.gcs.analyticscore.client.GcsWriteOptions;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Attribute;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Metric;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Operation;
 import com.google.cloud.storage.BlobId;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
+import java.util.Collections;
 
 /**
  * A unified OutputStream for writing objects to Google Cloud Storage.
@@ -41,6 +46,9 @@ import java.nio.channels.WritableByteChannel;
  */
 public class GoogleCloudStorageOutputStream extends OutputStream {
 
+  private static final ImmutableMap<String, String> COMMON_ATTRIBUTES =
+      ImmutableMap.of(Attribute.CLASS_NAME.name(), GoogleCloudStorageOutputStream.class.getName());
+  private final GcsFileSystem gcsFileSystem;
   private final WritableByteChannel channel;
 
   // Used for single-byte writes to avoid repeated allocation.
@@ -94,25 +102,51 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
       throws IOException {
     checkNotNull(gcsFileSystem, "GcsFileSystem shouldn't be null");
     checkNotNull(itemId, "GcsItemId shouldn't be null");
-    GcsWriteOptions writeOptions =
-        gcsFileSystem.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions();
-    WritableByteChannel channel = gcsFileSystem.create(itemId, writeOptions);
-    return new GoogleCloudStorageOutputStream(channel);
+    return gcsFileSystem
+        .getTelemetry()
+        .measure(
+            Operation.CREATE.name(),
+            Metric.WRITE_CREATE_DURATION,
+            ImmutableMap.of(
+                Attribute.CLASS_NAME.name(), GoogleCloudStorageOutputStream.class.getName()),
+            recorder -> {
+              GcsWriteOptions writeOptions =
+                  gcsFileSystem.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions();
+              WritableByteChannel channel = gcsFileSystem.create(itemId, writeOptions);
+              return new GoogleCloudStorageOutputStream(gcsFileSystem, channel);
+            });
   }
 
-  private GoogleCloudStorageOutputStream(WritableByteChannel channel) {
+  private GoogleCloudStorageOutputStream(GcsFileSystem gcsFileSystem, WritableByteChannel channel) {
+    checkNotNull(gcsFileSystem, "GcsFileSystem shouldn't be null");
     checkNotNull(channel, "WritableByteChannel shouldn't be null");
+    this.gcsFileSystem = gcsFileSystem;
     this.channel = channel;
   }
 
   @Override
   public void write(int b) throws IOException {
-    singleByteBuffer.clear();
-    singleByteBuffer.put((byte) b);
-    singleByteBuffer.flip();
-    while (singleByteBuffer.hasRemaining()) {
-      bytesWritten += channel.write(singleByteBuffer);
-    }
+    gcsFileSystem
+        .getTelemetry()
+        .measure(
+            Operation.WRITE.name(),
+            Metric.WRITE_DURATION,
+            COMMON_ATTRIBUTES,
+            recorder -> {
+              singleByteBuffer.clear();
+              singleByteBuffer.put((byte) b);
+              singleByteBuffer.flip();
+              int totalBytesWritten = 0;
+              while (singleByteBuffer.hasRemaining()) {
+                int written = channel.write(singleByteBuffer);
+                bytesWritten += written;
+                totalBytesWritten += written;
+              }
+              if (totalBytesWritten > 0) {
+                recorder.record(Metric.WRITE_BYTES, totalBytesWritten, Collections.emptyMap());
+              }
+              return null;
+            });
   }
 
   @Override
@@ -125,17 +159,40 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
       return;
     }
 
-    // Wrap the byte array and pass it to the GcsWriteChannel in the client module
-    ByteBuffer buffer = ByteBuffer.wrap(b, off, len);
-    while (buffer.hasRemaining()) {
-      bytesWritten += channel.write(buffer);
-    }
+    gcsFileSystem
+        .getTelemetry()
+        .measure(
+            Operation.WRITE.name(),
+            Metric.WRITE_DURATION,
+            COMMON_ATTRIBUTES,
+            recorder -> {
+              ByteBuffer buffer = ByteBuffer.wrap(b, off, len);
+              int totalBytesWritten = 0;
+              while (buffer.hasRemaining()) {
+                int written = channel.write(buffer);
+                bytesWritten += written;
+                totalBytesWritten += written;
+              }
+              if (totalBytesWritten > 0) {
+                recorder.record(Metric.WRITE_BYTES, totalBytesWritten, Collections.emptyMap());
+              }
+              return null;
+            });
   }
 
   @Override
   public void close() throws IOException {
     if (channel != null) {
-      channel.close();
+      gcsFileSystem
+          .getTelemetry()
+          .measure(
+              Operation.WRITE_CLOSE.name(),
+              Metric.WRITE_CLOSE_DURATION,
+              COMMON_ATTRIBUTES,
+              recorder -> {
+                channel.close();
+                return null;
+              });
     }
   }
 

--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStream.java
@@ -107,8 +107,7 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
         .measure(
             Operation.CREATE.name(),
             Metric.WRITE_CREATE_DURATION,
-            ImmutableMap.of(
-                Attribute.CLASS_NAME.name(), GoogleCloudStorageOutputStream.class.getName()),
+            COMMON_ATTRIBUTES,
             recorder -> {
               GcsWriteOptions writeOptions =
                   gcsFileSystem.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions();
@@ -142,9 +141,7 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
                 bytesWritten += written;
                 totalBytesWritten += written;
               }
-              if (totalBytesWritten > 0) {
-                recorder.record(Metric.WRITE_BYTES, totalBytesWritten, Collections.emptyMap());
-              }
+              recorder.record(Metric.WRITE_BYTES, totalBytesWritten, Collections.emptyMap());
               return null;
             });
   }
@@ -173,27 +170,23 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
                 bytesWritten += written;
                 totalBytesWritten += written;
               }
-              if (totalBytesWritten > 0) {
-                recorder.record(Metric.WRITE_BYTES, totalBytesWritten, Collections.emptyMap());
-              }
+              recorder.record(Metric.WRITE_BYTES, totalBytesWritten, Collections.emptyMap());
               return null;
             });
   }
 
   @Override
   public void close() throws IOException {
-    if (channel != null) {
-      gcsFileSystem
-          .getTelemetry()
-          .measure(
-              Operation.WRITE_CLOSE.name(),
-              Metric.WRITE_CLOSE_DURATION,
-              COMMON_ATTRIBUTES,
-              recorder -> {
-                channel.close();
-                return null;
-              });
-    }
+    gcsFileSystem
+        .getTelemetry()
+        .measure(
+            Operation.WRITE_CLOSE.name(),
+            Metric.WRITE_CLOSE_DURATION,
+            COMMON_ATTRIBUTES,
+            recorder -> {
+              channel.close();
+              return null;
+            });
   }
 
   /**

--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStream.java
@@ -53,7 +53,7 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
 
   // Used for single-byte writes to avoid repeated allocation.
   private final ByteBuffer singleByteBuffer = ByteBuffer.allocate(1);
-  private long bytesWritten = 0;
+  private long totalBytesWritten = 0;
 
   /**
    * Creates a new instance of {@link GoogleCloudStorageOutputStream} for the given file info.
@@ -135,13 +135,13 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
               singleByteBuffer.clear();
               singleByteBuffer.put((byte) b);
               singleByteBuffer.flip();
-              int totalBytesWritten = 0;
+              int bytesWrittenThisCall = 0;
               while (singleByteBuffer.hasRemaining()) {
                 int written = channel.write(singleByteBuffer);
-                bytesWritten += written;
                 totalBytesWritten += written;
+                bytesWrittenThisCall += written;
               }
-              recorder.record(Metric.WRITE_BYTES, totalBytesWritten, Collections.emptyMap());
+              recorder.record(Metric.WRITE_BYTES, bytesWrittenThisCall, Collections.emptyMap());
               return null;
             });
   }
@@ -164,13 +164,13 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
             COMMON_ATTRIBUTES,
             recorder -> {
               ByteBuffer buffer = ByteBuffer.wrap(b, off, len);
-              int totalBytesWritten = 0;
+              int bytesWrittenThisCall = 0;
               while (buffer.hasRemaining()) {
                 int written = channel.write(buffer);
-                bytesWritten += written;
                 totalBytesWritten += written;
+                bytesWrittenThisCall += written;
               }
-              recorder.record(Metric.WRITE_BYTES, totalBytesWritten, Collections.emptyMap());
+              recorder.record(Metric.WRITE_BYTES, bytesWrittenThisCall, Collections.emptyMap());
               return null;
             });
   }
@@ -196,6 +196,6 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
    * @return the number of bytes written to this stream
    */
   public long getBytesWritten() {
-    return bytesWritten;
+    return totalBytesWritten;
   }
 }

--- a/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStreamTest.java
+++ b/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStreamTest.java
@@ -67,7 +67,7 @@ class GoogleCloudStorageOutputStreamTest {
   }
 
   @Test
-  void write_recordsTelemetry() throws IOException {
+  void write_validData_recordsTelemetryMetrics() throws IOException {
     GcsFileSystem mockFileSystem = mock(GcsFileSystem.class);
     WritableByteChannel mockChannel = mock(WritableByteChannel.class);
     when(mockFileSystem.getFileSystemOptions()).thenReturn(fileSystemOptions);
@@ -101,7 +101,7 @@ class GoogleCloudStorageOutputStreamTest {
     stream.close();
 
     verify(mockTelemetry)
-        .measure(eq(Operation.CREATE.name()), eq(Metric.WRITE_CREATE_DURATION), any(), any());
+        .measure(eq(Operation.CREATE.name()), eq(Metric.CREATE_DURATION), any(), any());
     verify(mockTelemetry)
         .measure(eq(Operation.WRITE.name()), eq(Metric.WRITE_DURATION), any(), any());
     verify(mockTelemetry)

--- a/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStreamTest.java
+++ b/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStreamTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -32,6 +33,12 @@ import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsItemId;
 import com.google.cloud.gcs.analyticscore.client.GcsItemInfo;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Metric;
+import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Operation;
+import com.google.cloud.gcs.analyticscore.common.telemetry.MetricsRecorder;
+import com.google.cloud.gcs.analyticscore.common.telemetry.OperationSupplier;
+import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
+import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
@@ -57,6 +64,48 @@ class GoogleCloudStorageOutputStreamTest {
   void setUp() {
     fileSystemOptions = GcsFileSystemOptions.createFromOptions(Map.of(), "");
     fakeFileSystem = new FakeGcsFileSystemImpl(fileSystemOptions);
+  }
+
+  @Test
+  void write_recordsTelemetry() throws IOException {
+    GcsFileSystem mockFileSystem = mock(GcsFileSystem.class);
+    WritableByteChannel mockChannel = mock(WritableByteChannel.class);
+    when(mockFileSystem.getFileSystemOptions()).thenReturn(fileSystemOptions);
+    when(mockFileSystem.create(any(GcsItemId.class), any())).thenReturn(mockChannel);
+
+    Telemetry mockTelemetry = mock(Telemetry.class);
+    when(mockFileSystem.getTelemetry()).thenReturn(mockTelemetry);
+
+    when(mockChannel.write(any(ByteBuffer.class)))
+        .thenAnswer(
+            i -> {
+              ByteBuffer buf = i.getArgument(0);
+              int rem = buf.remaining();
+              buf.position(buf.position() + rem);
+              return rem;
+            });
+
+    // Stub measure to just execute the lambda and return its result
+    when(mockTelemetry.measure(any(), any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              MetricsRecorder recorder = mock(MetricsRecorder.class);
+              OperationSupplier closure = invocation.getArgument(3);
+              return closure.get(recorder);
+            });
+
+    GoogleCloudStorageOutputStream stream =
+        GoogleCloudStorageOutputStream.create(mockFileSystem, itemId);
+
+    stream.write(65);
+    stream.close();
+
+    verify(mockTelemetry)
+        .measure(eq(Operation.CREATE.name()), eq(Metric.WRITE_CREATE_DURATION), any(), any());
+    verify(mockTelemetry)
+        .measure(eq(Operation.WRITE.name()), eq(Metric.WRITE_DURATION), any(), any());
+    verify(mockTelemetry)
+        .measure(eq(Operation.WRITE_CLOSE.name()), eq(Metric.WRITE_CLOSE_DURATION), any(), any());
   }
 
   @Test
@@ -153,6 +202,7 @@ class GoogleCloudStorageOutputStreamTest {
   @Test
   void create_nullFileSystemOptions_throwsNullPointerException() {
     GcsFileSystem mockFileSystem = mock(GcsFileSystem.class);
+    when(mockFileSystem.getTelemetry()).thenReturn(new Telemetry(ImmutableList.of()));
     when(mockFileSystem.getFileSystemOptions()).thenReturn(null);
 
     assertThrows(
@@ -163,6 +213,7 @@ class GoogleCloudStorageOutputStreamTest {
   @Test
   void write_singleByte_partialWrites_loopsUntilFinished() throws IOException {
     GcsFileSystem mockFileSystem = mock(GcsFileSystem.class);
+    when(mockFileSystem.getTelemetry()).thenReturn(new Telemetry(ImmutableList.of()));
     WritableByteChannel mockChannel = mock(WritableByteChannel.class);
     when(mockFileSystem.getFileSystemOptions()).thenReturn(fileSystemOptions);
     when(mockFileSystem.create(any(GcsItemId.class), any())).thenReturn(mockChannel);
@@ -190,6 +241,7 @@ class GoogleCloudStorageOutputStreamTest {
   @Test
   void write_byteArray_partialWrites_loopsUntilFinished() throws IOException {
     GcsFileSystem mockFileSystem = mock(GcsFileSystem.class);
+    when(mockFileSystem.getTelemetry()).thenReturn(new Telemetry(ImmutableList.of()));
     WritableByteChannel mockChannel = mock(WritableByteChannel.class);
     when(mockFileSystem.getFileSystemOptions()).thenReturn(fileSystemOptions);
     when(mockFileSystem.create(any(GcsItemId.class), any())).thenReturn(mockChannel);
@@ -231,6 +283,7 @@ class GoogleCloudStorageOutputStreamTest {
   @Test
   void write_byteArray_zeroLength_doesNothing() throws IOException {
     GcsFileSystem mockFileSystem = mock(GcsFileSystem.class);
+    when(mockFileSystem.getTelemetry()).thenReturn(new Telemetry(ImmutableList.of()));
     WritableByteChannel mockChannel = mock(WritableByteChannel.class);
     when(mockFileSystem.getFileSystemOptions()).thenReturn(fileSystemOptions);
     when(mockFileSystem.create(any(GcsItemId.class), any())).thenReturn(mockChannel);
@@ -246,6 +299,7 @@ class GoogleCloudStorageOutputStreamTest {
   @Test
   void close_closesChannel() throws IOException {
     GcsFileSystem mockFileSystem = mock(GcsFileSystem.class);
+    when(mockFileSystem.getTelemetry()).thenReturn(new Telemetry(ImmutableList.of()));
     WritableByteChannel mockChannel = mock(WritableByteChannel.class);
     when(mockFileSystem.getFileSystemOptions()).thenReturn(fileSystemOptions);
     when(mockFileSystem.create(any(GcsItemId.class), any())).thenReturn(mockChannel);


### PR DESCRIPTION
## Type of Change

- [x] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [x] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [x] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
- Integrated telemetry tracking into `GoogleCloudStorageOutputStream` to measure durations and bytes for `CREATE`, `WRITE`, and `WRITE_CLOSE` operations.
- Added corresponding metric constants (`CREATE_DURATION`, `WRITE_DURATION`, `WRITE_CLOSE_DURATION`, etc.) to `GcsAnalyticsCoreTelemetryConstants`.
- Added relevant tests and updated others for telemetry changes. 

### Why?
- Providing comprehensive telemetry on write operations allows clients to accurately track latency, performance, and throughput (bytes written) during file uploads. 

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [x] All files include the Apache License 2.0 header
- [x] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? Yes*
