### PR TITLE
feat(core): Allow passing explicit GcsWriteOptions to GoogleCloudStorageOutputStream

### DIFF
--- a/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStream.java
+++ b/core/src/main/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStream.java
@@ -102,6 +102,27 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
       throws IOException {
     checkNotNull(gcsFileSystem, "GcsFileSystem shouldn't be null");
     checkNotNull(itemId, "GcsItemId shouldn't be null");
+    GcsWriteOptions writeOptions =
+        gcsFileSystem.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions();
+    return create(gcsFileSystem, itemId, writeOptions);
+  }
+
+  /**
+   * Creates a new instance of {@link GoogleCloudStorageOutputStream} for the given item ID using
+   * explicit write options.
+   *
+   * @param gcsFileSystem the file system client to use
+   * @param itemId the item ID identifying the object to write to
+   * @param writeOptions the specific write options to use for this stream
+   * @return a new output stream
+   * @throws IOException if an I/O error occurs
+   */
+  public static GoogleCloudStorageOutputStream create(
+      GcsFileSystem gcsFileSystem, GcsItemId itemId, GcsWriteOptions writeOptions)
+      throws IOException {
+    checkNotNull(gcsFileSystem, "GcsFileSystem shouldn't be null");
+    checkNotNull(itemId, "GcsItemId shouldn't be null");
+    checkNotNull(writeOptions, "GcsWriteOptions shouldn't be null");
     return gcsFileSystem
         .getTelemetry()
         .measure(
@@ -109,8 +130,6 @@ public class GoogleCloudStorageOutputStream extends OutputStream {
             Metric.CREATE_DURATION,
             COMMON_ATTRIBUTES,
             recorder -> {
-              GcsWriteOptions writeOptions =
-                  gcsFileSystem.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions();
               WritableByteChannel channel = gcsFileSystem.create(itemId, writeOptions);
               return new GoogleCloudStorageOutputStream(gcsFileSystem, channel);
             });

--- a/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStreamTest.java
+++ b/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStreamTest.java
@@ -151,12 +151,9 @@ class GoogleCloudStorageOutputStreamTest {
     GcsFileSystem mockFileSystem = mock(GcsFileSystem.class);
     WritableByteChannel mockChannel = mock(WritableByteChannel.class);
     when(mockFileSystem.getFileSystemOptions()).thenReturn(fileSystemOptions);
-
     GcsWriteOptions expectedOptions =
         GcsWriteOptions.builder().setChecksumValidationEnabled(true).build();
-
     when(mockFileSystem.create(eq(itemId), eq(expectedOptions))).thenReturn(mockChannel);
-
     Telemetry mockTelemetry = mock(Telemetry.class);
     when(mockFileSystem.getTelemetry()).thenReturn(mockTelemetry);
     when(mockTelemetry.measure(any(), any(), any(), any()))

--- a/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStreamTest.java
+++ b/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GoogleCloudStorageOutputStreamTest.java
@@ -33,6 +33,7 @@ import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsItemId;
 import com.google.cloud.gcs.analyticscore.client.GcsItemInfo;
+import com.google.cloud.gcs.analyticscore.client.GcsWriteOptions;
 import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Metric;
 import com.google.cloud.gcs.analyticscore.common.GcsAnalyticsCoreTelemetryConstants.Operation;
 import com.google.cloud.gcs.analyticscore.common.telemetry.MetricsRecorder;
@@ -146,6 +147,34 @@ class GoogleCloudStorageOutputStreamTest {
   }
 
   @Test
+  void create_withExplicitWriteOptions_usesProvidedOptions() throws IOException {
+    GcsFileSystem mockFileSystem = mock(GcsFileSystem.class);
+    WritableByteChannel mockChannel = mock(WritableByteChannel.class);
+    when(mockFileSystem.getFileSystemOptions()).thenReturn(fileSystemOptions);
+
+    GcsWriteOptions expectedOptions =
+        GcsWriteOptions.builder().setChecksumValidationEnabled(true).build();
+
+    when(mockFileSystem.create(eq(itemId), eq(expectedOptions))).thenReturn(mockChannel);
+
+    Telemetry mockTelemetry = mock(Telemetry.class);
+    when(mockFileSystem.getTelemetry()).thenReturn(mockTelemetry);
+    when(mockTelemetry.measure(any(), any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              MetricsRecorder recorder = mock(MetricsRecorder.class);
+              OperationSupplier closure = invocation.getArgument(3);
+              return closure.get(recorder);
+            });
+
+    GoogleCloudStorageOutputStream stream =
+        GoogleCloudStorageOutputStream.create(mockFileSystem, itemId, expectedOptions);
+
+    assertThat(stream).isNotNull();
+    verify(mockFileSystem).create(eq(itemId), eq(expectedOptions));
+  }
+
+  @Test
   void create_nullFileSystem_throwsNullPointerException() {
     var exception =
         assertThrows(
@@ -197,6 +226,15 @@ class GoogleCloudStorageOutputStreamTest {
             NullPointerException.class,
             () -> GoogleCloudStorageOutputStream.create(fakeFileSystem, (GcsItemId) null));
     assertThat(exception).hasMessageThat().isEqualTo("GcsItemId shouldn't be null");
+  }
+
+  @Test
+  void create_nullWriteOptions_throwsNullPointerException() {
+    var exception =
+        assertThrows(
+            NullPointerException.class,
+            () -> GoogleCloudStorageOutputStream.create(fakeFileSystem, itemId, null));
+    assertThat(exception).hasMessageThat().isEqualTo("GcsWriteOptions shouldn't be null");
   }
 
   @Test


### PR DESCRIPTION
## Type of Change

- [x] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
Added an overloaded `create` method in `GoogleCloudStorageOutputStream` that accepts `GcsWriteOptions` as an explicit parameter. The existing `create` method has been refactored to delegate to this new overload by default. Corresponding unit tests were added.

### Why?
Previously, `GoogleCloudStorageOutputStream.create` strictly extracted `GcsWriteOptions` from the global file system configuration. This restriction prevented integrating frameworks (like the Hadoop connector) from passing per-file dynamic configurations, such as overriding the `overwrite-existing` flag for a specific file write request.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [x] All files include the Apache License 2.0 header
- [x] Documentation has been updated to reflect changes (Javadoc added for the new API method)

---
*Generated/Assisted by Agent? Yes*
