### PR TITLE
feat: Add client methods and update DTO structures for getFileInfo 

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -46,6 +46,10 @@ limitations under the License.
             <artifactId>google-cloud-storage</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage-control</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClient.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClient.java
@@ -50,8 +50,11 @@ public interface GcsClient {
   /** Fetches folder metadata for HNS buckets. */
   GcsItemInfo getFolderInfo(GcsItemId itemId) throws IOException;
 
-  /** Lists objects in a bucket. */
-  List<GcsItemInfo> listObjectInfo(GcsItemId prefixId, int maxResults) throws IOException;
+  /**
+   * Fetches metadata for at most one object matching the given prefix without pagination. Optimized
+   * for fast directory emptiness checks.
+   */
+  List<GcsItemInfo> listFirstObjectWithPrefix(GcsItemId prefixId) throws IOException;
 
   boolean isHnsBucket(String bucketName) throws IOException;
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClient.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClient.java
@@ -18,6 +18,7 @@ package com.google.cloud.gcs.analyticscore.client;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
+import java.util.List;
 
 @VisibleForTesting
 public interface GcsClient {
@@ -50,7 +51,7 @@ public interface GcsClient {
   GcsItemInfo getFolderInfo(GcsItemId itemId) throws IOException;
 
   /** Lists objects in a bucket. */
-  java.util.List<GcsItemInfo> listObjectInfo(GcsItemId prefixId, int maxResults) throws IOException;
+  List<GcsItemInfo> listObjectInfo(GcsItemId prefixId, int maxResults) throws IOException;
 
   boolean isHnsBucket(String bucketName) throws IOException;
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClient.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClient.java
@@ -43,6 +43,15 @@ public interface GcsClient {
   /** Fetches object metadata. */
   GcsItemInfo getGcsItemInfo(GcsItemId itemId) throws IOException;
 
+  /** Fetches bucket metadata. */
+  GcsItemInfo getBucketInfo(GcsItemId itemId) throws IOException;
+
+  /** Fetches folder metadata for HNS buckets. */
+  GcsItemInfo getFolderInfo(GcsItemId itemId) throws IOException;
+
+  /** Lists objects in a bucket. */
+  java.util.List<GcsItemInfo> listObjectInfo(GcsItemId prefixId, int maxResults) throws IOException;
+
   boolean isHnsBucket(String bucketName) throws IOException;
 
   /** Close the client. */

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClient.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClient.java
@@ -18,7 +18,7 @@ package com.google.cloud.gcs.analyticscore.client;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
-import java.util.List;
+import java.util.Optional;
 
 @VisibleForTesting
 public interface GcsClient {
@@ -54,7 +54,7 @@ public interface GcsClient {
    * Fetches metadata for at most one object matching the given prefix without pagination. Optimized
    * for fast directory emptiness checks.
    */
-  List<GcsItemInfo> listFirstObjectWithPrefix(GcsItemId prefixId) throws IOException;
+  Optional<GcsItemInfo> listFirstObjectWithPrefix(GcsItemId prefixId) throws IOException;
 
   boolean isHnsBucket(String bucketName) throws IOException;
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -236,14 +236,16 @@ class GcsClientImpl implements GcsClient {
 
   @VisibleForTesting
   StorageControlClient lazyGetStorageControlClient() throws IOException {
-    if (this.storageControlClient == null) {
+    StorageControlClient result = this.storageControlClient;
+    if (result == null) {
       synchronized (this) {
-        if (this.storageControlClient == null) {
-          this.storageControlClient = createStorageControlClient(this.credentials);
+        result = this.storageControlClient;
+        if (result == null) {
+          this.storageControlClient = result = createStorageControlClient(this.credentials);
         }
       }
     }
-    return this.storageControlClient;
+    return result;
   }
 
   @VisibleForTesting

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -17,7 +17,6 @@ package com.google.cloud.gcs.analyticscore.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.paging.Page;
@@ -57,7 +56,6 @@ import java.nio.channels.WritableByteChannel;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
@@ -212,6 +210,12 @@ class GcsClientImpl implements GcsClient {
   @Override
   public GcsItemInfo getFolderInfo(GcsItemId itemId) throws IOException {
     checkNotNull(itemId, "Item ID must not be null.");
+    if (GcsItemId.ROOT.equals(itemId)) {
+      return GcsItemInfo.ROOT_INFO;
+    }
+    if (itemId.isBucket()) {
+      return getBucketInfo(itemId);
+    }
     checkArgument(itemId.isGcsObject(), "Expected a folder itemId");
     String objectName = itemId.getObjectName().orElse("");
     String folderName = UriUtil.removeTrailingSlash(objectName);
@@ -236,14 +240,19 @@ class GcsClientImpl implements GcsClient {
     if (this.storageControlClient == null) {
       synchronized (this) {
         if (this.storageControlClient == null) {
-          StorageControlSettings.Builder builder = StorageControlSettings.newBuilder();
-          this.credentials.ifPresent(
-              c -> builder.setCredentialsProvider(FixedCredentialsProvider.create(c)));
-          this.storageControlClient = StorageControlClient.create(builder.build());
+          this.storageControlClient = createStorageControlClient(this.credentials);
         }
       }
     }
     return this.storageControlClient;
+  }
+
+  @VisibleForTesting
+  protected StorageControlClient createStorageControlClient(Optional<Credentials> credentials)
+      throws IOException {
+    StorageControlSettings.Builder builder = StorageControlSettings.newBuilder();
+    credentials.ifPresent(c -> builder.setCredentialsProvider(FixedCredentialsProvider.create(c)));
+    return StorageControlClient.create(builder.build());
   }
 
   @Override
@@ -295,15 +304,7 @@ class GcsClientImpl implements GcsClient {
     Optional.ofNullable(blob.getContentEncoding()).ifPresent(infoBuilder::setContentEncoding);
     Optional.ofNullable(blob.getMetageneration()).ifPresent(infoBuilder::setMetaGeneration);
 
-    if (blob.getMetadata() != null) {
-      ImmutableMap.Builder<String, byte[]> xattrs = ImmutableMap.builder();
-      for (Map.Entry<String, String> entry : blob.getMetadata().entrySet()) {
-        if (entry.getValue() != null) {
-          xattrs.put(entry.getKey(), entry.getValue().getBytes(UTF_8));
-        }
-      }
-      infoBuilder.setExtendedAttributes(xattrs.build());
-    }
+    infoBuilder.setExtendedAttributes(GcsItemInfo.decodeMetadata(blob.getMetadata()));
 
     return infoBuilder.build();
   }
@@ -437,13 +438,6 @@ class GcsClientImpl implements GcsClient {
     }
   }
 
-  private static ImmutableMap<String, String> encodeMetadata(
-      ImmutableMap<String, byte[]> metadata) {
-    ImmutableMap.Builder<String, String> encoded = ImmutableMap.builder();
-    metadata.forEach((k, v) -> encoded.put(k, BaseEncoding.base64().encode(v)));
-    return encoded.build();
-  }
-
   private static BlobInfo createBlobInfo(GcsItemId itemId, GcsWriteOptions writeOptions) {
     checkNotNull(itemId, "itemId should not be null");
     String objectName =
@@ -465,7 +459,7 @@ class GcsClientImpl implements GcsClient {
               options.getContentEncoding().ifPresent(blobInfoBuilder::setContentEncoding);
               ImmutableMap<String, byte[]> metadata = options.getMetadata();
               if (!metadata.isEmpty()) {
-                blobInfoBuilder.setMetadata(encodeMetadata(metadata));
+                blobInfoBuilder.setMetadata(GcsItemInfo.encodeMetadata(metadata));
               }
             });
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -37,6 +37,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobField;
 import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.Storage.BucketField;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
@@ -78,6 +79,13 @@ class GcsClientImpl implements GcsClient {
           BlobField.MD5HASH,
           BlobField.CRC32C,
           BlobField.METADATA);
+  private static final List<BucketField> BUCKET_METADATA_FIELDS =
+      ImmutableList.of(
+          BucketField.NAME,
+          BucketField.LOCATION,
+          BucketField.METAGENERATION,
+          BucketField.TIME_CREATED,
+          BucketField.UPDATED);
   private static final String USER_AGENT_PREFIX = "gcs-analytics-core/";
 
   @VisibleForTesting Storage storage;
@@ -182,7 +190,19 @@ class GcsClientImpl implements GcsClient {
   public GcsItemInfo getBucketInfo(GcsItemId itemId) throws IOException {
     checkNotNull(itemId, "Item ID must not be null.");
     checkArgument(itemId.isBucket(), "Expected a bucket itemId");
-    BucketInfo bucketInfo = storage.get(itemId.getBucketName());
+    BucketInfo bucketInfo;
+    try {
+      bucketInfo =
+          storage.get(
+              itemId.getBucketName(),
+              Storage.BucketGetOption.fields(BUCKET_METADATA_FIELDS.toArray(new BucketField[0])));
+    } catch (StorageException e) {
+      if (e.getCode() == 404) {
+        bucketInfo = null;
+      } else {
+        throw new IOException("Unable to access bucket: " + itemId.getBucketName(), e);
+      }
+    }
     if (bucketInfo == null) {
       throw new FileNotFoundException("Bucket not found: " + itemId.getBucketName());
     }
@@ -253,7 +273,7 @@ class GcsClientImpl implements GcsClient {
     }
   }
 
-  private GcsItemInfo fromBlob(Blob blob) {
+  private static GcsItemInfo fromBlob(Blob blob) {
     GcsItemId.Builder idBuilder =
         GcsItemId.builder().setBucketName(blob.getBucket()).setObjectName(blob.getName());
     Optional.ofNullable(blob.getGeneration()).ifPresent(idBuilder::setContentGeneration);
@@ -290,7 +310,7 @@ class GcsClientImpl implements GcsClient {
     return infoBuilder.build();
   }
 
-  private GcsItemInfo fromBucketInfo(BucketInfo bucketInfo) {
+  private static GcsItemInfo fromBucketInfo(BucketInfo bucketInfo) {
     GcsItemId itemId = GcsItemId.builder().setBucketName(bucketInfo.getName()).build();
     GcsItemInfo.Builder builder =
         GcsItemInfo.createBucket(itemId).toBuilder()
@@ -302,7 +322,7 @@ class GcsClientImpl implements GcsClient {
     return builder.build();
   }
 
-  private GcsItemInfo fromFolder(Folder folder, GcsItemId itemId) {
+  private static GcsItemInfo fromFolder(Folder folder, GcsItemId itemId) {
     return GcsItemInfo.builder()
         .setItemId(itemId)
         .setSize(0)
@@ -426,7 +446,7 @@ class GcsClientImpl implements GcsClient {
     return encoded.build();
   }
 
-  private BlobInfo createBlobInfo(GcsItemId itemId, GcsWriteOptions writeOptions) {
+  private static BlobInfo createBlobInfo(GcsItemId itemId, GcsWriteOptions writeOptions) {
     checkNotNull(itemId, "itemId should not be null");
     String objectName =
         itemId

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -207,7 +207,7 @@ class GcsClientImpl implements GcsClient {
     } catch (NotFoundException e) {
       throw new FileNotFoundException("Folder not found: " + itemId);
     } catch (Exception e) {
-      throw new IOException("Folder not found: " + itemId, e);
+      throw new IOException("Failed to get folder info for: " + itemId, e);
     }
   }
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -18,8 +18,11 @@ package com.google.cloud.gcs.analyticscore.client;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.rpc.FixedHeaderProvider;
+import com.google.api.gax.rpc.NotFoundException;
 import com.google.auth.Credentials;
+import com.google.cloud.gcs.analyticscore.client.GcsItemInfo.ItemType;
 import com.google.cloud.gcs.analyticscore.client.GcsReadChannel.ItemInfoProvider;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.Blob;
@@ -37,8 +40,15 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
+import com.google.storage.control.v2.Folder;
+import com.google.storage.control.v2.FolderName;
+import com.google.storage.control.v2.GetFolderRequest;
+import com.google.storage.control.v2.StorageControlClient;
+import com.google.storage.control.v2.StorageControlSettings;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -48,13 +58,20 @@ import org.slf4j.LoggerFactory;
 class GcsClientImpl implements GcsClient {
   private static final Logger LOG = LoggerFactory.getLogger(GcsClientImpl.class);
   private static final List<Storage.BlobField> BLOB_METADATA_FIELDS =
-      ImmutableList.of(Storage.BlobField.GENERATION, Storage.BlobField.SIZE);
+      ImmutableList.of(
+          Storage.BlobField.GENERATION,
+          Storage.BlobField.SIZE,
+          Storage.BlobField.TIME_CREATED,
+          Storage.BlobField.UPDATED,
+          Storage.BlobField.METADATA);
   private static final String USER_AGENT_PREFIX = "gcs-analytics-core/";
 
   @VisibleForTesting Storage storage;
   private final GcsClientOptions clientOptions;
+  private final Optional<Credentials> credentials;
   private Supplier<ExecutorService> executorServiceSupplier;
   private final Telemetry telemetry;
+  private StorageControlClient storageControlClient;
 
   GcsClientImpl(
       Credentials credentials,
@@ -77,6 +94,7 @@ class GcsClientImpl implements GcsClient {
       Supplier<ExecutorService> executorServiceSupplier,
       Telemetry telemetry) {
     this.clientOptions = clientOptions;
+    this.credentials = credentials;
     this.executorServiceSupplier = executorServiceSupplier;
     this.telemetry = telemetry;
     this.storage = createStorage(credentials);
@@ -146,6 +164,145 @@ class GcsClientImpl implements GcsClient {
         String.format("Expected gcs object but got %s", itemId));
   }
 
+  @Override
+  public GcsItemInfo getBucketInfo(GcsItemId itemId) throws IOException {
+    checkNotNull(itemId, "Item ID must not be null.");
+    checkArgument(itemId.isBucket(), "Expected a bucket itemId");
+    BucketInfo bucketInfo = storage.get(itemId.getBucketName());
+    if (bucketInfo == null) {
+      throw new FileNotFoundException("Bucket not found: " + itemId.getBucketName());
+    }
+    return fromBucketInfo(bucketInfo);
+  }
+
+  @Override
+  public GcsItemInfo getFolderInfo(GcsItemId itemId) throws IOException {
+    checkNotNull(itemId, "Item ID must not be null.");
+    checkArgument(itemId.isGcsObject(), "Expected a folder itemId");
+    String objectName = itemId.getObjectName().orElse("");
+    String folderName = UriUtil.removeTrailingSlash(objectName);
+
+    GetFolderRequest request =
+        GetFolderRequest.newBuilder()
+            .setName(FolderName.format("_", itemId.getBucketName(), folderName))
+            .build();
+    try {
+      Folder folder = lazyGetStorageControlClient().getFolder(request);
+      return fromFolder(folder, itemId);
+    } catch (NotFoundException e) {
+      throw new FileNotFoundException("Folder not found: " + itemId);
+    } catch (Exception e) {
+      throw new IOException("Folder not found: " + itemId, e);
+    }
+  }
+
+  @VisibleForTesting
+  StorageControlClient lazyGetStorageControlClient() throws IOException {
+    if (this.storageControlClient == null) {
+      StorageControlSettings.Builder builder = StorageControlSettings.newBuilder();
+      this.credentials.ifPresent(
+          c -> builder.setCredentialsProvider(FixedCredentialsProvider.create(c)));
+      this.storageControlClient = StorageControlClient.create(builder.build());
+    }
+    return this.storageControlClient;
+  }
+
+  @Override
+  public java.util.List<GcsItemInfo> listObjectInfo(GcsItemId prefixId, int maxResults)
+      throws IOException {
+    String prefix = prefixId.getObjectName().orElse("");
+    com.google.api.gax.paging.Page<Blob> page =
+        storage.list(
+            prefixId.getBucketName(),
+            Storage.BlobListOption.prefix(prefix),
+            Storage.BlobListOption.pageSize(maxResults),
+            Storage.BlobListOption.fields(BLOB_METADATA_FIELDS.toArray(new Storage.BlobField[0])));
+
+    ImmutableList.Builder<GcsItemInfo> builder = ImmutableList.builder();
+    for (Blob blob : page.iterateAll()) {
+      builder.add(fromBlob(blob));
+      if (builder.build().size() >= maxResults && maxResults > 0) {
+        break;
+      }
+    }
+    return builder.build();
+  }
+
+  private GcsItemInfo fromBlob(Blob blob) {
+    GcsItemId id =
+        GcsItemId.builder()
+            .setContentGeneration(blob.getGeneration())
+            .setBucketName(blob.getBucket())
+            .setObjectName(blob.getName())
+            .build();
+    GcsItemInfo.Builder infoBuilder =
+        GcsItemInfo.builder()
+            .setItemId(id)
+            .setSize(blob.getSize())
+            .setContentGeneration(blob.getGeneration())
+            .setCreationTime(toEpochMilli(blob.getCreateTimeOffsetDateTime()))
+            .setModificationTime(toEpochMilli(blob.getUpdateTimeOffsetDateTime()))
+            .setVerificationAttributes(
+                VerificationAttributes.create(
+                    blob.getMd5() != null ? BaseEncoding.base64().decode(blob.getMd5()) : null,
+                    blob.getCrc32c() != null
+                        ? BaseEncoding.base64().decode(blob.getCrc32c())
+                        : null));
+
+    Optional.ofNullable(blob.getContentType()).ifPresent(infoBuilder::setContentType);
+    Optional.ofNullable(blob.getContentEncoding()).ifPresent(infoBuilder::setContentEncoding);
+    Optional.ofNullable(blob.getStorageClass())
+        .ifPresent(sc -> infoBuilder.setStorageClass(sc.name()));
+
+    if (blob.getMetadata() != null) {
+      ImmutableMap.Builder<String, byte[]> xattrs = ImmutableMap.builder();
+      for (java.util.Map.Entry<String, String> entry : blob.getMetadata().entrySet()) {
+        if (entry.getValue() != null) {
+          xattrs.put(
+              entry.getKey(), entry.getValue().getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        }
+      }
+      infoBuilder.setExtendedAttributes(xattrs.build());
+    }
+
+    return infoBuilder.build();
+  }
+
+  private GcsItemInfo fromBucketInfo(BucketInfo bucketInfo) {
+    GcsItemId itemId = GcsItemId.builder().setBucketName(bucketInfo.getName()).build();
+    GcsItemInfo.Builder builder =
+        GcsItemInfo.createBucket(itemId).toBuilder()
+            .setCreationTime(toEpochMilli(bucketInfo.getCreateTimeOffsetDateTime()))
+            .setModificationTime(toEpochMilli(bucketInfo.getUpdateTimeOffsetDateTime()));
+
+    Optional.ofNullable(bucketInfo.getLocation()).ifPresent(builder::setLocation);
+    Optional.ofNullable(bucketInfo.getStorageClass())
+        .ifPresent(sc -> builder.setStorageClass(sc.name()));
+    Optional.ofNullable(bucketInfo.getMetageneration()).ifPresent(builder::setMetaGeneration);
+    return builder.build();
+  }
+
+  private GcsItemInfo fromFolder(Folder folder, GcsItemId itemId) {
+    return GcsItemInfo.builder()
+        .setItemId(itemId)
+        .setSize(0)
+        .setItemType(ItemType.EXPLICIT_DIRECTORY)
+        .setCreationTime(folder.hasCreateTime() ? toEpochMilli(folder.getCreateTime()) : 0L)
+        .setModificationTime(folder.hasUpdateTime() ? toEpochMilli(folder.getUpdateTime()) : 0L)
+        .setMetaGeneration(folder.getMetageneration())
+        .build();
+  }
+
+  private static long toEpochMilli(java.time.OffsetDateTime dateTime) {
+    return dateTime != null ? dateTime.toInstant().toEpochMilli() : 0L;
+  }
+
+  private static long toEpochMilli(com.google.protobuf.Timestamp timestamp) {
+    return timestamp != null
+        ? Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos()).toEpochMilli()
+        : 0L;
+  }
+
   BucketProperties getBucketProperties(String bucketName) throws IOException {
     checkNotNull(bucketName, "bucketName cannot be null");
     try {
@@ -183,6 +340,13 @@ class GcsClientImpl implements GcsClient {
     } catch (Exception e) {
       LOG.debug("Exception while closing storage instance", e);
     }
+    if (storageControlClient != null) {
+      try {
+        storageControlClient.close();
+      } catch (Exception e) {
+        LOG.debug("Exception while closing storageControlClient", e);
+      }
+    }
   }
 
   @VisibleForTesting
@@ -217,19 +381,9 @@ class GcsClientImpl implements GcsClient {
     checkArgument(itemId.isGcsObject(), String.format("Expected gcs object got %s", itemId));
     Blob blob = getBlob(itemId.getBucketName(), itemId.getObjectName().get());
     if (blob == null) {
-      throw new IOException("Object not found:" + itemId);
+      throw new FileNotFoundException("Object not found: " + itemId);
     }
-    GcsItemId itemIdWithGeneration =
-        GcsItemId.builder()
-            .setContentGeneration(blob.getGeneration())
-            .setBucketName(blob.getBucket())
-            .setObjectName(blob.getName())
-            .build();
-    return GcsItemInfo.builder()
-        .setItemId(itemIdWithGeneration)
-        .setSize(blob.getSize())
-        .setContentGeneration(blob.getGeneration())
-        .build();
+    return fromBlob(blob);
   }
 
   private Blob getBlob(String bucketName, String objectName) throws IOException {

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -215,6 +215,7 @@ class GcsClientImpl implements GcsClient {
     checkArgument(itemId.isGcsObject(), "Expected a folder itemId");
     String objectName = itemId.getObjectName().orElse("");
     String folderName = UriUtil.removeTrailingSlash(objectName);
+    checkArgument(!folderName.isEmpty(), "Folder name cannot be empty");
 
     GetFolderRequest request =
         GetFolderRequest.newBuilder()

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -40,8 +40,8 @@ import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.io.BaseEncoding;
 import com.google.protobuf.Timestamp;
 import com.google.storage.control.v2.Folder;
@@ -54,7 +54,6 @@ import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
@@ -62,27 +61,30 @@ import org.slf4j.LoggerFactory;
 
 class GcsClientImpl implements GcsClient {
   private static final Logger LOG = LoggerFactory.getLogger(GcsClientImpl.class);
-  private static final List<BlobField> BLOB_METADATA_FIELDS =
-      ImmutableList.of(
-          BlobField.NAME,
-          BlobField.BUCKET,
-          BlobField.GENERATION,
-          BlobField.METAGENERATION,
-          BlobField.SIZE,
-          BlobField.CONTENT_TYPE,
-          BlobField.CONTENT_ENCODING,
-          BlobField.TIME_CREATED,
-          BlobField.UPDATED,
-          BlobField.MD5HASH,
-          BlobField.CRC32C,
-          BlobField.METADATA);
-  private static final List<BucketField> BUCKET_METADATA_FIELDS =
-      ImmutableList.of(
-          BucketField.NAME,
-          BucketField.LOCATION,
-          BucketField.METAGENERATION,
-          BucketField.TIME_CREATED,
-          BucketField.UPDATED);
+  private static final BlobField[] BLOB_METADATA_FIELDS_ARRAY =
+      new BlobField[] {
+        BlobField.NAME,
+        BlobField.BUCKET,
+        BlobField.GENERATION,
+        BlobField.METAGENERATION,
+        BlobField.SIZE,
+        BlobField.CONTENT_TYPE,
+        BlobField.CONTENT_ENCODING,
+        BlobField.TIME_CREATED,
+        BlobField.UPDATED,
+        BlobField.MD5HASH,
+        BlobField.CRC32C,
+        BlobField.METADATA
+      };
+  private static final BucketField[] BUCKET_METADATA_FIELDS_ARRAY =
+      new BucketField[] {
+        BucketField.NAME,
+        BucketField.LOCATION,
+        BucketField.METAGENERATION,
+        BucketField.TIME_CREATED,
+        BucketField.UPDATED,
+        BucketField.STORAGE_CLASS
+      };
   private static final String USER_AGENT_PREFIX = "gcs-analytics-core/";
 
   @VisibleForTesting Storage storage;
@@ -91,6 +93,7 @@ class GcsClientImpl implements GcsClient {
   private Supplier<ExecutorService> executorServiceSupplier;
   private final Telemetry telemetry;
   @VisibleForTesting volatile StorageControlClient storageControlClient;
+  private volatile boolean isStorageControlClientClosed = false;
 
   GcsClientImpl(
       Credentials credentials,
@@ -191,8 +194,7 @@ class GcsClientImpl implements GcsClient {
     try {
       bucketInfo =
           storage.get(
-              itemId.getBucketName(),
-              Storage.BucketGetOption.fields(BUCKET_METADATA_FIELDS.toArray(new BucketField[0])));
+              itemId.getBucketName(), Storage.BucketGetOption.fields(BUCKET_METADATA_FIELDS_ARRAY));
     } catch (StorageException e) {
       if (e.getCode() == 404) {
         bucketInfo = null;
@@ -236,9 +238,15 @@ class GcsClientImpl implements GcsClient {
 
   @VisibleForTesting
   StorageControlClient lazyGetStorageControlClient() throws IOException {
+    if (isStorageControlClientClosed) {
+      throw new IOException("StorageControlClient is closed");
+    }
     StorageControlClient result = this.storageControlClient;
     if (result == null) {
       synchronized (this) {
+        if (isStorageControlClientClosed) {
+          throw new IOException("StorageControlClient is closed");
+        }
         result = this.storageControlClient;
         if (result == null) {
           this.storageControlClient = result = createStorageControlClient(this.credentials);
@@ -257,7 +265,7 @@ class GcsClientImpl implements GcsClient {
   }
 
   @Override
-  public List<GcsItemInfo> listFirstObjectWithPrefix(GcsItemId prefixId) throws IOException {
+  public Optional<GcsItemInfo> listFirstObjectWithPrefix(GcsItemId prefixId) throws IOException {
     checkNotNull(prefixId, "prefixId must not be null");
     String prefix = prefixId.getObjectName().orElse("");
 
@@ -267,12 +275,10 @@ class GcsClientImpl implements GcsClient {
               prefixId.getBucketName(),
               BlobListOption.prefix(prefix),
               BlobListOption.pageSize(1),
-              BlobListOption.fields(BLOB_METADATA_FIELDS.toArray(new BlobField[0])));
+              BlobListOption.fields(BLOB_METADATA_FIELDS_ARRAY));
 
-      for (Blob blob : page.getValues()) {
-        return ImmutableList.of(fromBlob(blob));
-      }
-      return ImmutableList.of();
+      Blob blob = Iterables.getFirst(page.getValues(), null);
+      return Optional.ofNullable(blob).map(b -> fromBlob(b));
     } catch (StorageException e) {
       if (e.getCode() == 404) {
         throw new FileNotFoundException("Bucket not found: " + prefixId.getBucketName());
@@ -292,13 +298,14 @@ class GcsClientImpl implements GcsClient {
             .setItemId(id)
             .setSize(blob.getSize() == null ? 0L : blob.getSize())
             .setCreationTime(toEpochMilli(blob.getCreateTimeOffsetDateTime()))
-            .setModificationTime(toEpochMilli(blob.getUpdateTimeOffsetDateTime()))
-            .setVerificationAttributes(
-                VerificationAttributes.create(
-                    blob.getMd5() != null ? BaseEncoding.base64().decode(blob.getMd5()) : null,
-                    blob.getCrc32c() != null
-                        ? BaseEncoding.base64().decode(blob.getCrc32c())
-                        : null));
+            .setModificationTime(toEpochMilli(blob.getUpdateTimeOffsetDateTime()));
+
+    if (blob.getMd5() != null || blob.getCrc32c() != null) {
+      infoBuilder.setVerificationAttributes(
+          VerificationAttributes.create(
+              blob.getMd5() != null ? BaseEncoding.base64().decode(blob.getMd5()) : null,
+              blob.getCrc32c() != null ? BaseEncoding.base64().decode(blob.getCrc32c()) : null));
+    }
 
     Optional.ofNullable(blob.getGeneration()).ifPresent(infoBuilder::setContentGeneration);
     Optional.ofNullable(blob.getContentType()).ifPresent(infoBuilder::setContentType);
@@ -322,6 +329,9 @@ class GcsClientImpl implements GcsClient {
             .setModificationTime(toEpochMilli(bucketInfo.getUpdateTimeOffsetDateTime()));
 
     Optional.ofNullable(bucketInfo.getLocation()).ifPresent(builder::setLocation);
+    Optional.ofNullable(bucketInfo.getStorageClass())
+        .map(Object::toString)
+        .ifPresent(builder::setStorageClass);
     Optional.ofNullable(bucketInfo.getMetageneration()).ifPresent(builder::setMetaGeneration);
     return builder.build();
   }
@@ -382,13 +392,16 @@ class GcsClientImpl implements GcsClient {
       LOG.debug("Exception while closing storage instance", e);
     }
     synchronized (this) {
+      if (isStorageControlClientClosed) {
+        return;
+      }
+      isStorageControlClientClosed = true;
       if (storageControlClient != null) {
         try {
           storageControlClient.close();
         } catch (Exception e) {
           LOG.debug("Exception while closing storageControlClient", e);
         }
-        storageControlClient = null;
       }
     }
   }
@@ -435,9 +448,7 @@ class GcsClientImpl implements GcsClient {
     checkNotNull(objectName);
     BlobId blobId = BlobId.of(bucketName, objectName);
     try {
-      return storage.get(
-          blobId,
-          Storage.BlobGetOption.fields(BLOB_METADATA_FIELDS.toArray(new Storage.BlobField[0])));
+      return storage.get(blobId, Storage.BlobGetOption.fields(BLOB_METADATA_FIELDS_ARRAY));
     } catch (StorageException storageException) {
       throw new IOException("Unable to access blob :" + blobId, storageException);
     }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -17,8 +17,10 @@ package com.google.cloud.gcs.analyticscore.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.paging.Page;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.api.gax.rpc.NotFoundException;
 import com.google.auth.Credentials;
@@ -32,6 +34,8 @@ import com.google.cloud.storage.BlobWriteSession;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.BucketInfo.HierarchicalNamespace;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobField;
+import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
@@ -40,6 +44,7 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
+import com.google.protobuf.Timestamp;
 import com.google.storage.control.v2.Folder;
 import com.google.storage.control.v2.FolderName;
 import com.google.storage.control.v2.GetFolderRequest;
@@ -49,7 +54,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
@@ -57,13 +64,13 @@ import org.slf4j.LoggerFactory;
 
 class GcsClientImpl implements GcsClient {
   private static final Logger LOG = LoggerFactory.getLogger(GcsClientImpl.class);
-  private static final List<Storage.BlobField> BLOB_METADATA_FIELDS =
+  private static final List<BlobField> BLOB_METADATA_FIELDS =
       ImmutableList.of(
-          Storage.BlobField.GENERATION,
-          Storage.BlobField.SIZE,
-          Storage.BlobField.TIME_CREATED,
-          Storage.BlobField.UPDATED,
-          Storage.BlobField.METADATA);
+          BlobField.GENERATION,
+          BlobField.SIZE,
+          BlobField.TIME_CREATED,
+          BlobField.UPDATED,
+          BlobField.METADATA);
   private static final String USER_AGENT_PREFIX = "gcs-analytics-core/";
 
   @VisibleForTesting Storage storage;
@@ -208,15 +215,14 @@ class GcsClientImpl implements GcsClient {
   }
 
   @Override
-  public java.util.List<GcsItemInfo> listObjectInfo(GcsItemId prefixId, int maxResults)
-      throws IOException {
+  public List<GcsItemInfo> listObjectInfo(GcsItemId prefixId, int maxResults) throws IOException {
     String prefix = prefixId.getObjectName().orElse("");
-    com.google.api.gax.paging.Page<Blob> page =
+    Page<Blob> page =
         storage.list(
             prefixId.getBucketName(),
-            Storage.BlobListOption.prefix(prefix),
-            Storage.BlobListOption.pageSize(maxResults),
-            Storage.BlobListOption.fields(BLOB_METADATA_FIELDS.toArray(new Storage.BlobField[0])));
+            BlobListOption.prefix(prefix),
+            BlobListOption.pageSize(maxResults),
+            BlobListOption.fields(BLOB_METADATA_FIELDS.toArray(new BlobField[0])));
 
     ImmutableList.Builder<GcsItemInfo> builder = ImmutableList.builder();
     for (Blob blob : page.iterateAll()) {
@@ -256,10 +262,9 @@ class GcsClientImpl implements GcsClient {
 
     if (blob.getMetadata() != null) {
       ImmutableMap.Builder<String, byte[]> xattrs = ImmutableMap.builder();
-      for (java.util.Map.Entry<String, String> entry : blob.getMetadata().entrySet()) {
+      for (Map.Entry<String, String> entry : blob.getMetadata().entrySet()) {
         if (entry.getValue() != null) {
-          xattrs.put(
-              entry.getKey(), entry.getValue().getBytes(java.nio.charset.StandardCharsets.UTF_8));
+          xattrs.put(entry.getKey(), entry.getValue().getBytes(UTF_8));
         }
       }
       infoBuilder.setExtendedAttributes(xattrs.build());
@@ -293,11 +298,11 @@ class GcsClientImpl implements GcsClient {
         .build();
   }
 
-  private static long toEpochMilli(java.time.OffsetDateTime dateTime) {
+  private static long toEpochMilli(OffsetDateTime dateTime) {
     return dateTime != null ? dateTime.toInstant().toEpochMilli() : 0L;
   }
 
-  private static long toEpochMilli(com.google.protobuf.Timestamp timestamp) {
+  private static long toEpochMilli(Timestamp timestamp) {
     return timestamp != null
         ? Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos()).toEpochMilli()
         : 0L;

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -201,7 +201,7 @@ class GcsClientImpl implements GcsClient {
       }
     }
     if (bucketInfo == null) {
-      throw new FileNotFoundException("Bucket not found: " + itemId.getBucketName());
+      return GcsItemInfo.createNotFound(itemId);
     }
     return fromBucketInfo(bucketInfo);
   }
@@ -228,7 +228,7 @@ class GcsClientImpl implements GcsClient {
       Folder folder = lazyGetStorageControlClient().getFolder(request);
       return fromFolder(folder, itemId);
     } catch (NotFoundException e) {
-      throw new FileNotFoundException("Folder not found: " + itemId);
+      return GcsItemInfo.createNotFound(itemId);
     } catch (Exception e) {
       throw new IOException("Failed to get folder info for: " + itemId, e);
     }
@@ -425,7 +425,7 @@ class GcsClientImpl implements GcsClient {
     checkArgument(itemId.isGcsObject(), String.format("Expected gcs object got %s", itemId));
     Blob blob = getBlob(itemId.getBucketName(), itemId.getObjectName().get());
     if (blob == null) {
-      throw new FileNotFoundException("Object not found: " + itemId);
+      return GcsItemInfo.createNotFound(itemId);
     }
     return fromBlob(blob);
   }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -23,7 +23,6 @@ import com.google.api.gax.paging.Page;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.api.gax.rpc.NotFoundException;
 import com.google.auth.Credentials;
-import com.google.cloud.gcs.analyticscore.client.GcsItemInfo.ItemType;
 import com.google.cloud.gcs.analyticscore.client.GcsReadChannel.ItemInfoProvider;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
 import com.google.cloud.storage.Blob;
@@ -325,9 +324,9 @@ class GcsClientImpl implements GcsClient {
     return GcsItemInfo.builder()
         .setItemId(itemId)
         .setSize(0)
-        .setItemType(ItemType.EXPLICIT_DIRECTORY)
-        .setCreationTime(folder.hasCreateTime() ? toEpochMilli(folder.getCreateTime()) : 0L)
-        .setModificationTime(folder.hasUpdateTime() ? toEpochMilli(folder.getUpdateTime()) : 0L)
+        .setItemType(GcsItemInfo.ItemType.EXPLICIT_DIRECTORY)
+        .setCreationTime(toEpochMilli(folder.hasCreateTime() ? folder.getCreateTime() : null))
+        .setModificationTime(toEpochMilli(folder.hasUpdateTime() ? folder.getUpdateTime() : null))
         .setMetaGeneration(folder.getMetageneration())
         .build();
   }
@@ -379,11 +378,14 @@ class GcsClientImpl implements GcsClient {
     } catch (Exception e) {
       LOG.debug("Exception while closing storage instance", e);
     }
-    if (storageControlClient != null) {
-      try {
-        storageControlClient.close();
-      } catch (Exception e) {
-        LOG.debug("Exception while closing storageControlClient", e);
+    synchronized (this) {
+      if (storageControlClient != null) {
+        try {
+          storageControlClient.close();
+        } catch (Exception e) {
+          LOG.debug("Exception while closing storageControlClient", e);
+        }
+        storageControlClient = null;
       }
     }
   }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -305,6 +305,10 @@ class GcsClientImpl implements GcsClient {
     Optional.ofNullable(blob.getContentEncoding()).ifPresent(infoBuilder::setContentEncoding);
     Optional.ofNullable(blob.getMetageneration()).ifPresent(infoBuilder::setMetaGeneration);
 
+    if (blob.isDirectory()) {
+      infoBuilder.setItemType(GcsItemInfo.ItemType.PLACEHOLDER_DIRECTORY);
+    }
+
     infoBuilder.setExtendedAttributes(GcsItemInfo.decodeMetadata(blob.getMetadata()));
 
     return infoBuilder.build();
@@ -323,14 +327,11 @@ class GcsClientImpl implements GcsClient {
   }
 
   private static GcsItemInfo fromFolder(Folder folder, GcsItemId itemId) {
-    return GcsItemInfo.builder()
-        .setItemId(itemId)
-        .setSize(0)
-        .setItemType(GcsItemInfo.ItemType.EXPLICIT_DIRECTORY)
-        .setCreationTime(toEpochMilli(folder.hasCreateTime() ? folder.getCreateTime() : null))
-        .setModificationTime(toEpochMilli(folder.hasUpdateTime() ? folder.getUpdateTime() : null))
-        .setMetaGeneration(folder.getMetageneration())
-        .build();
+    return GcsItemInfo.createFolder(
+        itemId,
+        toEpochMilli(folder.hasCreateTime() ? folder.getCreateTime() : null),
+        toEpochMilli(folder.hasUpdateTime() ? folder.getUpdateTime() : null),
+        folder.getMetageneration());
   }
 
   private static long toEpochMilli(OffsetDateTime dateTime) {

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -209,7 +209,7 @@ class GcsClientImpl implements GcsClient {
   @Override
   public GcsItemInfo getFolderInfo(GcsItemId itemId) throws IOException {
     checkNotNull(itemId, "Item ID must not be null.");
-    if (GcsItemId.ROOT.equals(itemId)) {
+    if (itemId.isRoot()) {
       return GcsItemInfo.ROOT_INFO;
     }
     if (itemId.isBucket()) {

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -247,9 +247,8 @@ class GcsClientImpl implements GcsClient {
   }
 
   @Override
-  public List<GcsItemInfo> listObjectInfo(GcsItemId prefixId, int maxResults) throws IOException {
+  public List<GcsItemInfo> listFirstObjectWithPrefix(GcsItemId prefixId) throws IOException {
     checkNotNull(prefixId, "prefixId must not be null");
-    checkArgument(maxResults > 0, "maxResults must be > 0");
     String prefix = prefixId.getObjectName().orElse("");
 
     try {
@@ -257,24 +256,18 @@ class GcsClientImpl implements GcsClient {
           storage.list(
               prefixId.getBucketName(),
               BlobListOption.prefix(prefix),
-              BlobListOption.pageSize(maxResults),
+              BlobListOption.pageSize(1),
               BlobListOption.fields(BLOB_METADATA_FIELDS.toArray(new BlobField[0])));
 
-      ImmutableList.Builder<GcsItemInfo> builder = ImmutableList.builder();
-      int count = 0;
-      for (Blob blob : page.iterateAll()) {
-        builder.add(fromBlob(blob));
-        count++;
-        if (count >= maxResults) {
-          break;
-        }
+      for (Blob blob : page.getValues()) {
+        return ImmutableList.of(fromBlob(blob));
       }
-      return builder.build();
+      return ImmutableList.of();
     } catch (StorageException e) {
       if (e.getCode() == 404) {
         throw new FileNotFoundException("Bucket not found: " + prefixId.getBucketName());
       }
-      throw new IOException("Failed to list objects for prefix: " + prefixId, e);
+      throw new IOException("Failed to list the first object for prefix: " + prefixId, e);
     }
   }
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -73,7 +73,6 @@ class GcsClientImpl implements GcsClient {
           BlobField.SIZE,
           BlobField.CONTENT_TYPE,
           BlobField.CONTENT_ENCODING,
-          BlobField.STORAGE_CLASS,
           BlobField.TIME_CREATED,
           BlobField.UPDATED,
           BlobField.MD5HASH,
@@ -255,17 +254,15 @@ class GcsClientImpl implements GcsClient {
   }
 
   private GcsItemInfo fromBlob(Blob blob) {
-    GcsItemId id =
-        GcsItemId.builder()
-            .setContentGeneration(blob.getGeneration())
-            .setBucketName(blob.getBucket())
-            .setObjectName(blob.getName())
-            .build();
+    GcsItemId.Builder idBuilder =
+        GcsItemId.builder().setBucketName(blob.getBucket()).setObjectName(blob.getName());
+    Optional.ofNullable(blob.getGeneration()).ifPresent(idBuilder::setContentGeneration);
+    GcsItemId id = idBuilder.build();
+
     GcsItemInfo.Builder infoBuilder =
         GcsItemInfo.builder()
             .setItemId(id)
-            .setSize(blob.getSize())
-            .setContentGeneration(blob.getGeneration())
+            .setSize(blob.getSize() == null ? 0L : blob.getSize())
             .setCreationTime(toEpochMilli(blob.getCreateTimeOffsetDateTime()))
             .setModificationTime(toEpochMilli(blob.getUpdateTimeOffsetDateTime()))
             .setVerificationAttributes(
@@ -275,10 +272,9 @@ class GcsClientImpl implements GcsClient {
                         ? BaseEncoding.base64().decode(blob.getCrc32c())
                         : null));
 
+    Optional.ofNullable(blob.getGeneration()).ifPresent(infoBuilder::setContentGeneration);
     Optional.ofNullable(blob.getContentType()).ifPresent(infoBuilder::setContentType);
     Optional.ofNullable(blob.getContentEncoding()).ifPresent(infoBuilder::setContentEncoding);
-    Optional.ofNullable(blob.getStorageClass())
-        .ifPresent(sc -> infoBuilder.setStorageClass(sc.name()));
     Optional.ofNullable(blob.getMetageneration()).ifPresent(infoBuilder::setMetaGeneration);
 
     if (blob.getMetadata() != null) {
@@ -302,8 +298,6 @@ class GcsClientImpl implements GcsClient {
             .setModificationTime(toEpochMilli(bucketInfo.getUpdateTimeOffsetDateTime()));
 
     Optional.ofNullable(bucketInfo.getLocation()).ifPresent(builder::setLocation);
-    Optional.ofNullable(bucketInfo.getStorageClass())
-        .ifPresent(sc -> builder.setStorageClass(sc.name()));
     Optional.ofNullable(bucketInfo.getMetageneration()).ifPresent(builder::setMetaGeneration);
     return builder.build();
   }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -66,10 +66,18 @@ class GcsClientImpl implements GcsClient {
   private static final Logger LOG = LoggerFactory.getLogger(GcsClientImpl.class);
   private static final List<BlobField> BLOB_METADATA_FIELDS =
       ImmutableList.of(
+          BlobField.NAME,
+          BlobField.BUCKET,
           BlobField.GENERATION,
+          BlobField.METAGENERATION,
           BlobField.SIZE,
+          BlobField.CONTENT_TYPE,
+          BlobField.CONTENT_ENCODING,
+          BlobField.STORAGE_CLASS,
           BlobField.TIME_CREATED,
           BlobField.UPDATED,
+          BlobField.MD5HASH,
+          BlobField.CRC32C,
           BlobField.METADATA);
   private static final String USER_AGENT_PREFIX = "gcs-analytics-core/";
 
@@ -78,7 +86,7 @@ class GcsClientImpl implements GcsClient {
   private final Optional<Credentials> credentials;
   private Supplier<ExecutorService> executorServiceSupplier;
   private final Telemetry telemetry;
-  private StorageControlClient storageControlClient;
+  @VisibleForTesting StorageControlClient storageControlClient;
 
   GcsClientImpl(
       Credentials credentials,
@@ -216,22 +224,34 @@ class GcsClientImpl implements GcsClient {
 
   @Override
   public List<GcsItemInfo> listObjectInfo(GcsItemId prefixId, int maxResults) throws IOException {
+    checkNotNull(prefixId, "prefixId must not be null");
+    checkArgument(maxResults > 0, "maxResults must be > 0");
     String prefix = prefixId.getObjectName().orElse("");
-    Page<Blob> page =
-        storage.list(
-            prefixId.getBucketName(),
-            BlobListOption.prefix(prefix),
-            BlobListOption.pageSize(maxResults),
-            BlobListOption.fields(BLOB_METADATA_FIELDS.toArray(new BlobField[0])));
 
-    ImmutableList.Builder<GcsItemInfo> builder = ImmutableList.builder();
-    for (Blob blob : page.iterateAll()) {
-      builder.add(fromBlob(blob));
-      if (builder.build().size() >= maxResults && maxResults > 0) {
-        break;
+    try {
+      Page<Blob> page =
+          storage.list(
+              prefixId.getBucketName(),
+              BlobListOption.prefix(prefix),
+              BlobListOption.pageSize(maxResults),
+              BlobListOption.fields(BLOB_METADATA_FIELDS.toArray(new BlobField[0])));
+
+      ImmutableList.Builder<GcsItemInfo> builder = ImmutableList.builder();
+      int count = 0;
+      for (Blob blob : page.iterateAll()) {
+        builder.add(fromBlob(blob));
+        count++;
+        if (count >= maxResults) {
+          break;
+        }
       }
+      return builder.build();
+    } catch (StorageException e) {
+      if (e.getCode() == 404) {
+        throw new FileNotFoundException("Bucket not found: " + prefixId.getBucketName());
+      }
+      throw new IOException("Failed to list objects for prefix: " + prefixId, e);
     }
-    return builder.build();
   }
 
   private GcsItemInfo fromBlob(Blob blob) {
@@ -259,6 +279,7 @@ class GcsClientImpl implements GcsClient {
     Optional.ofNullable(blob.getContentEncoding()).ifPresent(infoBuilder::setContentEncoding);
     Optional.ofNullable(blob.getStorageClass())
         .ifPresent(sc -> infoBuilder.setStorageClass(sc.name()));
+    Optional.ofNullable(blob.getMetageneration()).ifPresent(infoBuilder::setMetaGeneration);
 
     if (blob.getMetadata() != null) {
       ImmutableMap.Builder<String, byte[]> xattrs = ImmutableMap.builder();

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -93,7 +93,7 @@ class GcsClientImpl implements GcsClient {
   private final Optional<Credentials> credentials;
   private Supplier<ExecutorService> executorServiceSupplier;
   private final Telemetry telemetry;
-  @VisibleForTesting StorageControlClient storageControlClient;
+  @VisibleForTesting volatile StorageControlClient storageControlClient;
 
   GcsClientImpl(
       Credentials credentials,
@@ -233,10 +233,14 @@ class GcsClientImpl implements GcsClient {
   @VisibleForTesting
   StorageControlClient lazyGetStorageControlClient() throws IOException {
     if (this.storageControlClient == null) {
-      StorageControlSettings.Builder builder = StorageControlSettings.newBuilder();
-      this.credentials.ifPresent(
-          c -> builder.setCredentialsProvider(FixedCredentialsProvider.create(c)));
-      this.storageControlClient = StorageControlClient.create(builder.build());
+      synchronized (this) {
+        if (this.storageControlClient == null) {
+          StorageControlSettings.Builder builder = StorageControlSettings.newBuilder();
+          this.credentials.ifPresent(
+              c -> builder.setCredentialsProvider(FixedCredentialsProvider.create(c)));
+          this.storageControlClient = StorageControlClient.create(builder.build());
+        }
+      }
     }
     return this.storageControlClient;
   }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileInfo.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileInfo.java
@@ -16,6 +16,7 @@
 package com.google.cloud.gcs.analyticscore.client;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.storage.BlobId;
 import com.google.common.collect.ImmutableMap;
 import java.net.URI;
 import java.util.Map;
@@ -49,6 +50,38 @@ public abstract class GcsFileInfo {
    * @return A map of file attributes
    */
   public abstract ImmutableMap<String, byte[]> getAttributes();
+
+  /** Indicates whether this file or directory exists. */
+  public boolean exists() {
+    return getItemInfo().exists();
+  }
+
+  public static GcsFileInfo createNotFound(URI uri) {
+    GcsItemId itemId = UriUtil.getItemIdFromString(uri.toString());
+    return builder()
+        .setItemInfo(GcsItemInfo.createNotFound(itemId))
+        .setUri(uri)
+        .setAttributes(ImmutableMap.of())
+        .build();
+  }
+
+  public static GcsFileInfo createNotFound(GcsItemId itemId) {
+    URI uri;
+    if (itemId.isRoot()) {
+      uri = GCS_ROOT_URI;
+    } else if (itemId.isBucket()) {
+      uri = URI.create("gs://" + itemId.getBucketName());
+    } else {
+      uri =
+          URI.create(
+              BlobId.of(itemId.getBucketName(), itemId.getObjectName().orElse("")).toGsUtilUri());
+    }
+    return builder()
+        .setItemInfo(GcsItemInfo.createNotFound(itemId))
+        .setUri(uri)
+        .setAttributes(ImmutableMap.of())
+        .build();
+  }
 
   public abstract Builder toBuilder();
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileInfo.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileInfo.java
@@ -48,8 +48,7 @@ public abstract class GcsFileInfo {
    *
    * @return A map of file attributes
    */
-  @SuppressWarnings("AutoValueImmutableFields")
-  public abstract Map<String, byte[]> getAttributes();
+  public abstract ImmutableMap<String, byte[]> getAttributes();
 
   public abstract Builder toBuilder();
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileInfo.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileInfo.java
@@ -16,6 +16,7 @@
 package com.google.cloud.gcs.analyticscore.client;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
 import java.net.URI;
 import java.util.Map;
 
@@ -27,6 +28,15 @@ import java.util.Map;
  */
 @AutoValue
 public abstract class GcsFileInfo {
+
+  public static final URI GCS_ROOT_URI = URI.create("gs:/");
+
+  public static final GcsFileInfo ROOT_INFO =
+      builder()
+          .setItemInfo(GcsItemInfo.ROOT_INFO)
+          .setUri(GCS_ROOT_URI)
+          .setAttributes(ImmutableMap.of())
+          .build();
 
   public abstract GcsItemInfo getItemInfo();
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemId.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemId.java
@@ -61,6 +61,17 @@ public abstract class GcsItemId {
   }
 
   /**
+   * Returns true if this identifier represents the GCS global root.
+   *
+   * <p>An item is root if it has an empty bucket name and no object path (the object name is either
+   * absent or empty).
+   */
+  public boolean isRoot() {
+    return this.getBucketName().isEmpty()
+        && (this.getObjectName().isEmpty() || this.getObjectName().get().isEmpty());
+  }
+
+  /**
    * Returns true if this identifier represents a GCS bucket.
    *
    * <p>An item is a bucket if it has a non-empty bucket name and no object path (the object name is

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemId.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemId.java
@@ -56,6 +56,7 @@ public abstract class GcsItemId {
    */
   public boolean isGcsObject() {
     return this.getBucketName() != null
+        && !this.getBucketName().isEmpty()
         && this.getObjectName().isPresent()
         && !this.getObjectName().get().isEmpty();
   }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemId.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemId.java
@@ -48,14 +48,27 @@ public abstract class GcsItemId {
     public abstract GcsItemId build();
   }
 
+  /**
+   * Returns true if this identifier represents a GCS object/folder within a bucket.
+   *
+   * <p>An item is a GCS object if it has a non-empty bucket name and a present, non-empty object
+   * name.
+   */
   public boolean isGcsObject() {
     return this.getBucketName() != null
         && this.getObjectName().isPresent()
         && !this.getObjectName().get().isEmpty();
   }
 
+  /**
+   * Returns true if this identifier represents a GCS bucket.
+   *
+   * <p>An item is a bucket if it has a non-empty bucket name and no object path (the object name is
+   * either absent or empty).
+   */
   public boolean isBucket() {
     return this.getBucketName() != null
+        && !this.getBucketName().isEmpty()
         && (this.getObjectName().isEmpty() || this.getObjectName().get().isEmpty());
   }
 }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemId.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemId.java
@@ -55,8 +55,7 @@ public abstract class GcsItemId {
    * name.
    */
   public boolean isGcsObject() {
-    return this.getBucketName() != null
-        && !this.getBucketName().isEmpty()
+    return !this.getBucketName().isEmpty()
         && this.getObjectName().isPresent()
         && !this.getObjectName().get().isEmpty();
   }
@@ -68,8 +67,7 @@ public abstract class GcsItemId {
    * either absent or empty).
    */
   public boolean isBucket() {
-    return this.getBucketName() != null
-        && !this.getBucketName().isEmpty()
+    return !this.getBucketName().isEmpty()
         && (this.getObjectName().isEmpty() || this.getObjectName().get().isEmpty());
   }
 }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemId.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemId.java
@@ -22,6 +22,8 @@ import java.util.Optional;
 @AutoValue
 public abstract class GcsItemId {
 
+  public static final GcsItemId ROOT = builder().setBucketName("").setObjectName("").build();
+
   // Name of the bucket.
   public abstract String getBucketName();
 
@@ -47,6 +49,13 @@ public abstract class GcsItemId {
   }
 
   public boolean isGcsObject() {
-    return this.getBucketName() != null && !this.getObjectName().isEmpty();
+    return this.getBucketName() != null
+        && this.getObjectName().isPresent()
+        && !this.getObjectName().get().isEmpty();
+  }
+
+  public boolean isBucket() {
+    return this.getBucketName() != null
+        && (this.getObjectName().isEmpty() || this.getObjectName().get().isEmpty());
   }
 }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
@@ -45,6 +45,9 @@ public abstract class GcsItemInfo {
   /** Location of the object. */
   public abstract Optional<String> getLocation();
 
+  /** Storage class of the object or default storage class of the bucket. */
+  public abstract Optional<String> getStorageClass();
+
   /** Verification attributes for the object. */
   public abstract Optional<VerificationAttributes> getVerificationAttributes();
 
@@ -175,6 +178,8 @@ public abstract class GcsItemInfo {
     public abstract Builder setContentEncoding(String contentEncoding);
 
     public abstract Builder setLocation(String location);
+
+    public abstract Builder setStorageClass(String storageClass);
 
     public abstract Builder setVerificationAttributes(
         VerificationAttributes verificationAttributes);

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
@@ -40,9 +40,6 @@ public abstract class GcsItemInfo {
   /** Location of the object. */
   public abstract Optional<String> getLocation();
 
-  /** Storage class of the object. */
-  public abstract Optional<String> getStorageClass();
-
   /** Verification attributes for the object. */
   public abstract Optional<VerificationAttributes> getVerificationAttributes();
 
@@ -128,8 +125,6 @@ public abstract class GcsItemInfo {
     public abstract Builder setContentEncoding(String contentEncoding);
 
     public abstract Builder setLocation(String location);
-
-    public abstract Builder setStorageClass(String storageClass);
 
     public abstract Builder setVerificationAttributes(
         VerificationAttributes verificationAttributes);

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
@@ -56,14 +56,12 @@ public abstract class GcsItemInfo {
   public enum ItemType {
     /** A standard storage object. */
     OBJECT,
-    /**
-     * An inferred directory, typically represented by a trailing slash in its name or empty object.
-     */
+    /** An inferred directory, which only exists because of other objects with this prefix */
     INFERRED_DIRECTORY,
-    /**
-     * An explicit directory/folder (e.g., an HNS folder or an explicit folder in a flat bucket).
-     */
-    EXPLICIT_DIRECTORY,
+    /** A 0-byte placeholder object created in a flat bucket to explicitly represent a directory */
+    PLACEHOLDER_DIRECTORY,
+    /** A native directory resource in a Hierarchical Namespace (HNS) enabled bucket */
+    NATIVE_FOLDER,
     /** A GCS bucket. */
     BUCKET,
     /** The global root namespace. */
@@ -84,16 +82,28 @@ public abstract class GcsItemInfo {
    */
   public abstract long getModificationTime();
 
-  public boolean isInferredDirectory() {
-    return getItemType() == ItemType.INFERRED_DIRECTORY;
-  }
-
-  public boolean isExplicitDirectory() {
-    return getItemType() == ItemType.EXPLICIT_DIRECTORY;
+  public static GcsItemInfo createFolder(
+      GcsItemId itemId, long creationTime, long modificationTime, long metaGeneration) {
+    return builder()
+        .setItemId(itemId)
+        .setSize(0)
+        .setItemType(ItemType.NATIVE_FOLDER)
+        .setCreationTime(creationTime)
+        .setModificationTime(modificationTime)
+        .setMetaGeneration(metaGeneration)
+        .build();
   }
 
   public static GcsItemInfo createInferredDirectory(GcsItemId itemId) {
     return builder().setItemId(itemId).setSize(0).setItemType(ItemType.INFERRED_DIRECTORY).build();
+  }
+
+  public static GcsItemInfo createPlaceholderDirectory(GcsItemId itemId) {
+    return builder()
+        .setItemId(itemId)
+        .setSize(0)
+        .setItemType(ItemType.PLACEHOLDER_DIRECTORY)
+        .build();
   }
 
   public static GcsItemInfo createBucket(GcsItemId itemId) {

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 @AutoValue
 public abstract class GcsItemInfo {
 
+  public static final GcsItemInfo ROOT_INFO = createRoot(GcsItemId.ROOT);
+
   /** Returns the identifier of the GCS item. */
   public abstract GcsItemId getItemId();
 
@@ -95,8 +97,6 @@ public abstract class GcsItemInfo {
   public static GcsItemInfo createBucket(GcsItemId itemId) {
     return builder().setItemId(itemId).setSize(0).setItemType(ItemType.BUCKET).build();
   }
-
-  public static final GcsItemInfo ROOT_INFO = createRoot(GcsItemId.ROOT);
 
   public static GcsItemInfo createRoot(GcsItemId itemId) {
     return builder().setItemId(itemId).setSize(0).setItemType(ItemType.ROOT).build();

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
@@ -114,6 +114,15 @@ public abstract class GcsItemInfo {
     return builder().setItemId(itemId).setSize(0).setItemType(ItemType.ROOT).build();
   }
 
+  public static GcsItemInfo createNotFound(GcsItemId itemId) {
+    return builder().setItemId(itemId).setSize(-1L).build();
+  }
+
+  /** Indicates whether this item exists. */
+  public boolean exists() {
+    return getSize() >= 0;
+  }
+
   public static ImmutableMap<String, String> encodeMetadata(ImmutableMap<String, byte[]> metadata) {
     ImmutableMap.Builder<String, String> encoded = ImmutableMap.builder();
     metadata.forEach((k, v) -> encoded.put(k, BaseEncoding.base64().encode(v)));

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
@@ -29,8 +29,25 @@ public abstract class GcsItemInfo {
   /** Size of an object in bytes. Returns -1 for items that do not exist. */
   public abstract long getSize();
 
+  /** Content type of the object. */
+  public abstract Optional<String> getContentType();
+
+  /** Content encoding of the object. */
+  public abstract Optional<String> getContentEncoding();
+
+  /** Location of the object. */
+  public abstract Optional<String> getLocation();
+
+  /** Storage class of the object. */
+  public abstract Optional<String> getStorageClass();
+
+  /** Verification attributes for the object. */
+  public abstract Optional<VerificationAttributes> getVerificationAttributes();
+
   /** Generation ID of the object when the metadata is read. */
   public abstract Optional<Long> getContentGeneration();
+
+  public abstract long getMetaGeneration();
 
   public enum ItemType {
     /** A standard storage object. */
@@ -39,8 +56,14 @@ public abstract class GcsItemInfo {
      * An inferred directory, typically represented by a trailing slash in its name or empty object.
      */
     INFERRED_DIRECTORY,
-    /** A native Hierarchical Namespace (HNS) folder. */
-    NATIVE_FOLDER
+    /**
+     * An explicit directory/folder (e.g., an HNS folder or an explicit folder in a flat bucket).
+     */
+    EXPLICIT_DIRECTORY,
+    /** A GCS bucket. */
+    BUCKET,
+    /** The global root namespace. */
+    ROOT
   }
 
   /** Returns the type of this item. */
@@ -49,20 +72,47 @@ public abstract class GcsItemInfo {
   /** Returns the custom extended attributes (metadata) associated with the item. */
   public abstract ImmutableMap<String, byte[]> getExtendedAttributes();
 
+  /** Returns the creation time of the object in milliseconds since epoch, or 0 if not available. */
+  public abstract long getCreationTime();
+
+  /**
+   * Returns the modification time of the object in milliseconds since epoch, or 0 if not available.
+   */
+  public abstract long getModificationTime();
+
   public boolean isInferredDirectory() {
     return getItemType() == ItemType.INFERRED_DIRECTORY;
   }
 
-  public boolean isNativeHnsFolder() {
-    return getItemType() == ItemType.NATIVE_FOLDER;
+  public boolean isExplicitDirectory() {
+    return getItemType() == ItemType.EXPLICIT_DIRECTORY;
   }
+
+  public static GcsItemInfo createInferredDirectory(GcsItemId itemId) {
+    return builder().setItemId(itemId).setSize(0).setItemType(ItemType.INFERRED_DIRECTORY).build();
+  }
+
+  public static GcsItemInfo createBucket(GcsItemId itemId) {
+    return builder().setItemId(itemId).setSize(0).setItemType(ItemType.BUCKET).build();
+  }
+
+  public static final GcsItemInfo ROOT_INFO = createRoot(GcsItemId.ROOT);
+
+  public static GcsItemInfo createRoot(GcsItemId itemId) {
+    return builder().setItemId(itemId).setSize(0).setItemType(ItemType.ROOT).build();
+  }
+
+  public abstract Builder toBuilder();
 
   public static Builder builder() {
     // By default, set size to -1, indicating a non-existent item.
     return new AutoValue_GcsItemInfo.Builder()
         .setSize(-1L)
         .setItemType(ItemType.OBJECT)
-        .setExtendedAttributes(ImmutableMap.of());
+        .setExtendedAttributes(ImmutableMap.of())
+        .setCreationTime(0L)
+        .setModificationTime(0L)
+        .setMetaGeneration(0L);
   }
 
   /** Builder for {@link GcsItemInfo}. */
@@ -73,11 +123,28 @@ public abstract class GcsItemInfo {
 
     public abstract Builder setSize(long size);
 
+    public abstract Builder setContentType(String contentType);
+
+    public abstract Builder setContentEncoding(String contentEncoding);
+
+    public abstract Builder setLocation(String location);
+
+    public abstract Builder setStorageClass(String storageClass);
+
+    public abstract Builder setVerificationAttributes(
+        VerificationAttributes verificationAttributes);
+
     public abstract Builder setContentGeneration(long contentGeneration);
+
+    public abstract Builder setMetaGeneration(long metaGeneration);
 
     public abstract Builder setItemType(ItemType itemType);
 
     public abstract Builder setExtendedAttributes(ImmutableMap<String, byte[]> extendedAttributes);
+
+    public abstract Builder setCreationTime(long creationTime);
+
+    public abstract Builder setModificationTime(long modificationTime);
 
     public abstract GcsItemInfo build();
   }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
@@ -126,6 +126,24 @@ public abstract class GcsItemInfo {
     return getSize() >= 0;
   }
 
+  /**
+   * @deprecated Use {@link #getItemType()} and check against {@link ItemType#INFERRED_DIRECTORY}
+   *     instead.
+   */
+  @Deprecated
+  public boolean isInferredDirectory() {
+    return getItemType() == ItemType.INFERRED_DIRECTORY;
+  }
+
+  /**
+   * @deprecated Use {@link #getItemType()} and check against {@link ItemType#NATIVE_FOLDER}
+   *     instead.
+   */
+  @Deprecated
+  public boolean isNativeHnsFolder() {
+    return getItemType() == ItemType.NATIVE_FOLDER;
+  }
+
   public static ImmutableMap<String, String> encodeMetadata(ImmutableMap<String, byte[]> metadata) {
     ImmutableMap.Builder<String, String> encoded = ImmutableMap.builder();
     metadata.forEach((k, v) -> encoded.put(k, BaseEncoding.base64().encode(v)));

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfo.java
@@ -17,11 +17,16 @@ package com.google.cloud.gcs.analyticscore.client;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
+import java.util.Map;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Represents metadata of a GCS Item. */
 @AutoValue
 public abstract class GcsItemInfo {
+  private static final Logger LOG = LoggerFactory.getLogger(GcsItemInfo.class);
 
   public static final GcsItemInfo ROOT_INFO = createRoot(GcsItemId.ROOT);
 
@@ -97,6 +102,32 @@ public abstract class GcsItemInfo {
 
   public static GcsItemInfo createRoot(GcsItemId itemId) {
     return builder().setItemId(itemId).setSize(0).setItemType(ItemType.ROOT).build();
+  }
+
+  public static ImmutableMap<String, String> encodeMetadata(ImmutableMap<String, byte[]> metadata) {
+    ImmutableMap.Builder<String, String> encoded = ImmutableMap.builder();
+    metadata.forEach((k, v) -> encoded.put(k, BaseEncoding.base64().encode(v)));
+    return encoded.build();
+  }
+
+  public static ImmutableMap<String, byte[]> decodeMetadata(Map<String, String> metadata) {
+    if (metadata == null || metadata.isEmpty()) {
+      return ImmutableMap.of();
+    }
+    ImmutableMap.Builder<String, byte[]> decoded = ImmutableMap.builder();
+    for (Map.Entry<String, String> entry : metadata.entrySet()) {
+      String key = entry.getKey();
+      if (key != null) {
+        String value = entry.getValue();
+        try {
+          byte[] decodedValue = (value == null) ? new byte[0] : BaseEncoding.base64().decode(value);
+          decoded.put(key, decodedValue);
+        } catch (IllegalArgumentException e) {
+          LOG.error("Failed to parse base64 encoded attribute value for key {}: {}", key, value, e);
+        }
+      }
+    }
+    return decoded.build();
   }
 
   public abstract Builder toBuilder();

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/UriUtil.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/UriUtil.java
@@ -67,7 +67,7 @@ final class UriUtil {
     return path;
   }
 
-  static String ensureTrailingSlash(String path) {
+  static String toDirectoryPath(String path) {
     if (path != null && !path.endsWith("/")) {
       return path + "/";
     }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/UriUtil.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/UriUtil.java
@@ -45,6 +45,10 @@ final class UriUtil {
 
     Matcher matcher = GCS_PATH_PATTERN.matcher(path);
     checkArgument(matcher.matches(), "Invalid GCS path: %s", path);
+    checkArgument(
+        !path.substring(5).contains("//"),
+        "GCS path must not have consecutive '/' characters: %s",
+        path);
 
     String bucketName = matcher.group(2);
     String relativePath = matcher.group(4);

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/UriUtil.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/UriUtil.java
@@ -51,4 +51,18 @@ final class UriUtil {
     }
     return GcsItemId.builder().setBucketName(bucketName).setObjectName(relativePath).build();
   }
+
+  static String removeTrailingSlash(String path) {
+    if (path != null && path.endsWith("/")) {
+      return path.substring(0, path.length() - 1);
+    }
+    return path;
+  }
+
+  static String ensureTrailingSlash(String path) {
+    if (path != null && !path.endsWith("/")) {
+      return path + "/";
+    }
+    return path;
+  }
 }

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/UriUtil.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/UriUtil.java
@@ -39,6 +39,10 @@ final class UriUtil {
   static GcsItemId getItemIdFromString(String path) {
     checkArgument(path != null, "path should not be null");
 
+    if (path.equals("gs:/")) {
+      return GcsItemId.ROOT;
+    }
+
     Matcher matcher = GCS_PATH_PATTERN.matcher(path);
     checkArgument(matcher.matches(), "Invalid GCS path: %s", path);
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/UriUtil.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/UriUtil.java
@@ -52,12 +52,12 @@ final class UriUtil {
 
     String bucketName = matcher.group(2);
     String relativePath = matcher.group(4);
-    checkArgument(bucketName != null, "GCS path must include a bucket name: %s", path);
-
-    if (relativePath == null) {
-      return GcsItemId.builder().setBucketName(bucketName).build();
+    if (bucketName == null) {
+      return GcsItemId.ROOT;
+    } else if (relativePath != null) {
+      return GcsItemId.builder().setBucketName(bucketName).setObjectName(relativePath).build();
     }
-    return GcsItemId.builder().setBucketName(bucketName).setObjectName(relativePath).build();
+    return GcsItemId.builder().setBucketName(bucketName).build();
   }
 
   static String removeTrailingSlash(String path) {

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/VerificationAttributes.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/VerificationAttributes.java
@@ -1,0 +1,20 @@
+package com.google.cloud.gcs.analyticscore.client;
+
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+
+/** GCS provided validation attributes for a single object. */
+@AutoValue
+public abstract class VerificationAttributes {
+  @Nullable
+  @SuppressWarnings("mutable")
+  public abstract byte[] getMd5hash();
+
+  @Nullable
+  @SuppressWarnings("mutable")
+  public abstract byte[] getCrc32c();
+
+  public static VerificationAttributes create(@Nullable byte[] md5hash, @Nullable byte[] crc32c) {
+    return new AutoValue_VerificationAttributes(md5hash, crc32c);
+  }
+}

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/VerificationAttributes.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/VerificationAttributes.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.gcs.analyticscore.client;
 
 import com.google.auto.value.AutoValue;

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -154,17 +154,18 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getGcsItemInfo_nonExistentBlob_throwsIOException() {
+  void getGcsItemInfo_nonExistentBlob_throwsFileNotFoundException() {
     GcsItemId nonExistentItemId =
         GcsItemId.builder()
             .setBucketName(TEST_BUCKET_NAME)
             .setObjectName(TEST_NON_EXISTENT_OBJECT)
             .build();
 
-    IOException e =
-        assertThrows(IOException.class, () -> gcsClient.getGcsItemInfo(nonExistentItemId));
+    FileNotFoundException e =
+        assertThrows(
+            FileNotFoundException.class, () -> gcsClient.getGcsItemInfo(nonExistentItemId));
 
-    assertThat(e).hasMessageThat().contains("Object not found:" + nonExistentItemId);
+    assertThat(e).hasMessageThat().contains("Object not found: " + nonExistentItemId);
   }
 
   @Test
@@ -1063,5 +1064,169 @@ class GcsClientImplTest {
     VectoredSeekableByteChannel channel = bidiClient.openReadChannel(itemId, readOptions);
 
     assertThat(channel).isInstanceOf(GcsBidiReadChannel.class);
+  }
+
+  @Test
+  void getBucketInfo_nullItemId_throwsNullPointerException() {
+    NullPointerException e =
+        assertThrows(NullPointerException.class, () -> gcsClient.getBucketInfo(null));
+
+    assertThat(e).hasMessageThat().contains("Item ID must not be null");
+  }
+
+  @Test
+  void getBucketInfo_notBucketItemId_throwsIllegalArgumentException() {
+    GcsItemId objectId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("object.txt").build();
+
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> gcsClient.getBucketInfo(objectId));
+
+    assertThat(e).hasMessageThat().contains("Expected a bucket itemId");
+  }
+
+  @Test
+  void getBucketInfo_nonExistentBucket_throwsFileNotFoundException() {
+    GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_NON_EXISTENT_BUCKET).build();
+
+    FileNotFoundException e =
+        assertThrows(FileNotFoundException.class, () -> gcsClient.getBucketInfo(bucketId));
+
+    assertThat(e).hasMessageThat().contains("Bucket not found: " + TEST_NON_EXISTENT_BUCKET);
+  }
+
+  @Test
+  void getBucketInfo_bucketExists_returnsBucketInfo() throws IOException {
+    String bucketName = "my-test-bucket";
+    GcsItemId bucketId = GcsItemId.builder().setBucketName(bucketName).build();
+    Storage mockStorage = mock(Storage.class);
+    Bucket mockBucket = mock(Bucket.class);
+    when(mockBucket.getName()).thenReturn(bucketName);
+    when(mockBucket.getLocation()).thenReturn("US");
+    when(mockStorage.get(eq(bucketName))).thenReturn(mockBucket);
+    GcsClientImpl clientWithMock =
+        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
+          @Override
+          protected Storage createStorage(Optional<Credentials> credentials) {
+            return mockStorage;
+          }
+        };
+
+    GcsItemInfo itemInfo = clientWithMock.getBucketInfo(bucketId);
+
+    assertThat(itemInfo).isNotNull();
+    assertThat(itemInfo.getItemId()).isEqualTo(bucketId);
+    assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.BUCKET);
+    assertThat(itemInfo.getSize()).isEqualTo(0L);
+    assertThat(itemInfo.getLocation().get()).isEqualTo("US");
+  }
+
+  @Test
+  void getFolderInfo_nullItemId_throwsNullPointerException() {
+    NullPointerException e =
+        assertThrows(NullPointerException.class, () -> gcsClient.getFolderInfo(null));
+
+    assertThat(e).hasMessageThat().contains("Item ID must not be null");
+  }
+
+  @Test
+  void getFolderInfo_notObjectItemId_throwsIllegalArgumentException() {
+    GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
+
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> gcsClient.getFolderInfo(bucketId));
+
+    assertThat(e).hasMessageThat().contains("Expected a folder itemId");
+  }
+
+  @Test
+  void getFolderInfo_folderExists_returnsFolderInfo() throws IOException {
+    GcsItemId folderItemId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("my-folder/").build();
+    com.google.storage.control.v2.StorageControlClient mockControlClient =
+        mock(com.google.storage.control.v2.StorageControlClient.class);
+    com.google.storage.control.v2.Folder mockFolder =
+        com.google.storage.control.v2.Folder.newBuilder()
+            .setName("projects/_/buckets/" + TEST_BUCKET + "/folders/my-folder")
+            .setMetageneration(3L)
+            .build();
+    when(mockControlClient.getFolder(any(com.google.storage.control.v2.GetFolderRequest.class)))
+        .thenReturn(mockFolder);
+    GcsClientImpl clientWithMockControl =
+        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
+          @Override
+          protected Storage createStorage(Optional<Credentials> credentials) {
+            return GcsClientImplTest.this.storage;
+          }
+
+          @Override
+          com.google.storage.control.v2.StorageControlClient lazyGetStorageControlClient() {
+            return mockControlClient;
+          }
+        };
+
+    GcsItemInfo itemInfo = clientWithMockControl.getFolderInfo(folderItemId);
+
+    assertThat(itemInfo.getItemId()).isEqualTo(folderItemId);
+    assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.EXPLICIT_DIRECTORY);
+    assertThat(itemInfo.getSize()).isEqualTo(0L);
+    assertThat(itemInfo.getMetaGeneration()).isEqualTo(3L);
+  }
+
+  @Test
+  void getFolderInfo_notFound_throwsFileNotFoundException() throws IOException {
+    GcsItemId folderItemId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("missing-folder").build();
+    com.google.storage.control.v2.StorageControlClient mockControlClient =
+        mock(com.google.storage.control.v2.StorageControlClient.class);
+    com.google.api.gax.rpc.NotFoundException notFoundException =
+        mock(com.google.api.gax.rpc.NotFoundException.class);
+    when(mockControlClient.getFolder(any(com.google.storage.control.v2.GetFolderRequest.class)))
+        .thenThrow(notFoundException);
+    GcsClientImpl clientWithMockControl =
+        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
+          @Override
+          protected Storage createStorage(Optional<Credentials> credentials) {
+            return GcsClientImplTest.this.storage;
+          }
+
+          @Override
+          com.google.storage.control.v2.StorageControlClient lazyGetStorageControlClient() {
+            return mockControlClient;
+          }
+        };
+
+    FileNotFoundException e =
+        assertThrows(
+            FileNotFoundException.class, () -> clientWithMockControl.getFolderInfo(folderItemId));
+
+    assertThat(e).hasMessageThat().contains("Folder not found: " + folderItemId);
+  }
+
+  @Test
+  void getFolderInfo_otherRpcException_throwsIOException() throws IOException {
+    GcsItemId folderItemId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("folder").build();
+    com.google.storage.control.v2.StorageControlClient mockControlClient =
+        mock(com.google.storage.control.v2.StorageControlClient.class);
+    when(mockControlClient.getFolder(any(com.google.storage.control.v2.GetFolderRequest.class)))
+        .thenThrow(new RuntimeException("RPC error"));
+    GcsClientImpl clientWithMockControl =
+        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
+          @Override
+          protected Storage createStorage(Optional<Credentials> credentials) {
+            return GcsClientImplTest.this.storage;
+          }
+
+          @Override
+          com.google.storage.control.v2.StorageControlClient lazyGetStorageControlClient() {
+            return mockControlClient;
+          }
+        };
+
+    IOException e =
+        assertThrows(IOException.class, () -> clientWithMockControl.getFolderInfo(folderItemId));
+
+    assertThat(e).hasMessageThat().contains("Folder not found: " + folderItemId);
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -49,12 +50,14 @@ import com.google.cloud.storage.HttpStorageOptions;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BucketGetOption;
+import com.google.cloud.storage.StorageClass;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.BaseEncoding;
 import com.google.protobuf.Timestamp;
 import com.google.storage.control.v2.Folder;
 import com.google.storage.control.v2.GetFolderRequest;
@@ -74,7 +77,6 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -191,6 +193,24 @@ class GcsClientImplTest {
     assertThat(itemInfo.getItemId().getBucketName()).isEqualTo(TEST_BUCKET);
     assertThat(itemInfo.getItemId().getObjectName()).hasValue("dir/");
     assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.PLACEHOLDER_DIRECTORY);
+    assertThat(itemInfo.getVerificationAttributes()).isEmpty();
+  }
+
+  @Test
+  void getGcsItemInfo_withMd5AndCrc32c_returnsVerificationAttributes() throws IOException {
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getBucket()).thenReturn(TEST_BUCKET);
+    when(mockBlob.getName()).thenReturn(TEST_OBJECT);
+    when(mockBlob.getMd5()).thenReturn(BaseEncoding.base64().encode("md5".getBytes(UTF_8)));
+    when(mockBlob.getCrc32c()).thenReturn(BaseEncoding.base64().encode("crc".getBytes(UTF_8)));
+    Storage mockStorage = mock(Storage.class);
+    when(mockStorage.get(any(BlobId.class), any(Storage.BlobGetOption[].class)))
+        .thenReturn(mockBlob);
+
+    GcsItemInfo itemInfo = createClientWithMockStorage(mockStorage).getGcsItemInfo(TEST_ITEM_ID);
+
+    assertThat(itemInfo.getVerificationAttributes())
+        .hasValue(VerificationAttributes.create("md5".getBytes(UTF_8), "crc".getBytes(UTF_8)));
   }
 
   @Test
@@ -1036,6 +1056,7 @@ class GcsClientImplTest {
     assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.BUCKET);
     assertThat(itemInfo.getSize()).isEqualTo(0L);
     assertThat(itemInfo.getLocation()).hasValue(TEST_LOCATION);
+    assertThat(itemInfo.getStorageClass()).hasValue(StorageClass.STANDARD.toString());
     assertThat(itemInfo.getMetaGeneration()).isEqualTo(2L);
     assertThat(itemInfo.getCreationTime())
         .isEqualTo(OffsetDateTime.parse("2026-08-01T10:00:00Z").toInstant().toEpochMilli());
@@ -1163,7 +1184,6 @@ class GcsClientImplTest {
 
     verify(mockStorage).close();
     verify(mockControlClient).close();
-    assertThat(localClient.storageControlClient).isNull();
   }
 
   @Test
@@ -1179,7 +1199,31 @@ class GcsClientImplTest {
 
     verify(mockStorage).close();
     verify(mockControlClient).close();
-    assertThat(localClient.storageControlClient).isNull();
+  }
+
+  @Test
+  void close_idempotent_closesStorageControlClientOnlyOnce() throws Exception {
+    Storage mockStorage = mock(Storage.class);
+    StorageControlClient mockControlClient = mock(StorageControlClient.class);
+    GcsClientImpl localClient = createClientWithMockStorage(mockStorage);
+    localClient.storageControlClient = mockControlClient;
+
+    localClient.close();
+    localClient.close();
+
+    verify(mockControlClient, times(1)).close();
+  }
+
+  @Test
+  void lazyGetStorageControlClient_afterClose_throwsIOException() throws Exception {
+    Storage mockStorage = mock(Storage.class);
+    GcsClientImpl localClient = createClientWithMockStorage(mockStorage);
+
+    localClient.close();
+
+    IOException e =
+        assertThrows(IOException.class, () -> localClient.lazyGetStorageControlClient());
+    assertThat(e).hasMessageThat().contains("StorageControlClient is closed");
   }
 
   @Test
@@ -1310,11 +1354,11 @@ class GcsClientImplTest {
     Storage mockStorage = createMockStorageWithBlobs(TEST_BUCKET, mockBlob);
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
-    List<GcsItemInfo> result = clientWithMock.listFirstObjectWithPrefix(prefixId);
+    Optional<GcsItemInfo> result = clientWithMock.listFirstObjectWithPrefix(prefixId);
 
-    assertThat(result).hasSize(1);
-    assertThat(result.get(0).getItemId().getObjectName()).hasValue(TEST_DIR + "file.txt");
-    assertThat(result.get(0).getSize()).isEqualTo(0L);
+    assertThat(result).isPresent();
+    assertThat(result.get().getItemId().getObjectName()).hasValue(TEST_DIR + "file.txt");
+    assertThat(result.get().getSize()).isEqualTo(0L);
   }
 
   @Test
@@ -1324,7 +1368,7 @@ class GcsClientImplTest {
     Storage mockStorage = createMockStorageWithBlobs(TEST_BUCKET);
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
-    List<GcsItemInfo> result = clientWithMock.listFirstObjectWithPrefix(prefixId);
+    Optional<GcsItemInfo> result = clientWithMock.listFirstObjectWithPrefix(prefixId);
 
     assertThat(result).isEmpty();
   }
@@ -1379,6 +1423,7 @@ class GcsClientImplTest {
     Bucket mockBucket = mock(Bucket.class);
     when(mockBucket.getName()).thenReturn(bucketName);
     when(mockBucket.getLocation()).thenReturn(TEST_LOCATION);
+    when(mockBucket.getStorageClass()).thenReturn(StorageClass.STANDARD);
     when(mockBucket.getMetageneration()).thenReturn(2L);
     when(mockBucket.getCreateTimeOffsetDateTime())
         .thenReturn(OffsetDateTime.parse("2026-08-01T10:00:00Z"));

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -1066,6 +1066,17 @@ class GcsClientImplTest {
   }
 
   @Test
+  void getFolderInfo_emptyFolderName_throwsIllegalArgumentException() {
+    GcsItemId rootSlashId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("/").build();
+
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> gcsClient.getFolderInfo(rootSlashId));
+
+    assertThat(e).hasMessageThat().contains("Folder name cannot be empty");
+  }
+
+  @Test
   void getFolderInfo_folderExists_returnsFolderInfo() throws IOException {
     GcsItemId folderItemId =
         GcsItemId.builder()

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -80,15 +80,18 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
@@ -196,21 +199,43 @@ class GcsClientImplTest {
     assertThat(itemInfo.getVerificationAttributes()).isEmpty();
   }
 
-  @Test
-  void getGcsItemInfo_withMd5AndCrc32c_returnsVerificationAttributes() throws IOException {
+  @ParameterizedTest
+  @CsvSource({"md5, crc", ", crc", "md5, "})
+  void getGcsItemInfo_withChecksums_returnsVerificationAttributes(String md5, String crc32c)
+      throws IOException {
     Blob mockBlob = mock(Blob.class);
     when(mockBlob.getBucket()).thenReturn(TEST_BUCKET);
     when(mockBlob.getName()).thenReturn(TEST_OBJECT);
-    when(mockBlob.getMd5()).thenReturn(BaseEncoding.base64().encode("md5".getBytes(UTF_8)));
-    when(mockBlob.getCrc32c()).thenReturn(BaseEncoding.base64().encode("crc".getBytes(UTF_8)));
+    if (md5 != null) {
+      when(mockBlob.getMd5()).thenReturn(BaseEncoding.base64().encode(md5.getBytes(UTF_8)));
+    }
+    if (crc32c != null) {
+      when(mockBlob.getCrc32c()).thenReturn(BaseEncoding.base64().encode(crc32c.getBytes(UTF_8)));
+    }
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.get(any(BlobId.class), any(Storage.BlobGetOption[].class)))
         .thenReturn(mockBlob);
 
     GcsItemInfo itemInfo = createClientWithMockStorage(mockStorage).getGcsItemInfo(TEST_ITEM_ID);
 
+    byte[] expectedMd5 = md5 != null ? md5.getBytes(UTF_8) : null;
+    byte[] expectedCrc32c = crc32c != null ? crc32c.getBytes(UTF_8) : null;
     assertThat(itemInfo.getVerificationAttributes())
-        .hasValue(VerificationAttributes.create("md5".getBytes(UTF_8), "crc".getBytes(UTF_8)));
+        .hasValue(VerificationAttributes.create(expectedMd5, expectedCrc32c));
+  }
+
+  @Test
+  void getGcsItemInfo_nullSize_defaultsToZero() throws IOException {
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getBucket()).thenReturn(TEST_BUCKET);
+    when(mockBlob.getName()).thenReturn(TEST_OBJECT);
+    Storage mockStorage = mock(Storage.class);
+    when(mockStorage.get(any(BlobId.class), any(Storage.BlobGetOption[].class)))
+        .thenReturn(mockBlob);
+
+    GcsItemInfo itemInfo = createClientWithMockStorage(mockStorage).getGcsItemInfo(TEST_ITEM_ID);
+
+    assertThat(itemInfo.getSize()).isEqualTo(0L);
   }
 
   @Test
@@ -1224,6 +1249,29 @@ class GcsClientImplTest {
     IOException e =
         assertThrows(IOException.class, () -> localClient.lazyGetStorageControlClient());
     assertThat(e).hasMessageThat().contains("StorageControlClient is closed");
+  }
+
+  @Test
+  void lazyGetStorageControlClient_closedWhileWaitingForLock_throwsIOException() throws Exception {
+    GcsClientImpl client = createClientWithMockStorage(mock(Storage.class));
+    CountDownLatch started = new CountDownLatch(1);
+    AtomicReference<IOException> thrown = new AtomicReference<>();
+
+    CompletableFuture<Void> future;
+    synchronized (client) {
+      future =
+          CompletableFuture.runAsync(
+              () -> {
+                started.countDown();
+                thrown.set(assertThrows(IOException.class, client::lazyGetStorageControlClient));
+              });
+      started.await(5, TimeUnit.SECONDS);
+      Thread.sleep(50);
+      client.close();
+    }
+    future.get(5, TimeUnit.SECONDS);
+
+    assertThat(thrown.get()).hasMessageThat().contains("StorageControlClient is closed");
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.gax.rpc.NotFoundException;
 import com.google.auth.Credentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
@@ -52,6 +53,9 @@ import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.storage.control.v2.Folder;
+import com.google.storage.control.v2.GetFolderRequest;
+import com.google.storage.control.v2.StorageControlClient;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -1143,15 +1147,13 @@ class GcsClientImplTest {
   void getFolderInfo_folderExists_returnsFolderInfo() throws IOException {
     GcsItemId folderItemId =
         GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("my-folder/").build();
-    com.google.storage.control.v2.StorageControlClient mockControlClient =
-        mock(com.google.storage.control.v2.StorageControlClient.class);
-    com.google.storage.control.v2.Folder mockFolder =
-        com.google.storage.control.v2.Folder.newBuilder()
+    StorageControlClient mockControlClient = mock(StorageControlClient.class);
+    Folder mockFolder =
+        Folder.newBuilder()
             .setName("projects/_/buckets/" + TEST_BUCKET + "/folders/my-folder")
             .setMetageneration(3L)
             .build();
-    when(mockControlClient.getFolder(any(com.google.storage.control.v2.GetFolderRequest.class)))
-        .thenReturn(mockFolder);
+    when(mockControlClient.getFolder(any(GetFolderRequest.class))).thenReturn(mockFolder);
     GcsClientImpl clientWithMockControl =
         new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
           @Override
@@ -1160,7 +1162,7 @@ class GcsClientImplTest {
           }
 
           @Override
-          com.google.storage.control.v2.StorageControlClient lazyGetStorageControlClient() {
+          StorageControlClient lazyGetStorageControlClient() {
             return mockControlClient;
           }
         };
@@ -1177,12 +1179,9 @@ class GcsClientImplTest {
   void getFolderInfo_notFound_throwsFileNotFoundException() throws IOException {
     GcsItemId folderItemId =
         GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("missing-folder").build();
-    com.google.storage.control.v2.StorageControlClient mockControlClient =
-        mock(com.google.storage.control.v2.StorageControlClient.class);
-    com.google.api.gax.rpc.NotFoundException notFoundException =
-        mock(com.google.api.gax.rpc.NotFoundException.class);
-    when(mockControlClient.getFolder(any(com.google.storage.control.v2.GetFolderRequest.class)))
-        .thenThrow(notFoundException);
+    StorageControlClient mockControlClient = mock(StorageControlClient.class);
+    NotFoundException notFoundException = mock(NotFoundException.class);
+    when(mockControlClient.getFolder(any(GetFolderRequest.class))).thenThrow(notFoundException);
     GcsClientImpl clientWithMockControl =
         new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
           @Override
@@ -1191,7 +1190,7 @@ class GcsClientImplTest {
           }
 
           @Override
-          com.google.storage.control.v2.StorageControlClient lazyGetStorageControlClient() {
+          StorageControlClient lazyGetStorageControlClient() {
             return mockControlClient;
           }
         };
@@ -1207,9 +1206,8 @@ class GcsClientImplTest {
   void getFolderInfo_otherRpcException_throwsIOException() throws IOException {
     GcsItemId folderItemId =
         GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("folder").build();
-    com.google.storage.control.v2.StorageControlClient mockControlClient =
-        mock(com.google.storage.control.v2.StorageControlClient.class);
-    when(mockControlClient.getFolder(any(com.google.storage.control.v2.GetFolderRequest.class)))
+    StorageControlClient mockControlClient = mock(StorageControlClient.class);
+    when(mockControlClient.getFolder(any(GetFolderRequest.class)))
         .thenThrow(new RuntimeException("RPC error"));
     GcsClientImpl clientWithMockControl =
         new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
@@ -1219,7 +1217,7 @@ class GcsClientImplTest {
           }
 
           @Override
-          com.google.storage.control.v2.StorageControlClient lazyGetStorageControlClient() {
+          StorageControlClient lazyGetStorageControlClient() {
             return mockControlClient;
           }
         };

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -987,9 +987,13 @@ class GcsClientImplTest {
   @Test
   void getBucketInfo_nonExistentBucket_throwsFileNotFoundException() {
     GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_NON_EXISTENT_BUCKET).build();
+    Storage mockStorage = mock(Storage.class);
+    when(mockStorage.get(eq(TEST_NON_EXISTENT_BUCKET), any(Storage.BucketGetOption[].class)))
+        .thenReturn(null);
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
     FileNotFoundException e =
-        assertThrows(FileNotFoundException.class, () -> gcsClient.getBucketInfo(bucketId));
+        assertThrows(FileNotFoundException.class, () -> clientWithMock.getBucketInfo(bucketId));
 
     assertThat(e).hasMessageThat().contains("Bucket not found: " + TEST_NON_EXISTENT_BUCKET);
   }
@@ -999,7 +1003,8 @@ class GcsClientImplTest {
     GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
     Bucket mockBucket = createMockBucket(TEST_BUCKET);
     Storage mockStorage = mock(Storage.class);
-    when(mockStorage.get(eq(TEST_BUCKET))).thenReturn(mockBucket);
+    when(mockStorage.get(eq(TEST_BUCKET), any(Storage.BucketGetOption[].class)))
+        .thenReturn(mockBucket);
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
     GcsItemInfo itemInfo = clientWithMock.getBucketInfo(bucketId);
@@ -1013,6 +1018,33 @@ class GcsClientImplTest {
         .isEqualTo(OffsetDateTime.parse("2026-08-01T10:00:00Z").toInstant().toEpochMilli());
     assertThat(itemInfo.getModificationTime())
         .isEqualTo(OffsetDateTime.parse("2026-08-02T10:00:00Z").toInstant().toEpochMilli());
+  }
+
+  @Test
+  void getBucketInfo_storageException404_throwsFileNotFoundException() {
+    GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
+    Storage mockStorage = mock(Storage.class);
+    when(mockStorage.get(eq(TEST_BUCKET), any(Storage.BucketGetOption[].class)))
+        .thenThrow(new StorageException(404, "Not Found"));
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
+
+    FileNotFoundException e =
+        assertThrows(FileNotFoundException.class, () -> clientWithMock.getBucketInfo(bucketId));
+
+    assertThat(e).hasMessageThat().contains("Bucket not found: " + TEST_BUCKET);
+  }
+
+  @Test
+  void getBucketInfo_storageException500_throwsIOException() {
+    GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
+    Storage mockStorage = mock(Storage.class);
+    when(mockStorage.get(eq(TEST_BUCKET), any(Storage.BucketGetOption[].class)))
+        .thenThrow(new StorageException(500, "Internal Error"));
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
+
+    IOException e = assertThrows(IOException.class, () -> clientWithMock.getBucketInfo(bucketId));
+
+    assertThat(e).hasMessageThat().contains("Unable to access bucket: " + TEST_BUCKET);
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -1125,6 +1125,16 @@ class GcsClientImplTest {
   }
 
   @Test
+  void lazyGetStorageControlClient_initializesClientWhenNull() throws Exception {
+    GcsClientImpl localClient = createClientWithMockStorage(mock(Storage.class));
+
+    StorageControlClient result = localClient.lazyGetStorageControlClient();
+
+    assertThat(result).isNotNull();
+    result.close();
+  }
+
+  @Test
   void getFolderInfo_notFound_throwsFileNotFoundException() throws IOException {
     GcsItemId folderItemId =
         GcsItemId.builder()

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -55,8 +55,6 @@ import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.io.BaseEncoding;
 import com.google.protobuf.Timestamp;
 import com.google.storage.control.v2.Folder;
 import com.google.storage.control.v2.GetFolderRequest;
@@ -105,8 +103,6 @@ class GcsClientImplTest {
   private static final String TEST_LOCATION = "US";
   private static final String TEST_FOLDER_NAME = "test-folder";
   private static final String TEST_DIR = "dir/";
-  private static final String TEST_CONTENT_TYPE = "text/plain";
-  private static final String TEST_CONTENT_ENCODING = "gzip";
   private static final String TEST_OBJECT_NAME = "test-object-name";
   private static final String BLOB_WRITE_SESSION_CONFIG_FIELD = "blobWriteSessionConfig";
   private static final int MB = 1024 * 1024;
@@ -1192,68 +1188,41 @@ class GcsClientImplTest {
   }
 
   @Test
-  void listObjectInfo_returnsObjectsWithMetadata() throws IOException {
+  void listFirstObjectWithPrefix_hasObjects_returnsSingleItem() throws IOException {
     GcsItemId prefixId =
         GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
-    Blob mockBlob = createMockBlobWithFullMetadata(TEST_BUCKET, TEST_DIR + TEST_OBJECT);
+    Blob mockBlob = createMockBlob(TEST_BUCKET, TEST_DIR + "file.txt");
     Storage mockStorage = createMockStorageWithBlobs(TEST_BUCKET, mockBlob);
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
-    List<GcsItemInfo> result = clientWithMock.listObjectInfo(prefixId, 10);
+    List<GcsItemInfo> result = clientWithMock.listFirstObjectWithPrefix(prefixId);
 
     assertThat(result).hasSize(1);
-    GcsItemInfo item = result.get(0);
-    assertThat(item.getItemId().getBucketName()).isEqualTo(TEST_BUCKET);
-    assertThat(item.getItemId().getObjectName()).hasValue(TEST_DIR + TEST_OBJECT);
-    assertThat(item.getSize()).isEqualTo(1024L);
+    assertThat(result.get(0).getItemId().getObjectName()).hasValue(TEST_DIR + "file.txt");
   }
 
   @Test
-  void listObjectInfo_withMaxResults_limitsReturnedItems() throws IOException {
-    GcsItemId prefixId =
-        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
-    Blob mockBlob1 = createMockBlob(TEST_BUCKET, TEST_DIR + "file1.txt");
-    Blob mockBlob2 = createMockBlob(TEST_BUCKET, TEST_DIR + "file2.txt");
-    Storage mockStorage = createMockStorageWithBlobs(TEST_BUCKET, mockBlob1, mockBlob2);
-    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
-
-    List<GcsItemInfo> result = clientWithMock.listObjectInfo(prefixId, 1);
-
-    assertThat(result).hasSize(1);
-    assertThat(result.get(0).getItemId().getObjectName()).hasValue(TEST_DIR + "file1.txt");
-  }
-
-  @Test
-  void listObjectInfo_emptyPage_returnsEmptyList() throws IOException {
+  void listFirstObjectWithPrefix_empty_returnsEmptyList() throws IOException {
     GcsItemId prefixId =
         GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
     Storage mockStorage = createMockStorageWithBlobs(TEST_BUCKET);
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
-    List<GcsItemInfo> result = clientWithMock.listObjectInfo(prefixId, 10);
+    List<GcsItemInfo> result = clientWithMock.listFirstObjectWithPrefix(prefixId);
 
     assertThat(result).isEmpty();
   }
 
   @Test
-  void listObjectInfo_nullPrefixId_throwsNullPointerException() {
+  void listFirstObjectWithPrefix_nullPrefixId_throwsNullPointerException() {
     NullPointerException e =
-        assertThrows(NullPointerException.class, () -> gcsClient.listObjectInfo(null, 10));
+        assertThrows(NullPointerException.class, () -> gcsClient.listFirstObjectWithPrefix(null));
 
     assertThat(e).hasMessageThat().contains("prefixId must not be null");
   }
 
   @Test
-  void listObjectInfo_nonPositiveMaxResults_throwsIllegalArgumentException() {
-    IllegalArgumentException e =
-        assertThrows(
-            IllegalArgumentException.class, () -> gcsClient.listObjectInfo(TEST_ITEM_ID, 0));
-
-    assertThat(e).hasMessageThat().contains("maxResults must be > 0");
-  }
-
-  @Test
-  void listObjectInfo_bucketNotFound_throwsFileNotFoundException() {
+  void listFirstObjectWithPrefix_bucketNotFound_throwsFileNotFoundException() {
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
         .thenThrow(new StorageException(404, "Bucket not found"));
@@ -1261,45 +1230,32 @@ class GcsClientImplTest {
 
     FileNotFoundException e =
         assertThrows(
-            FileNotFoundException.class, () -> clientWithMock.listObjectInfo(TEST_ITEM_ID, 10));
+            FileNotFoundException.class,
+            () -> clientWithMock.listFirstObjectWithPrefix(TEST_ITEM_ID));
 
     assertThat(e).hasMessageThat().contains("Bucket not found: " + TEST_BUCKET);
   }
 
   @Test
-  void listObjectInfo_storageException_throwsIOException() {
+  void listFirstObjectWithPrefix_storageException_throwsIOException() {
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
         .thenThrow(new StorageException(500, "Internal error"));
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
     IOException e =
-        assertThrows(IOException.class, () -> clientWithMock.listObjectInfo(TEST_ITEM_ID, 10));
+        assertThrows(
+            IOException.class, () -> clientWithMock.listFirstObjectWithPrefix(TEST_ITEM_ID));
 
-    assertThat(e).hasMessageThat().contains("Failed to list objects for prefix: " + TEST_ITEM_ID);
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Failed to list the first object for prefix: " + TEST_ITEM_ID);
   }
 
   private static Blob createMockBlob(String bucket, String name) {
     Blob mockBlob = mock(Blob.class);
     when(mockBlob.getBucket()).thenReturn(bucket);
     when(mockBlob.getName()).thenReturn(name);
-    return mockBlob;
-  }
-
-  private static Blob createMockBlobWithFullMetadata(String bucket, String name) {
-    Blob mockBlob = createMockBlob(bucket, name);
-    when(mockBlob.getGeneration()).thenReturn(100L);
-    when(mockBlob.getMetageneration()).thenReturn(2L);
-    when(mockBlob.getSize()).thenReturn(1024L);
-    when(mockBlob.getCreateTimeOffsetDateTime())
-        .thenReturn(OffsetDateTime.parse("2026-08-01T10:00:00Z"));
-    when(mockBlob.getUpdateTimeOffsetDateTime())
-        .thenReturn(OffsetDateTime.parse("2026-08-02T10:00:00Z"));
-    when(mockBlob.getContentType()).thenReturn(TEST_CONTENT_TYPE);
-    when(mockBlob.getContentEncoding()).thenReturn(TEST_CONTENT_ENCODING);
-    when(mockBlob.getMd5()).thenReturn(BaseEncoding.base64().encode("md5checksum".getBytes(UTF_8)));
-    when(mockBlob.getCrc32c()).thenReturn(BaseEncoding.base64().encode("crc32c".getBytes(UTF_8)));
-    when(mockBlob.getMetadata()).thenReturn(ImmutableMap.of("userKey", "userVal"));
     return mockBlob;
   }
 
@@ -1328,6 +1284,7 @@ class GcsClientImplTest {
   private static Storage createMockStorageWithBlobs(String bucket, Blob... blobs) {
     Page<Blob> mockPage = mock(Page.class);
     when(mockPage.iterateAll()).thenReturn(ImmutableList.copyOf(blobs));
+    when(mockPage.getValues()).thenReturn(ImmutableList.copyOf(blobs));
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.list(eq(bucket), any(Storage.BlobListOption[].class))).thenReturn(mockPage);
     return mockStorage;

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -49,7 +49,6 @@ import com.google.cloud.storage.HttpStorageOptions;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BucketGetOption;
-import com.google.cloud.storage.StorageClass;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
@@ -1009,7 +1008,6 @@ class GcsClientImplTest {
     assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.BUCKET);
     assertThat(itemInfo.getSize()).isEqualTo(0L);
     assertThat(itemInfo.getLocation()).hasValue(TEST_LOCATION);
-    assertThat(itemInfo.getStorageClass()).hasValue("STANDARD");
     assertThat(itemInfo.getMetaGeneration()).isEqualTo(2L);
     assertThat(itemInfo.getCreationTime())
         .isEqualTo(OffsetDateTime.parse("2026-08-01T10:00:00Z").toInstant().toEpochMilli());
@@ -1246,7 +1244,6 @@ class GcsClientImplTest {
         .thenReturn(OffsetDateTime.parse("2026-08-02T10:00:00Z"));
     when(mockBlob.getContentType()).thenReturn(TEST_CONTENT_TYPE);
     when(mockBlob.getContentEncoding()).thenReturn(TEST_CONTENT_ENCODING);
-    when(mockBlob.getStorageClass()).thenReturn(StorageClass.STANDARD);
     when(mockBlob.getMd5()).thenReturn(BaseEncoding.base64().encode("md5checksum".getBytes(UTF_8)));
     when(mockBlob.getCrc32c()).thenReturn(BaseEncoding.base64().encode("crc32c".getBytes(UTF_8)));
     when(mockBlob.getMetadata()).thenReturn(ImmutableMap.of("userKey", "userVal"));
@@ -1257,7 +1254,6 @@ class GcsClientImplTest {
     Bucket mockBucket = mock(Bucket.class);
     when(mockBucket.getName()).thenReturn(bucketName);
     when(mockBucket.getLocation()).thenReturn(TEST_LOCATION);
-    when(mockBucket.getStorageClass()).thenReturn(StorageClass.STANDARD);
     when(mockBucket.getMetageneration()).thenReturn(2L);
     when(mockBucket.getCreateTimeOffsetDateTime())
         .thenReturn(OffsetDateTime.parse("2026-08-01T10:00:00Z"));

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -1052,13 +1052,25 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getFolderInfo_notObjectItemId_throwsIllegalArgumentException() {
+  void getFolderInfo_rootItemId_returnsRootInfo() throws IOException {
+    GcsItemInfo itemInfo = gcsClient.getFolderInfo(GcsItemId.ROOT);
+
+    assertThat(itemInfo).isEqualTo(GcsItemInfo.ROOT_INFO);
+  }
+
+  @Test
+  void getFolderInfo_bucketItemId_returnsBucketInfo() throws IOException {
     GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
+    Bucket mockBucket = createMockBucket(TEST_BUCKET);
+    Storage mockStorage = mock(Storage.class);
+    when(mockStorage.get(eq(TEST_BUCKET), any(Storage.BucketGetOption[].class)))
+        .thenReturn(mockBucket);
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
-    IllegalArgumentException e =
-        assertThrows(IllegalArgumentException.class, () -> gcsClient.getFolderInfo(bucketId));
+    GcsItemInfo itemInfo = clientWithMock.getFolderInfo(bucketId);
 
-    assertThat(e).hasMessageThat().contains("Expected a folder itemId");
+    assertThat(itemInfo.getItemId()).isEqualTo(bucketId);
+    assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.BUCKET);
   }
 
   @Test
@@ -1121,24 +1133,15 @@ class GcsClientImplTest {
   }
 
   @Test
-  void lazyGetStorageControlClient_reusesExistingInstance() throws IOException {
-    GcsClientImpl localClient = createClientWithMockStorage(mock(Storage.class));
-    StorageControlClient mockClient = mock(StorageControlClient.class);
-    localClient.storageControlClient = mockClient;
+  void lazyGetStorageControlClient_initializesWhenNullAndReusesInstance() throws Exception {
+    StorageControlClient mockControlClient = mock(StorageControlClient.class);
+    GcsClientImpl mockClient = createClientWithMockControl(mockControlClient);
 
-    StorageControlClient result = localClient.lazyGetStorageControlClient();
+    StorageControlClient createdInstance = mockClient.lazyGetStorageControlClient();
+    StorageControlClient cachedInstance = mockClient.lazyGetStorageControlClient();
 
-    assertThat(result).isSameInstanceAs(mockClient);
-  }
-
-  @Test
-  void lazyGetStorageControlClient_initializesClientWhenNull() throws Exception {
-    GcsClientImpl localClient = createClientWithMockStorage(mock(Storage.class));
-
-    StorageControlClient result = localClient.lazyGetStorageControlClient();
-
-    assertThat(result).isNotNull();
-    result.close();
+    assertThat(createdInstance).isSameInstanceAs(mockControlClient);
+    assertThat(cachedInstance).isSameInstanceAs(mockControlClient);
   }
 
   @Test
@@ -1181,7 +1184,7 @@ class GcsClientImplTest {
       }
 
       @Override
-      StorageControlClient lazyGetStorageControlClient() {
+      protected StorageControlClient createStorageControlClient(Optional<Credentials> credentials) {
         return mockControlClient;
       }
     };

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -131,13 +131,7 @@ class GcsClientImplTest {
 
   @BeforeEach
   void setUp() throws IOException {
-    gcsClient =
-        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
-          @Override
-          protected Storage createStorage(Optional<Credentials> credentials) {
-            return GcsClientImplTest.this.storage;
-          }
-        };
+    gcsClient = createClientWithMockStorage(storage);
   }
 
   @Test
@@ -433,13 +427,7 @@ class GcsClientImplTest {
 
   @Test
   void create_withLocalStorage_writesSuccessfully() throws Exception {
-    GcsClientImpl client =
-        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
-          @Override
-          protected Storage createStorage(Optional<Credentials> credentials) {
-            return GcsClientImplTest.this.storage;
-          }
-        };
+    GcsClientImpl client = createClientWithMockStorage(storage);
     GcsItemId itemId =
         GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_WRITE_OBJECT).build();
     BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(TEST_BUCKET, TEST_WRITE_OBJECT)).build();
@@ -958,13 +946,7 @@ class GcsClientImplTest {
     Storage mockStorage = mock(Storage.class);
     ApiFuture<BlobReadSession> mockSessionFuture = mock(ApiFuture.class);
     when(mockStorage.blobReadSession(any(BlobId.class))).thenReturn(mockSessionFuture);
-    GcsClient bidiClient =
-        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
-          @Override
-          protected Storage createStorage(Optional<Credentials> credentials) {
-            return mockStorage;
-          }
-        };
+    GcsClient bidiClient = createClientWithMockStorage(mockStorage);
 
     VectoredSeekableByteChannel channel = bidiClient.openReadChannel(itemInfo, readOptions);
 
@@ -980,13 +962,7 @@ class GcsClientImplTest {
     Storage mockStorage = mock(Storage.class);
     ApiFuture<BlobReadSession> mockSessionFuture = mock(ApiFuture.class);
     when(mockStorage.blobReadSession(any(BlobId.class))).thenReturn(mockSessionFuture);
-    GcsClient bidiClient =
-        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
-          @Override
-          protected Storage createStorage(Optional<Credentials> credentials) {
-            return mockStorage;
-          }
-        };
+    GcsClient bidiClient = createClientWithMockStorage(mockStorage);
 
     VectoredSeekableByteChannel channel = bidiClient.openReadChannel(itemId, readOptions);
 
@@ -1025,16 +1001,8 @@ class GcsClientImplTest {
   @Test
   void getBucketInfo_bucketExists_returnsBucketInfo() throws IOException {
     GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
+    Bucket mockBucket = createMockBucket(TEST_BUCKET);
     Storage mockStorage = mock(Storage.class);
-    Bucket mockBucket = mock(Bucket.class);
-    when(mockBucket.getName()).thenReturn(TEST_BUCKET);
-    when(mockBucket.getLocation()).thenReturn(TEST_LOCATION);
-    when(mockBucket.getStorageClass()).thenReturn(StorageClass.STANDARD);
-    when(mockBucket.getMetageneration()).thenReturn(2L);
-    when(mockBucket.getCreateTimeOffsetDateTime())
-        .thenReturn(OffsetDateTime.parse("2026-08-01T10:00:00Z"));
-    when(mockBucket.getUpdateTimeOffsetDateTime())
-        .thenReturn(OffsetDateTime.parse("2026-08-02T10:00:00Z"));
     when(mockStorage.get(eq(TEST_BUCKET))).thenReturn(mockBucket);
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
@@ -1044,8 +1012,8 @@ class GcsClientImplTest {
     assertThat(itemInfo.getItemId()).isEqualTo(bucketId);
     assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.BUCKET);
     assertThat(itemInfo.getSize()).isEqualTo(0L);
-    assertThat(itemInfo.getLocation().get()).isEqualTo(TEST_LOCATION);
-    assertThat(itemInfo.getStorageClass().get()).isEqualTo("STANDARD");
+    assertThat(itemInfo.getLocation()).hasValue(TEST_LOCATION);
+    assertThat(itemInfo.getStorageClass()).hasValue("STANDARD");
     assertThat(itemInfo.getMetaGeneration()).isEqualTo(2L);
     assertThat(itemInfo.getCreationTime())
         .isEqualTo(OffsetDateTime.parse("2026-08-01T10:00:00Z").toInstant().toEpochMilli());
@@ -1078,14 +1046,8 @@ class GcsClientImplTest {
             .setBucketName(TEST_BUCKET)
             .setObjectName(TEST_FOLDER_NAME + "/")
             .build();
+    Folder mockFolder = createMockFolder(TEST_BUCKET, TEST_FOLDER_NAME);
     StorageControlClient mockControlClient = mock(StorageControlClient.class);
-    Folder mockFolder =
-        Folder.newBuilder()
-            .setName("projects/_/buckets/" + TEST_BUCKET + "/folders/" + TEST_FOLDER_NAME)
-            .setMetageneration(3L)
-            .setCreateTime(Timestamp.newBuilder().setSeconds(1000).setNanos(500).build())
-            .setUpdateTime(Timestamp.newBuilder().setSeconds(2000).setNanos(500).build())
-            .build();
     when(mockControlClient.getFolder(any(GetFolderRequest.class))).thenReturn(mockFolder);
     GcsClientImpl clientWithMockControl = createClientWithMockControl(mockControlClient);
 
@@ -1188,29 +1150,8 @@ class GcsClientImplTest {
   void listObjectInfo_returnsObjectsWithMetadata() throws IOException {
     GcsItemId prefixId =
         GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
-    Blob mockBlob = mock(Blob.class);
-    when(mockBlob.getBucket()).thenReturn(TEST_BUCKET);
-    when(mockBlob.getName()).thenReturn(TEST_DIR + TEST_OBJECT);
-    when(mockBlob.getGeneration()).thenReturn(100L);
-    when(mockBlob.getMetageneration()).thenReturn(2L);
-    when(mockBlob.getSize()).thenReturn(1024L);
-    when(mockBlob.getCreateTimeOffsetDateTime())
-        .thenReturn(OffsetDateTime.parse("2026-08-01T10:00:00Z"));
-    when(mockBlob.getUpdateTimeOffsetDateTime())
-        .thenReturn(OffsetDateTime.parse("2026-08-02T10:00:00Z"));
-    when(mockBlob.getContentType()).thenReturn(TEST_CONTENT_TYPE);
-    when(mockBlob.getContentEncoding()).thenReturn(TEST_CONTENT_ENCODING);
-    when(mockBlob.getStorageClass()).thenReturn(StorageClass.STANDARD);
-    when(mockBlob.getMd5()).thenReturn(BaseEncoding.base64().encode("md5checksum".getBytes(UTF_8)));
-    when(mockBlob.getCrc32c()).thenReturn(BaseEncoding.base64().encode("crc32c".getBytes(UTF_8)));
-    when(mockBlob.getMetadata()).thenReturn(ImmutableMap.of("userKey", "userVal"));
-
-    @SuppressWarnings("unchecked")
-    Page<Blob> mockPage = mock(Page.class);
-    when(mockPage.iterateAll()).thenReturn(ImmutableList.of(mockBlob));
-    Storage mockStorage = mock(Storage.class);
-    when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
-        .thenReturn(mockPage);
+    Blob mockBlob = createMockBlobWithFullMetadata(TEST_BUCKET, TEST_DIR + TEST_OBJECT);
+    Storage mockStorage = createMockStorageWithBlobs(TEST_BUCKET, mockBlob);
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
     List<GcsItemInfo> result = clientWithMock.listObjectInfo(prefixId, 10);
@@ -1218,44 +1159,35 @@ class GcsClientImplTest {
     assertThat(result).hasSize(1);
     GcsItemInfo item = result.get(0);
     assertThat(item.getItemId().getBucketName()).isEqualTo(TEST_BUCKET);
-    assertThat(item.getItemId().getObjectName().get()).isEqualTo(TEST_DIR + TEST_OBJECT);
+    assertThat(item.getItemId().getObjectName()).hasValue(TEST_DIR + TEST_OBJECT);
     assertThat(item.getSize()).isEqualTo(1024L);
-    assertThat(item.getContentGeneration()).isEqualTo(Optional.of(100L));
-    assertThat(item.getMetaGeneration()).isEqualTo(2L);
-    assertThat(item.getContentType()).isEqualTo(Optional.of(TEST_CONTENT_TYPE));
-    assertThat(item.getContentEncoding()).isEqualTo(Optional.of(TEST_CONTENT_ENCODING));
-    assertThat(item.getStorageClass()).isEqualTo(Optional.of("STANDARD"));
-    assertThat(item.getCreationTime())
-        .isEqualTo(OffsetDateTime.parse("2026-08-01T10:00:00Z").toInstant().toEpochMilli());
-    assertThat(item.getModificationTime())
-        .isEqualTo(OffsetDateTime.parse("2026-08-02T10:00:00Z").toInstant().toEpochMilli());
-    assertThat(item.getExtendedAttributes()).containsKey("userKey");
-    assertThat(item.getExtendedAttributes().get("userKey")).isEqualTo("userVal".getBytes(UTF_8));
   }
 
   @Test
   void listObjectInfo_withMaxResults_limitsReturnedItems() throws IOException {
     GcsItemId prefixId =
         GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
-    Blob mockBlob1 = mock(Blob.class);
-    when(mockBlob1.getBucket()).thenReturn(TEST_BUCKET);
-    when(mockBlob1.getName()).thenReturn(TEST_DIR + "file1.txt");
-    Blob mockBlob2 = mock(Blob.class);
-    when(mockBlob2.getBucket()).thenReturn(TEST_BUCKET);
-    when(mockBlob2.getName()).thenReturn(TEST_DIR + "file2.txt");
-
-    @SuppressWarnings("unchecked")
-    Page<Blob> mockPage = mock(Page.class);
-    when(mockPage.iterateAll()).thenReturn(ImmutableList.of(mockBlob1, mockBlob2));
-    Storage mockStorage = mock(Storage.class);
-    when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
-        .thenReturn(mockPage);
+    Blob mockBlob1 = createMockBlob(TEST_BUCKET, TEST_DIR + "file1.txt");
+    Blob mockBlob2 = createMockBlob(TEST_BUCKET, TEST_DIR + "file2.txt");
+    Storage mockStorage = createMockStorageWithBlobs(TEST_BUCKET, mockBlob1, mockBlob2);
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
     List<GcsItemInfo> result = clientWithMock.listObjectInfo(prefixId, 1);
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getItemId().getObjectName().get()).isEqualTo(TEST_DIR + "file1.txt");
+  }
+
+  @Test
+  void listObjectInfo_emptyPage_returnsEmptyList() throws IOException {
+    GcsItemId prefixId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
+    Storage mockStorage = createMockStorageWithBlobs(TEST_BUCKET);
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
+
+    List<GcsItemInfo> result = clientWithMock.listObjectInfo(prefixId, 10);
+
+    assertThat(result).isEmpty();
   }
 
   @Test
@@ -1312,5 +1244,61 @@ class GcsClientImplTest {
         assertThrows(IOException.class, () -> clientWithMock.listObjectInfo(prefixId, 10));
 
     assertThat(e).hasMessageThat().contains("Failed to list objects for prefix: " + prefixId);
+  }
+
+  private static Blob createMockBlob(String bucket, String name) {
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getBucket()).thenReturn(bucket);
+    when(mockBlob.getName()).thenReturn(name);
+    return mockBlob;
+  }
+
+  private static Blob createMockBlobWithFullMetadata(String bucket, String name) {
+    Blob mockBlob = createMockBlob(bucket, name);
+    when(mockBlob.getGeneration()).thenReturn(100L);
+    when(mockBlob.getMetageneration()).thenReturn(2L);
+    when(mockBlob.getSize()).thenReturn(1024L);
+    when(mockBlob.getCreateTimeOffsetDateTime())
+        .thenReturn(OffsetDateTime.parse("2026-08-01T10:00:00Z"));
+    when(mockBlob.getUpdateTimeOffsetDateTime())
+        .thenReturn(OffsetDateTime.parse("2026-08-02T10:00:00Z"));
+    when(mockBlob.getContentType()).thenReturn(TEST_CONTENT_TYPE);
+    when(mockBlob.getContentEncoding()).thenReturn(TEST_CONTENT_ENCODING);
+    when(mockBlob.getStorageClass()).thenReturn(StorageClass.STANDARD);
+    when(mockBlob.getMd5()).thenReturn(BaseEncoding.base64().encode("md5checksum".getBytes(UTF_8)));
+    when(mockBlob.getCrc32c()).thenReturn(BaseEncoding.base64().encode("crc32c".getBytes(UTF_8)));
+    when(mockBlob.getMetadata()).thenReturn(ImmutableMap.of("userKey", "userVal"));
+    return mockBlob;
+  }
+
+  private static Bucket createMockBucket(String bucketName) {
+    Bucket mockBucket = mock(Bucket.class);
+    when(mockBucket.getName()).thenReturn(bucketName);
+    when(mockBucket.getLocation()).thenReturn(TEST_LOCATION);
+    when(mockBucket.getStorageClass()).thenReturn(StorageClass.STANDARD);
+    when(mockBucket.getMetageneration()).thenReturn(2L);
+    when(mockBucket.getCreateTimeOffsetDateTime())
+        .thenReturn(OffsetDateTime.parse("2026-08-01T10:00:00Z"));
+    when(mockBucket.getUpdateTimeOffsetDateTime())
+        .thenReturn(OffsetDateTime.parse("2026-08-02T10:00:00Z"));
+    return mockBucket;
+  }
+
+  private static Folder createMockFolder(String bucketName, String folderName) {
+    return Folder.newBuilder()
+        .setName("projects/_/buckets/" + bucketName + "/folders/" + folderName)
+        .setMetageneration(3L)
+        .setCreateTime(Timestamp.newBuilder().setSeconds(1000).setNanos(500).build())
+        .setUpdateTime(Timestamp.newBuilder().setSeconds(2000).setNanos(500).build())
+        .build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Storage createMockStorageWithBlobs(String bucket, Blob... blobs) {
+    Page<Blob> mockPage = mock(Page.class);
+    when(mockPage.iterateAll()).thenReturn(ImmutableList.copyOf(blobs));
+    Storage mockStorage = mock(Storage.class);
+    when(mockStorage.list(eq(bucket), any(Storage.BlobListOption[].class))).thenReturn(mockPage);
+    return mockStorage;
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -979,11 +979,8 @@ class GcsClientImplTest {
 
   @Test
   void getBucketInfo_notBucketItemId_throwsIllegalArgumentException() {
-    GcsItemId objectId =
-        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("object.txt").build();
-
     IllegalArgumentException e =
-        assertThrows(IllegalArgumentException.class, () -> gcsClient.getBucketInfo(objectId));
+        assertThrows(IllegalArgumentException.class, () -> gcsClient.getBucketInfo(TEST_ITEM_ID));
 
     assertThat(e).hasMessageThat().contains("Expected a bucket itemId");
   }
@@ -1008,7 +1005,6 @@ class GcsClientImplTest {
 
     GcsItemInfo itemInfo = clientWithMock.getBucketInfo(bucketId);
 
-    assertThat(itemInfo).isNotNull();
     assertThat(itemInfo.getItemId()).isEqualTo(bucketId);
     assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.BUCKET);
     assertThat(itemInfo.getSize()).isEqualTo(0L);
@@ -1119,17 +1115,15 @@ class GcsClientImplTest {
 
   @Test
   void getFolderInfo_otherRpcException_throwsIOException() throws IOException {
-    GcsItemId folderItemId =
-        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_OBJECT).build();
     StorageControlClient mockControlClient = mock(StorageControlClient.class);
     when(mockControlClient.getFolder(any(GetFolderRequest.class)))
         .thenThrow(new RuntimeException("RPC error"));
     GcsClientImpl clientWithMockControl = createClientWithMockControl(mockControlClient);
 
     IOException e =
-        assertThrows(IOException.class, () -> clientWithMockControl.getFolderInfo(folderItemId));
+        assertThrows(IOException.class, () -> clientWithMockControl.getFolderInfo(TEST_ITEM_ID));
 
-    assertThat(e).hasMessageThat().contains("Folder not found: " + folderItemId);
+    assertThat(e).hasMessageThat().contains("Failed to get folder info for: " + TEST_ITEM_ID);
   }
 
   private GcsClientImpl createClientWithMockControl(StorageControlClient mockControlClient) {
@@ -1175,7 +1169,7 @@ class GcsClientImplTest {
     List<GcsItemInfo> result = clientWithMock.listObjectInfo(prefixId, 1);
 
     assertThat(result).hasSize(1);
-    assertThat(result.get(0).getItemId().getObjectName().get()).isEqualTo(TEST_DIR + "file1.txt");
+    assertThat(result.get(0).getItemId().getObjectName()).hasValue(TEST_DIR + "file1.txt");
   }
 
   @Test
@@ -1192,33 +1186,23 @@ class GcsClientImplTest {
 
   @Test
   void listObjectInfo_nullPrefixId_throwsNullPointerException() {
-    Storage mockStorage = mock(Storage.class);
-    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
-
     NullPointerException e =
-        assertThrows(NullPointerException.class, () -> clientWithMock.listObjectInfo(null, 10));
+        assertThrows(NullPointerException.class, () -> gcsClient.listObjectInfo(null, 10));
 
     assertThat(e).hasMessageThat().contains("prefixId must not be null");
   }
 
   @Test
   void listObjectInfo_nonPositiveMaxResults_throwsIllegalArgumentException() {
-    GcsItemId prefixId =
-        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
-    Storage mockStorage = mock(Storage.class);
-    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
-
     IllegalArgumentException e =
         assertThrows(
-            IllegalArgumentException.class, () -> clientWithMock.listObjectInfo(prefixId, 0));
+            IllegalArgumentException.class, () -> gcsClient.listObjectInfo(TEST_ITEM_ID, 0));
 
     assertThat(e).hasMessageThat().contains("maxResults must be > 0");
   }
 
   @Test
   void listObjectInfo_bucketNotFound_throwsFileNotFoundException() {
-    GcsItemId prefixId =
-        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
         .thenThrow(new StorageException(404, "Bucket not found"));
@@ -1226,24 +1210,22 @@ class GcsClientImplTest {
 
     FileNotFoundException e =
         assertThrows(
-            FileNotFoundException.class, () -> clientWithMock.listObjectInfo(prefixId, 10));
+            FileNotFoundException.class, () -> clientWithMock.listObjectInfo(TEST_ITEM_ID, 10));
 
     assertThat(e).hasMessageThat().contains("Bucket not found: " + TEST_BUCKET);
   }
 
   @Test
   void listObjectInfo_storageException_throwsIOException() {
-    GcsItemId prefixId =
-        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
         .thenThrow(new StorageException(500, "Internal error"));
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
     IOException e =
-        assertThrows(IOException.class, () -> clientWithMock.listObjectInfo(prefixId, 10));
+        assertThrows(IOException.class, () -> clientWithMock.listObjectInfo(TEST_ITEM_ID, 10));
 
-    assertThat(e).hasMessageThat().contains("Failed to list objects for prefix: " + prefixId);
+    assertThat(e).hasMessageThat().contains("Failed to list objects for prefix: " + TEST_ITEM_ID);
   }
 
   private static Blob createMockBlob(String bucket, String name) {

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -172,7 +172,29 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getGcsItemInfo_nonExistentBlob_throwsFileNotFoundException() {
+  void getGcsItemInfo_placeholderDirectory_returnsPlaceholderDirectoryItemInfo()
+      throws IOException {
+    GcsItemId directoryId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("dir/").build();
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getBucket()).thenReturn(TEST_BUCKET);
+    when(mockBlob.getName()).thenReturn("dir/");
+    when(mockBlob.getGeneration()).thenReturn(1L);
+    when(mockBlob.isDirectory()).thenReturn(true);
+    Storage mockStorage = mock(Storage.class);
+    when(mockStorage.get(eq(BlobId.of(TEST_BUCKET, "dir/")), any(Storage.BlobGetOption[].class)))
+        .thenReturn(mockBlob);
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
+
+    GcsItemInfo itemInfo = clientWithMock.getGcsItemInfo(directoryId);
+
+    assertThat(itemInfo.getItemId().getBucketName()).isEqualTo(TEST_BUCKET);
+    assertThat(itemInfo.getItemId().getObjectName()).hasValue("dir/");
+    assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.PLACEHOLDER_DIRECTORY);
+  }
+
+  @Test
+  void getGcsItemInfo_storageReturnsNull_throwsFileNotFoundException() {
     GcsItemId nonExistentItemId =
         GcsItemId.builder()
             .setBucketName(TEST_BUCKET_NAME)
@@ -393,7 +415,7 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getBucketProperties_storageException_throwsIOException() {
+  void getBucketProperties_storageThrows500_throwsIOException() {
     Storage mockStorage = mock(Storage.class);
     GcsClientImpl localGcsClient = createClientWithMockStorage(mockStorage);
     doThrow(new StorageException(500, "Internal Error"))
@@ -761,7 +783,7 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getBlob_whenStorageThrowsException_throwsIOException() throws Exception {
+  void getGcsItemInfo_storageThrows500_throwsIOException() throws Exception {
     Storage mockStorage = mock(Storage.class);
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
     GcsItemId itemId =
@@ -989,7 +1011,7 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getBucketInfo_nonExistentBucket_throwsFileNotFoundException() {
+  void getBucketInfo_storageReturnsNull_throwsFileNotFoundException() {
     GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_NON_EXISTENT_BUCKET).build();
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.get(eq(TEST_NON_EXISTENT_BUCKET), any(Storage.BucketGetOption[].class)))
@@ -1025,7 +1047,7 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getBucketInfo_storageException404_throwsFileNotFoundException() {
+  void getBucketInfo_storageThrows404_throwsFileNotFoundException() {
     GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.get(eq(TEST_BUCKET), any(Storage.BucketGetOption[].class)))
@@ -1039,7 +1061,7 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getBucketInfo_storageException500_throwsIOException() {
+  void getBucketInfo_storageThrows500_throwsIOException() {
     GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.get(eq(TEST_BUCKET), any(Storage.BucketGetOption[].class)))
@@ -1107,7 +1129,7 @@ class GcsClientImplTest {
     GcsItemInfo itemInfo = clientWithMockControl.getFolderInfo(folderItemId);
 
     assertThat(itemInfo.getItemId()).isEqualTo(folderItemId);
-    assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.EXPLICIT_DIRECTORY);
+    assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.NATIVE_FOLDER);
     assertThat(itemInfo.getSize()).isEqualTo(0L);
     assertThat(itemInfo.getMetaGeneration()).isEqualTo(3L);
     assertThat(itemInfo.getCreationTime())
@@ -1161,6 +1183,7 @@ class GcsClientImplTest {
 
     verify(mockStorage).close();
     verify(mockControlClient).close();
+    assertThat(localClient.storageControlClient).isNull();
   }
 
   @Test
@@ -1321,7 +1344,7 @@ class GcsClientImplTest {
   }
 
   @Test
-  void listFirstObjectWithPrefix_bucketNotFound_throwsFileNotFoundException() {
+  void listFirstObjectWithPrefix_storageThrows404_throwsFileNotFoundException() {
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
         .thenThrow(new StorageException(404, "Bucket not found"));
@@ -1336,7 +1359,7 @@ class GcsClientImplTest {
   }
 
   @Test
-  void listFirstObjectWithPrefix_storageException_throwsIOException() {
+  void listFirstObjectWithPrefix_storageThrows500_throwsIOException() {
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
         .thenThrow(new StorageException(500, "Internal error"));
@@ -1382,7 +1405,6 @@ class GcsClientImplTest {
   @SuppressWarnings("unchecked")
   private static Storage createMockStorageWithBlobs(String bucket, Blob... blobs) {
     Page<Blob> mockPage = mock(Page.class);
-    when(mockPage.iterateAll()).thenReturn(ImmutableList.copyOf(blobs));
     when(mockPage.getValues()).thenReturn(ImmutableList.copyOf(blobs));
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.list(eq(bucket), any(Storage.BlobListOption[].class))).thenReturn(mockPage);

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -59,6 +59,7 @@ import com.google.protobuf.Timestamp;
 import com.google.storage.control.v2.Folder;
 import com.google.storage.control.v2.GetFolderRequest;
 import com.google.storage.control.v2.StorageControlClient;
+import com.google.storage.control.v2.StorageControlSettings;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -76,8 +77,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -161,6 +167,8 @@ class GcsClientImplTest {
     assertThat(itemInfo.getItemId()).isEqualTo(expectedItemId);
     assertThat(itemInfo.getSize()).isEqualTo(objectData.length());
     assertThat(itemInfo.getContentGeneration().get()).isEqualTo(0L);
+    assertThat(itemInfo.getVerificationAttributes().get().getMd5hash()).isNull();
+    assertThat(itemInfo.getVerificationAttributes().get().getCrc32c()).isNotNull();
   }
 
   @Test
@@ -1109,6 +1117,24 @@ class GcsClientImplTest {
   }
 
   @Test
+  void getFolderInfo_folderWithoutCreateOrUpdateTime_setsTimestampsToZero() throws IOException {
+    GcsItemId folderItemId =
+        GcsItemId.builder()
+            .setBucketName(TEST_BUCKET)
+            .setObjectName(TEST_FOLDER_NAME + "/")
+            .build();
+    StorageControlClient mockControlClient = mock(StorageControlClient.class);
+    when(mockControlClient.getFolder(any(GetFolderRequest.class)))
+        .thenReturn(Folder.getDefaultInstance());
+    GcsClientImpl clientWithMockControl = createClientWithMockControl(mockControlClient);
+
+    GcsItemInfo itemInfo = clientWithMockControl.getFolderInfo(folderItemId);
+
+    assertThat(itemInfo.getCreationTime()).isEqualTo(0L);
+    assertThat(itemInfo.getModificationTime()).isEqualTo(0L);
+  }
+
+  @Test
   void close_withStorageControlClient_closesBoth() throws Exception {
     Storage mockStorage = mock(Storage.class);
     StorageControlClient mockControlClient = mock(StorageControlClient.class);
@@ -1119,17 +1145,47 @@ class GcsClientImplTest {
 
     verify(mockStorage).close();
     verify(mockControlClient).close();
+    assertThat(localClient.storageControlClient).isNull();
   }
 
   @Test
-  void close_whenStorageCloseThrowsException_doesNotPropagate() throws Exception {
+  void close_whenUnderlyingClientsThrowException_suppressesException() throws Exception {
     Storage mockStorage = mock(Storage.class);
-    doThrow(new RuntimeException("close error")).when(mockStorage).close();
+    StorageControlClient mockControlClient = mock(StorageControlClient.class);
+    doThrow(new RuntimeException("storage close error")).when(mockStorage).close();
+    doThrow(new RuntimeException("control client close error")).when(mockControlClient).close();
     GcsClientImpl localClient = createClientWithMockStorage(mockStorage);
+    localClient.storageControlClient = mockControlClient;
 
     localClient.close();
 
     verify(mockStorage).close();
+    verify(mockControlClient).close();
+  }
+
+  @Test
+  void createStorageControlClient_withCredentials_createsClient() throws Exception {
+    GcsClientImpl localClient = createClientWithMockStorage(mock(Storage.class));
+
+    try (StorageControlClient controlClient =
+        localClient.createStorageControlClient(Optional.of(NoCredentials.getInstance()))) {
+      assertThat(controlClient).isNotNull();
+    }
+  }
+
+  @Test
+  void createStorageControlClient_withoutCredentials_createsClient() throws Exception {
+    GcsClientImpl localClient = createClientWithMockStorage(mock(Storage.class));
+    StorageControlClient mockControlClient = mock(StorageControlClient.class);
+
+    try (MockedStatic<StorageControlClient> mocked = mockStatic(StorageControlClient.class)) {
+      mocked
+          .when(() -> StorageControlClient.create(any(StorageControlSettings.class)))
+          .thenReturn(mockControlClient);
+
+      assertThat(localClient.createStorageControlClient(Optional.empty()))
+          .isSameInstanceAs(mockControlClient);
+    }
   }
 
   @Test
@@ -1142,6 +1198,45 @@ class GcsClientImplTest {
 
     assertThat(createdInstance).isSameInstanceAs(mockControlClient);
     assertThat(cachedInstance).isSameInstanceAs(mockControlClient);
+  }
+
+  @Test
+  void lazyGetStorageControlClient_concurrentCalls_instantiatesExactlyOnce() throws Exception {
+    StorageControlClient mockClientInstance = mock(StorageControlClient.class);
+    AtomicInteger factoryInvocations = new AtomicInteger();
+    GcsClientImpl client =
+        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
+          @Override
+          protected StorageControlClient createStorageControlClient(
+              Optional<Credentials> credentials) {
+            factoryInvocations.incrementAndGet();
+            return mockClientInstance;
+          }
+        };
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    CountDownLatch ready = new CountDownLatch(2);
+    CountDownLatch start = new CountDownLatch(1);
+    Callable<StorageControlClient> task =
+        () -> {
+          ready.countDown();
+          start.await();
+          return client.lazyGetStorageControlClient();
+        };
+
+    try {
+      Future<StorageControlClient> f1 = executor.submit(task);
+      Future<StorageControlClient> f2 = executor.submit(task);
+      ready.await(5, TimeUnit.SECONDS);
+      start.countDown();
+      StorageControlClient result1 = f1.get(5, TimeUnit.SECONDS);
+      StorageControlClient result2 = f2.get(5, TimeUnit.SECONDS);
+
+      assertThat(result1).isSameInstanceAs(mockClientInstance);
+      assertThat(result2).isSameInstanceAs(mockClientInstance);
+      assertThat(factoryInvocations.get()).isEqualTo(1);
+    } finally {
+      executor.shutdownNow();
+    }
   }
 
   @Test
@@ -1202,6 +1297,7 @@ class GcsClientImplTest {
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getItemId().getObjectName()).hasValue(TEST_DIR + "file.txt");
+    assertThat(result.get(0).getSize()).isEqualTo(0L);
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -28,10 +28,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.gax.paging.Page;
 import com.google.api.gax.rpc.NotFoundException;
 import com.google.auth.Credentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.gcs.analyticscore.common.telemetry.Telemetry;
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BlobReadSession;
@@ -47,12 +49,16 @@ import com.google.cloud.storage.HttpStorageOptions;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BucketGetOption;
+import com.google.cloud.storage.StorageClass;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
+import com.google.protobuf.Timestamp;
 import com.google.storage.control.v2.Folder;
 import com.google.storage.control.v2.GetFolderRequest;
 import com.google.storage.control.v2.StorageControlClient;
@@ -66,14 +72,19 @@ import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.FileAlreadyExistsException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
@@ -86,11 +97,17 @@ class GcsClientImplTest {
   private static final String TEST_BUCKET_ID = "test-bucket-id";
   private static final String TEST_OBJECT_ID = "test-object-id";
   private static final String TEST_WRITE_OBJECT = "test-write-object";
-  private static final String TEST_NULL_OPTIONS_OBJECT = "test-null-options";
   private static final String TEST_NON_EXISTENT_OBJECT = "non-existent-object";
   private static final String TEST_HNS_BUCKET = "hns-bucket";
   private static final String TEST_FLAT_BUCKET = "flat-bucket";
   private static final String TEST_NON_EXISTENT_BUCKET = "non-existent-bucket";
+  private static final String TEST_FORBIDDEN_BUCKET = "forbidden-bucket";
+  private static final String TEST_ERROR_BUCKET = "error-bucket";
+  private static final String TEST_LOCATION = "US";
+  private static final String TEST_FOLDER_NAME = "test-folder";
+  private static final String TEST_DIR = "dir/";
+  private static final String TEST_CONTENT_TYPE = "text/plain";
+  private static final String TEST_CONTENT_ENCODING = "gzip";
   private static final String TEST_OBJECT_NAME = "test-object-name";
   private static final String BLOB_WRITE_SESSION_CONFIG_FIELD = "blobWriteSessionConfig";
   private static final int MB = 1024 * 1024;
@@ -326,18 +343,7 @@ class GcsClientImplTest {
     BucketProperties bucketProperties = localGcsClient.getBucketProperties(TEST_HNS_BUCKET);
 
     assertThat(bucketProperties.isHnsEnabled()).isTrue();
-  }
-
-  @Test
-  void isHnsBucket_hnsBucket_returnsTrue() throws IOException {
-    Storage mockStorage = mock(Storage.class);
-    GcsClientImpl localGcsClient = createClientWithMockStorage(mockStorage);
-    Bucket mockBucket = mockBucketWithHns(true);
-    doReturn(mockBucket).when(mockStorage).get(eq(TEST_HNS_BUCKET), any(BucketGetOption.class));
-
-    boolean isHns = localGcsClient.isHnsBucket(TEST_HNS_BUCKET);
-
-    assertThat(isHns).isTrue();
+    assertThat(localGcsClient.isHnsBucket(TEST_HNS_BUCKET)).isTrue();
   }
 
   @Test
@@ -350,18 +356,7 @@ class GcsClientImplTest {
     BucketProperties bucketProperties = localGcsClient.getBucketProperties(TEST_FLAT_BUCKET);
 
     assertThat(bucketProperties.isHnsEnabled()).isFalse();
-  }
-
-  @Test
-  void isHnsBucket_flatBucket_returnsFalse() throws IOException {
-    Storage mockStorage = mock(Storage.class);
-    GcsClientImpl localGcsClient = createClientWithMockStorage(mockStorage);
-    Bucket mockBucket = mockBucketWithHns(false);
-    doReturn(mockBucket).when(mockStorage).get(eq(TEST_FLAT_BUCKET), any(BucketGetOption.class));
-
-    boolean isHns = localGcsClient.isHnsBucket(TEST_FLAT_BUCKET);
-
-    assertThat(isHns).isFalse();
+    assertThat(localGcsClient.isHnsBucket(TEST_FLAT_BUCKET)).isFalse();
   }
 
   @Test
@@ -393,9 +388,9 @@ class GcsClientImplTest {
     GcsClientImpl localGcsClient = createClientWithMockStorage(mockStorage);
     doThrow(new StorageException(403, "Forbidden"))
         .when(mockStorage)
-        .get(eq("forbidden-bucket"), any(BucketGetOption.class));
+        .get(eq(TEST_FORBIDDEN_BUCKET), any(BucketGetOption.class));
 
-    BucketProperties properties = localGcsClient.getBucketProperties("forbidden-bucket");
+    BucketProperties properties = localGcsClient.getBucketProperties(TEST_FORBIDDEN_BUCKET);
 
     assertThat(properties.isHnsEnabled()).isFalse();
   }
@@ -406,12 +401,13 @@ class GcsClientImplTest {
     GcsClientImpl localGcsClient = createClientWithMockStorage(mockStorage);
     doThrow(new StorageException(500, "Internal Error"))
         .when(mockStorage)
-        .get(eq("error-bucket"), any(BucketGetOption.class));
+        .get(eq(TEST_ERROR_BUCKET), any(BucketGetOption.class));
 
     IOException e =
-        assertThrows(IOException.class, () -> localGcsClient.getBucketProperties("error-bucket"));
+        assertThrows(
+            IOException.class, () -> localGcsClient.getBucketProperties(TEST_ERROR_BUCKET));
 
-    assertThat(e).hasMessageThat().contains("Unable to access bucket: error-bucket");
+    assertThat(e).hasMessageThat().contains("Unable to access bucket: " + TEST_ERROR_BUCKET);
   }
 
   private GcsClientImpl createClientWithMockStorage(Storage mockStorage) {
@@ -709,14 +705,16 @@ class GcsClientImplTest {
         .contains("GenerationMatch{key=IF_GENERATION_MATCH, val=12345}");
   }
 
-  @Test
-  void createStorage_withParallelCompositeUpload_setsPcuSessionConfig() throws Exception {
+  @ParameterizedTest
+  @EnumSource(GcsClientOptions.PartFileCleanupType.class)
+  void createStorage_withParallelCompositeUpload_setsPcuSessionConfig(
+      GcsClientOptions.PartFileCleanupType cleanupType) throws Exception {
     GcsClientOptions clientOptions =
         GcsClientOptions.builder()
             .setUploadType(GcsClientOptions.UploadType.PARALLEL_COMPOSITE_UPLOAD)
             .setPcuBufferCount(5)
             .setPcuBufferCapacity(128 * MB)
-            .setPcuPartFileCleanupType(GcsClientOptions.PartFileCleanupType.NEVER)
+            .setPcuPartFileCleanupType(cleanupType)
             .setPcuPartFileNamePrefix("custom-prefix-")
             .build();
 
@@ -786,27 +784,6 @@ class GcsClientImplTest {
   }
 
   @Test
-  void close_whenStorageThrowsException_handledSilently() throws Exception {
-    Storage mockStorage = mock(Storage.class);
-    doThrow(new RuntimeException("close failed")).when(mockStorage).close();
-    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
-
-    clientWithMock.close();
-
-    verify(mockStorage).close();
-  }
-
-  @Test
-  void close_whenCalled_closesStorage() throws Exception {
-    Storage mockStorage = mock(Storage.class);
-    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
-
-    clientWithMock.close();
-
-    verify(mockStorage).close();
-  }
-
-  @Test
   void create_whenOpenThrowsIOException_propagatesIOException() throws Exception {
     Storage mockStorage = mock(Storage.class);
     BlobWriteSession mockSession = mockBlobWriteSession(mockStorage);
@@ -823,36 +800,6 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getGcsItemInfo_whenBucketItemIdProvided_throwsUnsupportedOperationException()
-      throws Exception {
-    GcsItemId bucketItemId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
-    GcsClientImpl client =
-        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry);
-
-    UnsupportedOperationException thrown =
-        assertThrows(
-            UnsupportedOperationException.class, () -> client.getGcsItemInfo(bucketItemId));
-
-    assertThat(thrown).hasMessageThat().contains("Expected gcs object but got");
-  }
-
-  @Test
-  void create_withNullWriteOptions_success() throws Exception {
-    GcsItemId itemId =
-        GcsItemId.builder()
-            .setBucketName(TEST_BUCKET)
-            .setObjectName(TEST_NULL_OPTIONS_OBJECT)
-            .build();
-    try (WritableByteChannel channel = gcsClient.createWriteChannel(itemId, null)) {
-      channel.write(ByteBuffer.wrap("null options write".getBytes(UTF_8)));
-    }
-    assertThat(
-            new String(
-                storage.readAllBytes(BlobId.of(TEST_BUCKET, TEST_NULL_OPTIONS_OBJECT)), UTF_8))
-        .isEqualTo("null options write");
-  }
-
-  @Test
   void createStorage_withWriteToDiskAndNoTempPaths_setsBufferToTempDirSessionConfig()
       throws Exception {
     GcsClientOptions clientOptions =
@@ -865,30 +812,6 @@ class GcsClientImplTest {
 
     assertThat(getBlobWriteSessionConfig(client.storage.getOptions()))
         .isInstanceOf(BufferToDiskThenUpload.class);
-  }
-
-  @Test
-  void createStorage_withParallelCompositeUploadAndOnSuccessCleanup_setsPcuSessionConfig()
-      throws Exception {
-    GcsClientOptions clientOptions =
-        GcsClientOptions.builder()
-            .setUploadType(GcsClientOptions.UploadType.PARALLEL_COMPOSITE_UPLOAD)
-            .setPcuPartFileCleanupType(GcsClientOptions.PartFileCleanupType.ON_SUCCESS)
-            .build();
-
-    assertPcuSessionConfig(clientOptions);
-  }
-
-  @Test
-  void createStorage_withParallelCompositeUploadAndAlwaysCleanup_setsPcuSessionConfig()
-      throws Exception {
-    GcsClientOptions clientOptions =
-        GcsClientOptions.builder()
-            .setUploadType(GcsClientOptions.UploadType.PARALLEL_COMPOSITE_UPLOAD)
-            .setPcuPartFileCleanupType(GcsClientOptions.PartFileCleanupType.ALWAYS)
-            .build();
-
-    assertPcuSessionConfig(clientOptions);
   }
 
   @Test
@@ -1101,20 +1024,19 @@ class GcsClientImplTest {
 
   @Test
   void getBucketInfo_bucketExists_returnsBucketInfo() throws IOException {
-    String bucketName = "my-test-bucket";
-    GcsItemId bucketId = GcsItemId.builder().setBucketName(bucketName).build();
+    GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
     Storage mockStorage = mock(Storage.class);
     Bucket mockBucket = mock(Bucket.class);
-    when(mockBucket.getName()).thenReturn(bucketName);
-    when(mockBucket.getLocation()).thenReturn("US");
-    when(mockStorage.get(eq(bucketName))).thenReturn(mockBucket);
-    GcsClientImpl clientWithMock =
-        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
-          @Override
-          protected Storage createStorage(Optional<Credentials> credentials) {
-            return mockStorage;
-          }
-        };
+    when(mockBucket.getName()).thenReturn(TEST_BUCKET);
+    when(mockBucket.getLocation()).thenReturn(TEST_LOCATION);
+    when(mockBucket.getStorageClass()).thenReturn(StorageClass.STANDARD);
+    when(mockBucket.getMetageneration()).thenReturn(2L);
+    when(mockBucket.getCreateTimeOffsetDateTime())
+        .thenReturn(OffsetDateTime.parse("2026-08-01T10:00:00Z"));
+    when(mockBucket.getUpdateTimeOffsetDateTime())
+        .thenReturn(OffsetDateTime.parse("2026-08-02T10:00:00Z"));
+    when(mockStorage.get(eq(TEST_BUCKET))).thenReturn(mockBucket);
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
     GcsItemInfo itemInfo = clientWithMock.getBucketInfo(bucketId);
 
@@ -1122,7 +1044,13 @@ class GcsClientImplTest {
     assertThat(itemInfo.getItemId()).isEqualTo(bucketId);
     assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.BUCKET);
     assertThat(itemInfo.getSize()).isEqualTo(0L);
-    assertThat(itemInfo.getLocation().get()).isEqualTo("US");
+    assertThat(itemInfo.getLocation().get()).isEqualTo(TEST_LOCATION);
+    assertThat(itemInfo.getStorageClass().get()).isEqualTo("STANDARD");
+    assertThat(itemInfo.getMetaGeneration()).isEqualTo(2L);
+    assertThat(itemInfo.getCreationTime())
+        .isEqualTo(OffsetDateTime.parse("2026-08-01T10:00:00Z").toInstant().toEpochMilli());
+    assertThat(itemInfo.getModificationTime())
+        .isEqualTo(OffsetDateTime.parse("2026-08-02T10:00:00Z").toInstant().toEpochMilli());
   }
 
   @Test
@@ -1146,26 +1074,20 @@ class GcsClientImplTest {
   @Test
   void getFolderInfo_folderExists_returnsFolderInfo() throws IOException {
     GcsItemId folderItemId =
-        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("my-folder/").build();
+        GcsItemId.builder()
+            .setBucketName(TEST_BUCKET)
+            .setObjectName(TEST_FOLDER_NAME + "/")
+            .build();
     StorageControlClient mockControlClient = mock(StorageControlClient.class);
     Folder mockFolder =
         Folder.newBuilder()
-            .setName("projects/_/buckets/" + TEST_BUCKET + "/folders/my-folder")
+            .setName("projects/_/buckets/" + TEST_BUCKET + "/folders/" + TEST_FOLDER_NAME)
             .setMetageneration(3L)
+            .setCreateTime(Timestamp.newBuilder().setSeconds(1000).setNanos(500).build())
+            .setUpdateTime(Timestamp.newBuilder().setSeconds(2000).setNanos(500).build())
             .build();
     when(mockControlClient.getFolder(any(GetFolderRequest.class))).thenReturn(mockFolder);
-    GcsClientImpl clientWithMockControl =
-        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
-          @Override
-          protected Storage createStorage(Optional<Credentials> credentials) {
-            return GcsClientImplTest.this.storage;
-          }
-
-          @Override
-          StorageControlClient lazyGetStorageControlClient() {
-            return mockControlClient;
-          }
-        };
+    GcsClientImpl clientWithMockControl = createClientWithMockControl(mockControlClient);
 
     GcsItemInfo itemInfo = clientWithMockControl.getFolderInfo(folderItemId);
 
@@ -1173,27 +1095,58 @@ class GcsClientImplTest {
     assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.EXPLICIT_DIRECTORY);
     assertThat(itemInfo.getSize()).isEqualTo(0L);
     assertThat(itemInfo.getMetaGeneration()).isEqualTo(3L);
+    assertThat(itemInfo.getCreationTime())
+        .isEqualTo(Instant.ofEpochSecond(1000, 500).toEpochMilli());
+    assertThat(itemInfo.getModificationTime())
+        .isEqualTo(Instant.ofEpochSecond(2000, 500).toEpochMilli());
+  }
+
+  @Test
+  void close_withStorageControlClient_closesBoth() throws Exception {
+    Storage mockStorage = mock(Storage.class);
+    StorageControlClient mockControlClient = mock(StorageControlClient.class);
+    GcsClientImpl localClient = createClientWithMockStorage(mockStorage);
+    localClient.storageControlClient = mockControlClient;
+
+    localClient.close();
+
+    verify(mockStorage).close();
+    verify(mockControlClient).close();
+  }
+
+  @Test
+  void close_whenStorageCloseThrowsException_doesNotPropagate() throws Exception {
+    Storage mockStorage = mock(Storage.class);
+    doThrow(new RuntimeException("close error")).when(mockStorage).close();
+    GcsClientImpl localClient = createClientWithMockStorage(mockStorage);
+
+    localClient.close();
+
+    verify(mockStorage).close();
+  }
+
+  @Test
+  void lazyGetStorageControlClient_reusesExistingInstance() throws IOException {
+    GcsClientImpl localClient = createClientWithMockStorage(mock(Storage.class));
+    StorageControlClient mockClient = mock(StorageControlClient.class);
+    localClient.storageControlClient = mockClient;
+
+    StorageControlClient result = localClient.lazyGetStorageControlClient();
+
+    assertThat(result).isSameInstanceAs(mockClient);
   }
 
   @Test
   void getFolderInfo_notFound_throwsFileNotFoundException() throws IOException {
     GcsItemId folderItemId =
-        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("missing-folder").build();
+        GcsItemId.builder()
+            .setBucketName(TEST_BUCKET)
+            .setObjectName(TEST_NON_EXISTENT_OBJECT)
+            .build();
     StorageControlClient mockControlClient = mock(StorageControlClient.class);
     NotFoundException notFoundException = mock(NotFoundException.class);
     when(mockControlClient.getFolder(any(GetFolderRequest.class))).thenThrow(notFoundException);
-    GcsClientImpl clientWithMockControl =
-        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
-          @Override
-          protected Storage createStorage(Optional<Credentials> credentials) {
-            return GcsClientImplTest.this.storage;
-          }
-
-          @Override
-          StorageControlClient lazyGetStorageControlClient() {
-            return mockControlClient;
-          }
-        };
+    GcsClientImpl clientWithMockControl = createClientWithMockControl(mockControlClient);
 
     FileNotFoundException e =
         assertThrows(
@@ -1205,26 +1158,159 @@ class GcsClientImplTest {
   @Test
   void getFolderInfo_otherRpcException_throwsIOException() throws IOException {
     GcsItemId folderItemId =
-        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("folder").build();
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_OBJECT).build();
     StorageControlClient mockControlClient = mock(StorageControlClient.class);
     when(mockControlClient.getFolder(any(GetFolderRequest.class)))
         .thenThrow(new RuntimeException("RPC error"));
-    GcsClientImpl clientWithMockControl =
-        new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
-          @Override
-          protected Storage createStorage(Optional<Credentials> credentials) {
-            return GcsClientImplTest.this.storage;
-          }
-
-          @Override
-          StorageControlClient lazyGetStorageControlClient() {
-            return mockControlClient;
-          }
-        };
+    GcsClientImpl clientWithMockControl = createClientWithMockControl(mockControlClient);
 
     IOException e =
         assertThrows(IOException.class, () -> clientWithMockControl.getFolderInfo(folderItemId));
 
     assertThat(e).hasMessageThat().contains("Folder not found: " + folderItemId);
+  }
+
+  private GcsClientImpl createClientWithMockControl(StorageControlClient mockControlClient) {
+    return new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
+      @Override
+      protected Storage createStorage(Optional<Credentials> credentials) {
+        return GcsClientImplTest.this.storage;
+      }
+
+      @Override
+      StorageControlClient lazyGetStorageControlClient() {
+        return mockControlClient;
+      }
+    };
+  }
+
+  @Test
+  void listObjectInfo_returnsObjectsWithMetadata() throws IOException {
+    GcsItemId prefixId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getBucket()).thenReturn(TEST_BUCKET);
+    when(mockBlob.getName()).thenReturn(TEST_DIR + TEST_OBJECT);
+    when(mockBlob.getGeneration()).thenReturn(100L);
+    when(mockBlob.getMetageneration()).thenReturn(2L);
+    when(mockBlob.getSize()).thenReturn(1024L);
+    when(mockBlob.getCreateTimeOffsetDateTime())
+        .thenReturn(OffsetDateTime.parse("2026-08-01T10:00:00Z"));
+    when(mockBlob.getUpdateTimeOffsetDateTime())
+        .thenReturn(OffsetDateTime.parse("2026-08-02T10:00:00Z"));
+    when(mockBlob.getContentType()).thenReturn(TEST_CONTENT_TYPE);
+    when(mockBlob.getContentEncoding()).thenReturn(TEST_CONTENT_ENCODING);
+    when(mockBlob.getStorageClass()).thenReturn(StorageClass.STANDARD);
+    when(mockBlob.getMd5()).thenReturn(BaseEncoding.base64().encode("md5checksum".getBytes(UTF_8)));
+    when(mockBlob.getCrc32c()).thenReturn(BaseEncoding.base64().encode("crc32c".getBytes(UTF_8)));
+    when(mockBlob.getMetadata()).thenReturn(ImmutableMap.of("userKey", "userVal"));
+
+    @SuppressWarnings("unchecked")
+    Page<Blob> mockPage = mock(Page.class);
+    when(mockPage.iterateAll()).thenReturn(ImmutableList.of(mockBlob));
+    Storage mockStorage = mock(Storage.class);
+    when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
+        .thenReturn(mockPage);
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
+
+    List<GcsItemInfo> result = clientWithMock.listObjectInfo(prefixId, 10);
+
+    assertThat(result).hasSize(1);
+    GcsItemInfo item = result.get(0);
+    assertThat(item.getItemId().getBucketName()).isEqualTo(TEST_BUCKET);
+    assertThat(item.getItemId().getObjectName().get()).isEqualTo(TEST_DIR + TEST_OBJECT);
+    assertThat(item.getSize()).isEqualTo(1024L);
+    assertThat(item.getContentGeneration()).isEqualTo(Optional.of(100L));
+    assertThat(item.getMetaGeneration()).isEqualTo(2L);
+    assertThat(item.getContentType()).isEqualTo(Optional.of(TEST_CONTENT_TYPE));
+    assertThat(item.getContentEncoding()).isEqualTo(Optional.of(TEST_CONTENT_ENCODING));
+    assertThat(item.getStorageClass()).isEqualTo(Optional.of("STANDARD"));
+    assertThat(item.getCreationTime())
+        .isEqualTo(OffsetDateTime.parse("2026-08-01T10:00:00Z").toInstant().toEpochMilli());
+    assertThat(item.getModificationTime())
+        .isEqualTo(OffsetDateTime.parse("2026-08-02T10:00:00Z").toInstant().toEpochMilli());
+    assertThat(item.getExtendedAttributes()).containsKey("userKey");
+    assertThat(item.getExtendedAttributes().get("userKey")).isEqualTo("userVal".getBytes(UTF_8));
+  }
+
+  @Test
+  void listObjectInfo_withMaxResults_limitsReturnedItems() throws IOException {
+    GcsItemId prefixId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
+    Blob mockBlob1 = mock(Blob.class);
+    when(mockBlob1.getBucket()).thenReturn(TEST_BUCKET);
+    when(mockBlob1.getName()).thenReturn(TEST_DIR + "file1.txt");
+    Blob mockBlob2 = mock(Blob.class);
+    when(mockBlob2.getBucket()).thenReturn(TEST_BUCKET);
+    when(mockBlob2.getName()).thenReturn(TEST_DIR + "file2.txt");
+
+    @SuppressWarnings("unchecked")
+    Page<Blob> mockPage = mock(Page.class);
+    when(mockPage.iterateAll()).thenReturn(ImmutableList.of(mockBlob1, mockBlob2));
+    Storage mockStorage = mock(Storage.class);
+    when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
+        .thenReturn(mockPage);
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
+
+    List<GcsItemInfo> result = clientWithMock.listObjectInfo(prefixId, 1);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getItemId().getObjectName().get()).isEqualTo(TEST_DIR + "file1.txt");
+  }
+
+  @Test
+  void listObjectInfo_nullPrefixId_throwsNullPointerException() {
+    Storage mockStorage = mock(Storage.class);
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
+
+    NullPointerException e =
+        assertThrows(NullPointerException.class, () -> clientWithMock.listObjectInfo(null, 10));
+
+    assertThat(e).hasMessageThat().contains("prefixId must not be null");
+  }
+
+  @Test
+  void listObjectInfo_nonPositiveMaxResults_throwsIllegalArgumentException() {
+    GcsItemId prefixId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
+    Storage mockStorage = mock(Storage.class);
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> clientWithMock.listObjectInfo(prefixId, 0));
+
+    assertThat(e).hasMessageThat().contains("maxResults must be > 0");
+  }
+
+  @Test
+  void listObjectInfo_bucketNotFound_throwsFileNotFoundException() {
+    GcsItemId prefixId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
+    Storage mockStorage = mock(Storage.class);
+    when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
+        .thenThrow(new StorageException(404, "Bucket not found"));
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
+
+    FileNotFoundException e =
+        assertThrows(
+            FileNotFoundException.class, () -> clientWithMock.listObjectInfo(prefixId, 10));
+
+    assertThat(e).hasMessageThat().contains("Bucket not found: " + TEST_BUCKET);
+  }
+
+  @Test
+  void listObjectInfo_storageException_throwsIOException() {
+    GcsItemId prefixId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
+    Storage mockStorage = mock(Storage.class);
+    when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
+        .thenThrow(new StorageException(500, "Internal error"));
+    GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
+
+    IOException e =
+        assertThrows(IOException.class, () -> clientWithMock.listObjectInfo(prefixId, 10));
+
+    assertThat(e).hasMessageThat().contains("Failed to list objects for prefix: " + prefixId);
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -194,18 +194,16 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getGcsItemInfo_storageReturnsNull_throwsFileNotFoundException() {
+  void getGcsItemInfo_storageReturnsNull_returnsNotFoundItemInfo() throws IOException {
     GcsItemId nonExistentItemId =
         GcsItemId.builder()
             .setBucketName(TEST_BUCKET_NAME)
             .setObjectName(TEST_NON_EXISTENT_OBJECT)
             .build();
 
-    FileNotFoundException e =
-        assertThrows(
-            FileNotFoundException.class, () -> gcsClient.getGcsItemInfo(nonExistentItemId));
+    GcsItemInfo itemInfo = gcsClient.getGcsItemInfo(nonExistentItemId);
 
-    assertThat(e).hasMessageThat().contains("Object not found: " + nonExistentItemId);
+    assertNotFound(itemInfo, nonExistentItemId);
   }
 
   @Test
@@ -1011,17 +1009,16 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getBucketInfo_storageReturnsNull_throwsFileNotFoundException() {
+  void getBucketInfo_storageReturnsNull_returnsNotFoundItemInfo() throws IOException {
     GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_NON_EXISTENT_BUCKET).build();
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.get(eq(TEST_NON_EXISTENT_BUCKET), any(Storage.BucketGetOption[].class)))
         .thenReturn(null);
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
-    FileNotFoundException e =
-        assertThrows(FileNotFoundException.class, () -> clientWithMock.getBucketInfo(bucketId));
+    GcsItemInfo itemInfo = clientWithMock.getBucketInfo(bucketId);
 
-    assertThat(e).hasMessageThat().contains("Bucket not found: " + TEST_NON_EXISTENT_BUCKET);
+    assertNotFound(itemInfo, bucketId);
   }
 
   @Test
@@ -1047,17 +1044,16 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getBucketInfo_storageThrows404_throwsFileNotFoundException() {
+  void getBucketInfo_storageThrows404_returnsNotFoundItemInfo() throws IOException {
     GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.get(eq(TEST_BUCKET), any(Storage.BucketGetOption[].class)))
         .thenThrow(new StorageException(404, "Not Found"));
     GcsClientImpl clientWithMock = createClientWithMockStorage(mockStorage);
 
-    FileNotFoundException e =
-        assertThrows(FileNotFoundException.class, () -> clientWithMock.getBucketInfo(bucketId));
+    GcsItemInfo itemInfo = clientWithMock.getBucketInfo(bucketId);
 
-    assertThat(e).hasMessageThat().contains("Bucket not found: " + TEST_BUCKET);
+    assertNotFound(itemInfo, bucketId);
   }
 
   @Test
@@ -1263,7 +1259,7 @@ class GcsClientImplTest {
   }
 
   @Test
-  void getFolderInfo_notFound_throwsFileNotFoundException() throws IOException {
+  void getFolderInfo_notFound_returnsNotFoundItemInfo() throws IOException {
     GcsItemId folderItemId =
         GcsItemId.builder()
             .setBucketName(TEST_BUCKET)
@@ -1274,11 +1270,9 @@ class GcsClientImplTest {
     when(mockControlClient.getFolder(any(GetFolderRequest.class))).thenThrow(notFoundException);
     GcsClientImpl clientWithMockControl = createClientWithMockControl(mockControlClient);
 
-    FileNotFoundException e =
-        assertThrows(
-            FileNotFoundException.class, () -> clientWithMockControl.getFolderInfo(folderItemId));
+    GcsItemInfo itemInfo = clientWithMockControl.getFolderInfo(folderItemId);
 
-    assertThat(e).hasMessageThat().contains("Folder not found: " + folderItemId);
+    assertNotFound(itemInfo, folderItemId);
   }
 
   @Test
@@ -1409,5 +1403,11 @@ class GcsClientImplTest {
     Storage mockStorage = mock(Storage.class);
     when(mockStorage.list(eq(bucket), any(Storage.BlobListOption[].class))).thenReturn(mockPage);
     return mockStorage;
+  }
+
+  private static void assertNotFound(GcsItemInfo itemInfo, GcsItemId expectedItemId) {
+    assertThat(itemInfo.getItemId()).isEqualTo(expectedItemId);
+    assertThat(itemInfo.exists()).isFalse();
+    assertThat(itemInfo.getSize()).isEqualTo(-1L);
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileInfoTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileInfoTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.gcs.analyticscore.client;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class GcsFileInfoTest {
+
+  @Test
+  void rootInfo_hasRootUriAndRootItemInfo() {
+    GcsFileInfo rootInfo = GcsFileInfo.ROOT_INFO;
+
+    assertThat(rootInfo.getUri()).isEqualTo(GcsFileInfo.GCS_ROOT_URI);
+    assertThat(rootInfo.getItemInfo()).isEqualTo(GcsItemInfo.ROOT_INFO);
+    assertThat(rootInfo.getAttributes()).isEmpty();
+  }
+}

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileInfoTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileInfoTest.java
@@ -17,9 +17,17 @@ package com.google.cloud.gcs.analyticscore.client;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableMap;
+import java.net.URI;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class GcsFileInfoTest {
+
+  private static final String TEST_BUCKET = "bucket";
 
   @Test
   void rootInfo_hasRootUriAndRootItemInfo() {
@@ -28,5 +36,63 @@ class GcsFileInfoTest {
     assertThat(rootInfo.getUri()).isEqualTo(GcsFileInfo.GCS_ROOT_URI);
     assertThat(rootInfo.getItemInfo()).isEqualTo(GcsItemInfo.ROOT_INFO);
     assertThat(rootInfo.getAttributes()).isEmpty();
+    assertThat(rootInfo.exists()).isTrue();
+  }
+
+  @Test
+  void createNotFound_withUri_returnsNotFoundFileInfo() {
+    URI uri = URI.create("gs://" + TEST_BUCKET + "/non-existent.txt");
+
+    GcsFileInfo fileInfo = GcsFileInfo.createNotFound(uri);
+
+    assertNotFound(fileInfo, uri);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideItemIdsAndExpectedUris")
+  void createNotFound_withItemId_returnsNotFoundFileInfo(GcsItemId itemId, URI expectedUri) {
+    GcsFileInfo fileInfo = GcsFileInfo.createNotFound(itemId);
+
+    assertNotFound(fileInfo, expectedUri);
+    assertThat(fileInfo.getItemInfo().getItemId()).isEqualTo(itemId);
+  }
+
+  private static Stream<Arguments> provideItemIdsAndExpectedUris() {
+    return Stream.of(
+        Arguments.of(
+            GcsItemId.builder()
+                .setBucketName(TEST_BUCKET)
+                .setObjectName("non-existent.txt")
+                .build(),
+            URI.create("gs://" + TEST_BUCKET + "/non-existent.txt")),
+        Arguments.of(
+            GcsItemId.builder().setBucketName(TEST_BUCKET).build(),
+            URI.create("gs://" + TEST_BUCKET)),
+        Arguments.of(GcsItemId.ROOT, GcsFileInfo.GCS_ROOT_URI));
+  }
+
+  @Test
+  void exists_withExistingItemInfo_returnsTrue() {
+    GcsItemInfo existingInfo =
+        GcsItemInfo.builder()
+            .setItemId(
+                GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("file.txt").build())
+            .setSize(100L)
+            .build();
+    GcsFileInfo fileInfo =
+        GcsFileInfo.builder()
+            .setItemInfo(existingInfo)
+            .setUri(URI.create("gs://" + TEST_BUCKET + "/file.txt"))
+            .setAttributes(ImmutableMap.of())
+            .build();
+
+    assertThat(fileInfo.exists()).isTrue();
+  }
+
+  private static void assertNotFound(GcsFileInfo fileInfo, URI expectedUri) {
+    assertThat(fileInfo.getUri()).isEqualTo(expectedUri);
+    assertThat(fileInfo.exists()).isFalse();
+    assertThat(fileInfo.getItemInfo().exists()).isFalse();
+    assertThat(fileInfo.getItemInfo().getSize()).isEqualTo(-1L);
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
@@ -16,7 +16,7 @@
 package com.google.cloud.gcs.analyticscore.client;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -216,14 +216,9 @@ class GcsFileSystemImplTest {
 
     GcsFileInfo fileInfo = gcsFileSystem.getFileInfo(gcsPath);
 
-    assertNotNull(fileInfo);
-    assertEquals(gcsPath, fileInfo.getUri());
-    assertEquals(TEST_BUCKET, fileInfo.getItemInfo().getItemId().getBucketName());
-    assertTrue(fileInfo.getItemInfo().getItemId().getObjectName().isPresent());
-    assertEquals(TEST_OBJECT, fileInfo.getItemInfo().getItemId().getObjectName().get());
-    assertEquals(content.length(), fileInfo.getItemInfo().getSize());
-    assertNotNull(fileInfo.getAttributes());
-    assertTrue(fileInfo.getAttributes().isEmpty());
+    assertThat(fileInfo.getUri()).isEqualTo(gcsPath);
+    assertThat(fileInfo.getItemInfo()).isEqualTo(mockItemInfo);
+    assertThat(fileInfo.getAttributes()).isEmpty();
   }
 
   @Test
@@ -292,14 +287,9 @@ class GcsFileSystemImplTest {
 
     GcsFileInfo fileInfo = gcsFileSystem.getFileInfo(itemId);
 
-    assertNotNull(fileInfo);
-    assertEquals("gs://" + TEST_BUCKET + "/" + TEST_OBJECT, fileInfo.getUri().toString());
-    assertEquals(TEST_BUCKET, fileInfo.getItemInfo().getItemId().getBucketName());
-    assertTrue(fileInfo.getItemInfo().getItemId().getObjectName().isPresent());
-    assertEquals(TEST_OBJECT, fileInfo.getItemInfo().getItemId().getObjectName().get());
-    assertEquals(content.length(), fileInfo.getItemInfo().getSize());
-    assertNotNull(fileInfo.getAttributes());
-    assertTrue(fileInfo.getAttributes().isEmpty());
+    assertThat(fileInfo.getUri().toString()).isEqualTo("gs://" + TEST_BUCKET + "/" + TEST_OBJECT);
+    assertThat(fileInfo.getItemInfo()).isEqualTo(mockItemInfo);
+    assertThat(fileInfo.getAttributes()).isEmpty();
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemImplTest.java
@@ -16,6 +16,7 @@
 package com.google.cloud.gcs.analyticscore.client;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemIdTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemIdTest.java
@@ -52,4 +52,13 @@ class GcsItemIdTest {
 
     assertThat(gcsItemId.isGcsObject()).isFalse();
   }
+
+  @Test
+  void root_hasEmptyBucketAndObjectName() {
+    GcsItemId root = GcsItemId.ROOT;
+
+    assertThat(root.getBucketName()).isEmpty();
+    assertThat(root.getObjectName().isPresent()).isTrue();
+    assertThat(root.getObjectName().get()).isEmpty();
+  }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemIdTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemIdTest.java
@@ -95,6 +95,42 @@ class GcsItemIdTest {
   }
 
   @Test
+  void isRoot_root_returnsTrue() {
+    GcsItemId root = GcsItemId.ROOT;
+
+    assertThat(root.isRoot()).isTrue();
+  }
+
+  @Test
+  void isRoot_bucket_returnsFalse() {
+    GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
+
+    assertThat(bucketId.isRoot()).isFalse();
+  }
+
+  @Test
+  void isRoot_object_returnsFalse() {
+    GcsItemId objectId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_OBJECT).build();
+
+    assertThat(objectId.isRoot()).isFalse();
+  }
+
+  @Test
+  void isRoot_emptyBucketWithoutObject_returnsTrue() {
+    GcsItemId root = GcsItemId.builder().setBucketName("").build();
+
+    assertThat(root.isRoot()).isTrue();
+  }
+
+  @Test
+  void isRoot_emptyBucketWithObject_returnsFalse() {
+    GcsItemId itemId = GcsItemId.builder().setBucketName("").setObjectName(TEST_OBJECT).build();
+
+    assertThat(itemId.isRoot()).isFalse();
+  }
+
+  @Test
   void root_hasEmptyBucketAndObjectName() {
     GcsItemId root = GcsItemId.ROOT;
 
@@ -102,5 +138,6 @@ class GcsItemIdTest {
     assertThat(root.getObjectName()).hasValue("");
     assertThat(root.isBucket()).isFalse();
     assertThat(root.isGcsObject()).isFalse();
+    assertThat(root.isRoot()).isTrue();
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemIdTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemIdTest.java
@@ -21,36 +21,55 @@ import org.junit.jupiter.api.Test;
 
 class GcsItemIdTest {
 
+  private static final String TEST_BUCKET = "test-bucket";
+  private static final String TEST_OBJECT = "test-object";
+
   @Test
   void build_gcsObject_succeeds() {
     GcsItemId gcsItemId =
-        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_OBJECT).build();
 
-    assertThat(gcsItemId.getBucketName()).isEqualTo("test-bucket");
-    assertThat(gcsItemId.getObjectName().get()).isEqualTo("test-object");
+    assertThat(gcsItemId.getBucketName()).isEqualTo(TEST_BUCKET);
+    assertThat(gcsItemId.getObjectName().get()).isEqualTo(TEST_OBJECT);
   }
 
   @Test
   void build_gcsBucket_succeeds() {
-    GcsItemId gcsItemId = GcsItemId.builder().setBucketName("test-bucket").build();
+    GcsItemId gcsItemId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
 
-    assertThat(gcsItemId.getBucketName()).isEqualTo("test-bucket");
+    assertThat(gcsItemId.getBucketName()).isEqualTo(TEST_BUCKET);
     assertThat(gcsItemId.getObjectName().isEmpty()).isTrue();
   }
 
   @Test
   void isGcsObject_itemIdPointsToGcsObject_returnsTrue() {
     GcsItemId gcsItemId =
-        GcsItemId.builder().setBucketName("test-bucket").setObjectName("test-object").build();
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_OBJECT).build();
 
     assertThat(gcsItemId.isGcsObject()).isTrue();
   }
 
   @Test
-  void isGcsObject_itemIdPointsToDirectory_returnsFalse() {
-    GcsItemId gcsItemId = GcsItemId.builder().setBucketName("test-bucket").build();
+  void isGcsObject_itemIdPointsToBucket_returnsFalse() {
+    GcsItemId gcsItemId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
 
     assertThat(gcsItemId.isGcsObject()).isFalse();
+  }
+
+  @Test
+  void isBucket_withBucketOnly_returnsTrue() {
+    GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
+
+    assertThat(bucketId.isBucket()).isTrue();
+    assertThat(bucketId.isGcsObject()).isFalse();
+  }
+
+  @Test
+  void isBucket_withObject_returnsFalse() {
+    GcsItemId objectId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_OBJECT).build();
+
+    assertThat(objectId.isBucket()).isFalse();
   }
 
   @Test
@@ -60,5 +79,7 @@ class GcsItemIdTest {
     assertThat(root.getBucketName()).isEmpty();
     assertThat(root.getObjectName().isPresent()).isTrue();
     assertThat(root.getObjectName().get()).isEmpty();
+    assertThat(root.isBucket()).isFalse();
+    assertThat(root.isGcsObject()).isFalse();
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemIdTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemIdTest.java
@@ -57,6 +57,13 @@ class GcsItemIdTest {
   }
 
   @Test
+  void isGcsObject_emptyBucketWithObject_returnsFalse() {
+    GcsItemId itemId = GcsItemId.builder().setBucketName("").setObjectName(TEST_OBJECT).build();
+
+    assertThat(itemId.isGcsObject()).isFalse();
+  }
+
+  @Test
   void isBucket_withBucketOnly_returnsTrue() {
     GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
 

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemIdTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemIdTest.java
@@ -30,7 +30,7 @@ class GcsItemIdTest {
         GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_OBJECT).build();
 
     assertThat(gcsItemId.getBucketName()).isEqualTo(TEST_BUCKET);
-    assertThat(gcsItemId.getObjectName().get()).isEqualTo(TEST_OBJECT);
+    assertThat(gcsItemId.getObjectName()).hasValue(TEST_OBJECT);
   }
 
   @Test
@@ -38,7 +38,7 @@ class GcsItemIdTest {
     GcsItemId gcsItemId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
 
     assertThat(gcsItemId.getBucketName()).isEqualTo(TEST_BUCKET);
-    assertThat(gcsItemId.getObjectName().isEmpty()).isTrue();
+    assertThat(gcsItemId.getObjectName()).isEmpty();
   }
 
   @Test
@@ -77,8 +77,7 @@ class GcsItemIdTest {
     GcsItemId root = GcsItemId.ROOT;
 
     assertThat(root.getBucketName()).isEmpty();
-    assertThat(root.getObjectName().isPresent()).isTrue();
-    assertThat(root.getObjectName().get()).isEmpty();
+    assertThat(root.getObjectName()).hasValue("");
     assertThat(root.isBucket()).isFalse();
     assertThat(root.isGcsObject()).isFalse();
   }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemIdTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemIdTest.java
@@ -64,6 +64,13 @@ class GcsItemIdTest {
   }
 
   @Test
+  void isGcsObject_emptyObjectName_returnsFalse() {
+    GcsItemId itemId = GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("").build();
+
+    assertThat(itemId.isGcsObject()).isFalse();
+  }
+
+  @Test
   void isBucket_withBucketOnly_returnsTrue() {
     GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
 
@@ -77,6 +84,14 @@ class GcsItemIdTest {
         GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_OBJECT).build();
 
     assertThat(objectId.isBucket()).isFalse();
+  }
+
+  @Test
+  void isBucket_withEmptyObjectName_returnsTrue() {
+    GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("").build();
+
+    assertThat(bucketId.isBucket()).isTrue();
+    assertThat(bucketId.isGcsObject()).isFalse();
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
@@ -17,6 +17,9 @@ package com.google.cloud.gcs.analyticscore.client;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class GcsItemInfoTest {
@@ -72,5 +75,50 @@ class GcsItemInfoTest {
     assertThat(rootInfo.getItemId()).isEqualTo(GcsItemId.ROOT);
     assertThat(rootInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.ROOT);
     assertThat(rootInfo.getSize()).isEqualTo(0L);
+  }
+
+  @Test
+  void encodeAndDecodeMetadata_roundTripsCorrectly() {
+    ImmutableMap<String, byte[]> original =
+        ImmutableMap.of(
+            "key1", new byte[] {1, 2, 3},
+            "key2", new byte[] {0, -1, 127});
+
+    ImmutableMap<String, String> encoded = GcsItemInfo.encodeMetadata(original);
+    ImmutableMap<String, byte[]> decoded = GcsItemInfo.decodeMetadata(encoded);
+
+    assertThat(decoded.keySet()).isEqualTo(original.keySet());
+    decoded.forEach((k, v) -> assertThat(v).isEqualTo(original.get(k)));
+  }
+
+  @Test
+  void decodeMetadata_nullOrEmpty_returnsEmptyMap() {
+    assertThat(GcsItemInfo.decodeMetadata(null)).isEmpty();
+    assertThat(GcsItemInfo.decodeMetadata(ImmutableMap.of())).isEmpty();
+  }
+
+  @Test
+  void decodeMetadata_invalidBase64Value_ignoresInvalidAttributeAndDecodesValidAttributes() {
+    Map<String, String> metadata =
+        ImmutableMap.of(
+            "validKey",
+            GcsItemInfo.encodeMetadata(ImmutableMap.of("validKey", new byte[] {1, 2}))
+                .get("validKey"),
+            "invalidKey",
+            "not-base-64!!!");
+
+    ImmutableMap<String, byte[]> decoded = GcsItemInfo.decodeMetadata(metadata);
+
+    assertThat(decoded.keySet()).containsExactly("validKey");
+    assertThat(decoded.get("validKey")).isEqualTo(new byte[] {1, 2});
+  }
+
+  @Test
+  void decodeMetadata_nullKeyIsIgnored_nullValueMapsToEmptyByteArray() {
+    assertThat(GcsItemInfo.decodeMetadata(Collections.singletonMap(null, "dmFs"))).isEmpty();
+    ImmutableMap<String, byte[]> decodedNullVal =
+        GcsItemInfo.decodeMetadata(Collections.singletonMap("key", null));
+    assertThat(decodedNullVal.keySet()).containsExactly("key");
+    assertThat(decodedNullVal.get("key")).isEmpty();
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
@@ -173,4 +173,28 @@ class GcsItemInfoTest {
 
     assertThat(itemInfo.getStorageClass()).isEmpty();
   }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void isInferredDirectory_withInferredDirectoryType_returnsTrue() {
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder()
+            .setItemId(GcsItemId.builder().setBucketName("bucket").setObjectName("dir/").build())
+            .setItemType(GcsItemInfo.ItemType.INFERRED_DIRECTORY)
+            .build();
+
+    assertThat(itemInfo.isInferredDirectory()).isTrue();
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void isNativeHnsFolder_withNativeFolderType_returnsTrue() {
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder()
+            .setItemId(GcsItemId.builder().setBucketName("bucket").setObjectName("folder/").build())
+            .setItemType(GcsItemInfo.ItemType.NATIVE_FOLDER)
+            .build();
+
+    assertThat(itemInfo.isNativeHnsFolder()).isTrue();
+  }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
@@ -87,6 +87,31 @@ class GcsItemInfoTest {
     assertThat(rootInfo.getItemId()).isEqualTo(GcsItemId.ROOT);
     assertThat(rootInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.ROOT);
     assertThat(rootInfo.getSize()).isEqualTo(0L);
+    assertThat(rootInfo.exists()).isTrue();
+  }
+
+  @Test
+  void createNotFound_returnsItemInfoWithNegativeSizeAndExistsFalse() {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("non-existent.txt").build();
+
+    GcsItemInfo itemInfo = GcsItemInfo.createNotFound(itemId);
+
+    assertThat(itemInfo.getItemId()).isEqualTo(itemId);
+    assertThat(itemInfo.getSize()).isEqualTo(-1L);
+    assertThat(itemInfo.exists()).isFalse();
+  }
+
+  @Test
+  void exists_withNonNegativeSize_returnsTrue() {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName("file.txt").build();
+
+    GcsItemInfo existingInfo = GcsItemInfo.builder().setItemId(itemId).setSize(100L).build();
+    GcsItemInfo zeroSizeInfo = GcsItemInfo.builder().setItemId(itemId).setSize(0L).build();
+
+    assertThat(existingInfo.exists()).isTrue();
+    assertThat(zeroSizeInfo.exists()).isTrue();
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
@@ -158,4 +158,19 @@ class GcsItemInfoTest {
     assertThat(decodedNullVal.keySet()).containsExactly("key");
     assertThat(decodedNullVal.get("key")).isEmpty();
   }
+
+  @Test
+  void builder_withStorageClass_populatesStorageClass() {
+    GcsItemInfo itemInfo =
+        GcsItemInfo.builder().setItemId(GcsItemId.ROOT).setStorageClass("STANDARD").build();
+
+    assertThat(itemInfo.getStorageClass()).hasValue("STANDARD");
+  }
+
+  @Test
+  void builder_withoutStorageClass_hasEmptyStorageClass() {
+    GcsItemInfo itemInfo = GcsItemInfo.builder().setItemId(GcsItemId.ROOT).build();
+
+    assertThat(itemInfo.getStorageClass()).isEmpty();
+  }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
@@ -21,11 +21,17 @@ import org.junit.jupiter.api.Test;
 
 class GcsItemInfoTest {
 
+  private static final String TEST_BUCKET = "bucket";
+  private static final String TEST_DIR = "dir/";
+  private static final String TEST_FOLDER = "folder/";
+  private static final String TEST_OBJECT = "obj";
+
   @Test
   void isInferredDirectory() {
     GcsItemInfo itemInfo =
         GcsItemInfo.builder()
-            .setItemId(GcsItemId.builder().setBucketName("bucket").setObjectName("dir/").build())
+            .setItemId(
+                GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build())
             .setItemType(GcsItemInfo.ItemType.INFERRED_DIRECTORY)
             .build();
 
@@ -37,7 +43,8 @@ class GcsItemInfoTest {
   void isExplicitDirectory() {
     GcsItemInfo itemInfo =
         GcsItemInfo.builder()
-            .setItemId(GcsItemId.builder().setBucketName("bucket").setObjectName("folder/").build())
+            .setItemId(
+                GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_FOLDER).build())
             .setItemType(GcsItemInfo.ItemType.EXPLICIT_DIRECTORY)
             .build();
 
@@ -49,7 +56,8 @@ class GcsItemInfoTest {
   void isObject() {
     GcsItemInfo itemInfo =
         GcsItemInfo.builder()
-            .setItemId(GcsItemId.builder().setBucketName("bucket").setObjectName("obj").build())
+            .setItemId(
+                GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_OBJECT).build())
             .setItemType(GcsItemInfo.ItemType.OBJECT)
             .build();
 

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
@@ -30,19 +30,19 @@ class GcsItemInfoTest {
             .build();
 
     assertThat(itemInfo.isInferredDirectory()).isTrue();
-    assertThat(itemInfo.isNativeHnsFolder()).isFalse();
+    assertThat(itemInfo.isExplicitDirectory()).isFalse();
   }
 
   @Test
-  void isNativeHnsFolder() {
+  void isExplicitDirectory() {
     GcsItemInfo itemInfo =
         GcsItemInfo.builder()
             .setItemId(GcsItemId.builder().setBucketName("bucket").setObjectName("folder/").build())
-            .setItemType(GcsItemInfo.ItemType.NATIVE_FOLDER)
+            .setItemType(GcsItemInfo.ItemType.EXPLICIT_DIRECTORY)
             .build();
 
     assertThat(itemInfo.isInferredDirectory()).isFalse();
-    assertThat(itemInfo.isNativeHnsFolder()).isTrue();
+    assertThat(itemInfo.isExplicitDirectory()).isTrue();
   }
 
   @Test
@@ -54,6 +54,15 @@ class GcsItemInfoTest {
             .build();
 
     assertThat(itemInfo.isInferredDirectory()).isFalse();
-    assertThat(itemInfo.isNativeHnsFolder()).isFalse();
+    assertThat(itemInfo.isExplicitDirectory()).isFalse();
+  }
+
+  @Test
+  void rootInfo_hasRootItemTypeAndZeroSize() {
+    GcsItemInfo rootInfo = GcsItemInfo.ROOT_INFO;
+
+    assertThat(rootInfo.getItemId()).isEqualTo(GcsItemId.ROOT);
+    assertThat(rootInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.ROOT);
+    assertThat(rootInfo.getSize()).isEqualTo(0L);
   }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
@@ -31,12 +31,10 @@ class GcsItemInfoTest {
 
   @Test
   void isInferredDirectory() {
-    GcsItemInfo itemInfo =
-        GcsItemInfo.builder()
-            .setItemId(
-                GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build())
-            .setItemType(GcsItemInfo.ItemType.INFERRED_DIRECTORY)
-            .build();
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
+
+    GcsItemInfo itemInfo = GcsItemInfo.createInferredDirectory(itemId);
 
     assertThat(itemInfo.isInferredDirectory()).isTrue();
     assertThat(itemInfo.isExplicitDirectory()).isFalse();

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsItemInfoTest.java
@@ -27,43 +27,57 @@ class GcsItemInfoTest {
   private static final String TEST_BUCKET = "bucket";
   private static final String TEST_DIR = "dir/";
   private static final String TEST_FOLDER = "folder/";
-  private static final String TEST_OBJECT = "obj";
 
   @Test
-  void isInferredDirectory() {
+  void createInferredDirectory_returnsItemInfoWithInferredDirectoryType() {
     GcsItemId itemId =
         GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
 
     GcsItemInfo itemInfo = GcsItemInfo.createInferredDirectory(itemId);
 
-    assertThat(itemInfo.isInferredDirectory()).isTrue();
-    assertThat(itemInfo.isExplicitDirectory()).isFalse();
+    assertThat(itemInfo.getItemId()).isEqualTo(itemId);
+    assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.INFERRED_DIRECTORY);
+    assertThat(itemInfo.getSize()).isEqualTo(0L);
   }
 
   @Test
-  void isExplicitDirectory() {
-    GcsItemInfo itemInfo =
-        GcsItemInfo.builder()
-            .setItemId(
-                GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_FOLDER).build())
-            .setItemType(GcsItemInfo.ItemType.EXPLICIT_DIRECTORY)
-            .build();
+  void createPlaceholderDirectory_returnsItemInfoWithPlaceholderDirectoryType() {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_DIR).build();
 
-    assertThat(itemInfo.isInferredDirectory()).isFalse();
-    assertThat(itemInfo.isExplicitDirectory()).isTrue();
+    GcsItemInfo itemInfo = GcsItemInfo.createPlaceholderDirectory(itemId);
+
+    assertThat(itemInfo.getItemId()).isEqualTo(itemId);
+    assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.PLACEHOLDER_DIRECTORY);
+    assertThat(itemInfo.getSize()).isEqualTo(0L);
   }
 
   @Test
-  void isObject() {
-    GcsItemInfo itemInfo =
-        GcsItemInfo.builder()
-            .setItemId(
-                GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_OBJECT).build())
-            .setItemType(GcsItemInfo.ItemType.OBJECT)
-            .build();
+  void createFolder_returnsItemInfoWithNativeFolderTypeAndTimestamps() {
+    GcsItemId itemId =
+        GcsItemId.builder().setBucketName(TEST_BUCKET).setObjectName(TEST_FOLDER).build();
 
-    assertThat(itemInfo.isInferredDirectory()).isFalse();
-    assertThat(itemInfo.isExplicitDirectory()).isFalse();
+    GcsItemInfo itemInfo = GcsItemInfo.createFolder(itemId, 1000L, 2000L, 1L);
+
+    assertThat(itemInfo.getItemId()).isEqualTo(itemId);
+    assertThat(itemInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.NATIVE_FOLDER);
+    assertThat(itemInfo.getSize()).isEqualTo(0L);
+    assertThat(itemInfo.getContentGeneration()).isEmpty();
+    assertThat(itemInfo.getMetaGeneration()).isEqualTo(1L);
+    assertThat(itemInfo.getCreationTime()).isEqualTo(1000L);
+    assertThat(itemInfo.getModificationTime()).isEqualTo(2000L);
+    assertThat(itemInfo.getExtendedAttributes()).isEmpty();
+  }
+
+  @Test
+  void createBucket_returnsItemInfoWithBucketType() {
+    GcsItemId bucketId = GcsItemId.builder().setBucketName(TEST_BUCKET).build();
+
+    GcsItemInfo bucketInfo = GcsItemInfo.createBucket(bucketId);
+
+    assertThat(bucketInfo.getItemId()).isEqualTo(bucketId);
+    assertThat(bucketInfo.getItemType()).isEqualTo(GcsItemInfo.ItemType.BUCKET);
+    assertThat(bucketInfo.getSize()).isEqualTo(0L);
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
@@ -33,7 +33,7 @@ class UriUtilTest {
     GcsItemId itemId = UriUtil.getItemIdFromString(gcsBucketName);
 
     assertThat(itemId.getBucketName()).isEqualTo(TEST_BUCKET);
-    assertThat(itemId.getObjectName().isEmpty()).isTrue();
+    assertThat(itemId.getObjectName()).isEmpty();
   }
 
   @Test
@@ -43,8 +43,7 @@ class UriUtilTest {
     GcsItemId itemId = UriUtil.getItemIdFromString(gcsObjectName);
 
     assertThat(itemId.getBucketName()).isEqualTo(TEST_BUCKET);
-    assertThat(itemId.getObjectName().isPresent()).isTrue();
-    assertThat(itemId.getObjectName().get()).isEqualTo(TEST_OBJECT);
+    assertThat(itemId.getObjectName()).hasValue(TEST_OBJECT);
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
@@ -47,6 +47,15 @@ class UriUtilTest {
   }
 
   @Test
+  void getItemIdFromString_rootPath_returnsRootItemId() {
+    String rootPath = "gs:/";
+
+    GcsItemId itemId = UriUtil.getItemIdFromString(rootPath);
+
+    assertThat(itemId).isEqualTo(GcsItemId.ROOT);
+  }
+
+  @Test
   void getItemIdFromString_gsOnly_throwsIllegalArgumentException() {
     IllegalArgumentException e =
         assertThrows(IllegalArgumentException.class, () -> UriUtil.getItemIdFromString("gs://"));
@@ -65,6 +74,7 @@ class UriUtilTest {
   @Test
   void getItemIdFromString_invalidPath_throwsIllegalArgumentException() {
     String invalidPath = "http://test-bucket/test-object";
+
     IllegalArgumentException e =
         assertThrows(
             IllegalArgumentException.class, () -> UriUtil.getItemIdFromString(invalidPath));

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
@@ -109,22 +109,22 @@ class UriUtilTest {
   }
 
   @Test
-  void ensureTrailingSlash_withoutTrailingSlash_appendsSlash() {
-    String result = UriUtil.ensureTrailingSlash(TEST_PATH);
+  void toDirectoryPath_withoutTrailingSlash_appendsSlash() {
+    String result = UriUtil.toDirectoryPath(TEST_PATH);
 
     assertThat(result).isEqualTo(TEST_PATH + "/");
   }
 
   @Test
-  void ensureTrailingSlash_withTrailingSlash_returnsSame() {
-    String result = UriUtil.ensureTrailingSlash(TEST_PATH + "/");
+  void toDirectoryPath_withTrailingSlash_returnsOriginal() {
+    String result = UriUtil.toDirectoryPath(TEST_PATH + "/");
 
     assertThat(result).isEqualTo(TEST_PATH + "/");
   }
 
   @Test
-  void ensureTrailingSlash_nullPath_returnsNull() {
-    String result = UriUtil.ensureTrailingSlash(null);
+  void toDirectoryPath_nullPath_returnsNull() {
+    String result = UriUtil.toDirectoryPath(null);
 
     assertThat(result).isNull();
   }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
@@ -83,6 +83,20 @@ class UriUtilTest {
   }
 
   @Test
+  void getItemIdFromString_consecutiveSlashes_throwsIllegalArgumentException() {
+    String consecutiveSlashPath = "gs://test-bucket/dir//test-object";
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> UriUtil.getItemIdFromString(consecutiveSlashPath));
+
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo("GCS path must not have consecutive '/' characters: " + consecutiveSlashPath);
+  }
+
+  @Test
   void removeTrailingSlash_withTrailingSlash_removesSlash() {
     String result = UriUtil.removeTrailingSlash(TEST_PATH + "/");
 

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
@@ -20,31 +20,35 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-public final class UriUtilTest {
+class UriUtilTest {
+
+  private static final String TEST_BUCKET = "test-bucket";
+  private static final String TEST_OBJECT = "test-object";
+  private static final String TEST_PATH = "dir/subdir";
 
   @Test
-  public void getItemIdFromString_gcsBucket_succeeds() {
-    String gcsBucketName = "gs://test-bucket";
+  void getItemIdFromString_gcsBucket_succeeds() {
+    String gcsBucketName = "gs://" + TEST_BUCKET;
 
     GcsItemId itemId = UriUtil.getItemIdFromString(gcsBucketName);
 
-    assertThat(itemId.getBucketName()).isEqualTo("test-bucket");
+    assertThat(itemId.getBucketName()).isEqualTo(TEST_BUCKET);
     assertThat(itemId.getObjectName().isEmpty()).isTrue();
   }
 
   @Test
-  public void getItemIdFromString_gcsObject_succeeds() {
-    String gcsObjectName = "gs://test-bucket/test-object";
+  void getItemIdFromString_gcsObject_succeeds() {
+    String gcsObjectName = "gs://" + TEST_BUCKET + "/" + TEST_OBJECT;
 
     GcsItemId itemId = UriUtil.getItemIdFromString(gcsObjectName);
 
-    assertThat(itemId.getBucketName()).isEqualTo("test-bucket");
+    assertThat(itemId.getBucketName()).isEqualTo(TEST_BUCKET);
     assertThat(itemId.getObjectName().isPresent()).isTrue();
-    assertThat(itemId.getObjectName().get()).isEqualTo("test-object");
+    assertThat(itemId.getObjectName().get()).isEqualTo(TEST_OBJECT);
   }
 
   @Test
-  public void getItemIdFromString_gsOnly_throwsIllegalArgumentException() {
+  void getItemIdFromString_gsOnly_throwsIllegalArgumentException() {
     IllegalArgumentException e =
         assertThrows(IllegalArgumentException.class, () -> UriUtil.getItemIdFromString("gs://"));
 
@@ -52,7 +56,7 @@ public final class UriUtilTest {
   }
 
   @Test
-  public void getItemIdFromString_nullPath_throwsIllegalArgumentException() {
+  void getItemIdFromString_nullPath_throwsIllegalArgumentException() {
     IllegalArgumentException e =
         assertThrows(IllegalArgumentException.class, () -> UriUtil.getItemIdFromString(null));
 
@@ -60,8 +64,8 @@ public final class UriUtilTest {
   }
 
   @Test
-  public void getItemIdFromString_invalidPath_throwsIllegalArgumentException() {
-    String invalidPath = "http://test-bucket/test-pbject";
+  void getItemIdFromString_invalidPath_throwsIllegalArgumentException() {
+    String invalidPath = "http://test-bucket/test-object";
     IllegalArgumentException e =
         assertThrows(
             IllegalArgumentException.class, () -> UriUtil.getItemIdFromString(invalidPath));
@@ -70,50 +74,42 @@ public final class UriUtilTest {
   }
 
   @Test
-  public void removeTrailingSlash_withTrailingSlash_removesSlash() {
-    String path = "dir/subdir/";
+  void removeTrailingSlash_withTrailingSlash_removesSlash() {
+    String result = UriUtil.removeTrailingSlash(TEST_PATH + "/");
 
-    String result = UriUtil.removeTrailingSlash(path);
-
-    assertThat(result).isEqualTo("dir/subdir");
+    assertThat(result).isEqualTo(TEST_PATH);
   }
 
   @Test
-  public void removeTrailingSlash_withoutTrailingSlash_returnsSame() {
-    String path = "dir/subdir";
+  void removeTrailingSlash_withoutTrailingSlash_returnsSame() {
+    String result = UriUtil.removeTrailingSlash(TEST_PATH);
 
-    String result = UriUtil.removeTrailingSlash(path);
-
-    assertThat(result).isEqualTo("dir/subdir");
+    assertThat(result).isEqualTo(TEST_PATH);
   }
 
   @Test
-  public void removeTrailingSlash_nullPath_returnsNull() {
+  void removeTrailingSlash_nullPath_returnsNull() {
     String result = UriUtil.removeTrailingSlash(null);
 
     assertThat(result).isNull();
   }
 
   @Test
-  public void ensureTrailingSlash_withoutTrailingSlash_appendsSlash() {
-    String path = "dir/subdir";
+  void ensureTrailingSlash_withoutTrailingSlash_appendsSlash() {
+    String result = UriUtil.ensureTrailingSlash(TEST_PATH);
 
-    String result = UriUtil.ensureTrailingSlash(path);
-
-    assertThat(result).isEqualTo("dir/subdir/");
+    assertThat(result).isEqualTo(TEST_PATH + "/");
   }
 
   @Test
-  public void ensureTrailingSlash_withTrailingSlash_returnsSame() {
-    String path = "dir/subdir/";
+  void ensureTrailingSlash_withTrailingSlash_returnsSame() {
+    String result = UriUtil.ensureTrailingSlash(TEST_PATH + "/");
 
-    String result = UriUtil.ensureTrailingSlash(path);
-
-    assertThat(result).isEqualTo("dir/subdir/");
+    assertThat(result).isEqualTo(TEST_PATH + "/");
   }
 
   @Test
-  public void ensureTrailingSlash_nullPath_returnsNull() {
+  void ensureTrailingSlash_nullPath_returnsNull() {
     String result = UriUtil.ensureTrailingSlash(null);
 
     assertThat(result).isNull();

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
@@ -68,4 +68,54 @@ public final class UriUtilTest {
 
     assertThat(e).hasMessageThat().isEqualTo("Invalid GCS path: " + invalidPath);
   }
+
+  @Test
+  public void removeTrailingSlash_withTrailingSlash_removesSlash() {
+    String path = "dir/subdir/";
+
+    String result = UriUtil.removeTrailingSlash(path);
+
+    assertThat(result).isEqualTo("dir/subdir");
+  }
+
+  @Test
+  public void removeTrailingSlash_withoutTrailingSlash_returnsSame() {
+    String path = "dir/subdir";
+
+    String result = UriUtil.removeTrailingSlash(path);
+
+    assertThat(result).isEqualTo("dir/subdir");
+  }
+
+  @Test
+  public void removeTrailingSlash_nullPath_returnsNull() {
+    String result = UriUtil.removeTrailingSlash(null);
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  public void ensureTrailingSlash_withoutTrailingSlash_appendsSlash() {
+    String path = "dir/subdir";
+
+    String result = UriUtil.ensureTrailingSlash(path);
+
+    assertThat(result).isEqualTo("dir/subdir/");
+  }
+
+  @Test
+  public void ensureTrailingSlash_withTrailingSlash_returnsSame() {
+    String path = "dir/subdir/";
+
+    String result = UriUtil.ensureTrailingSlash(path);
+
+    assertThat(result).isEqualTo("dir/subdir/");
+  }
+
+  @Test
+  public void ensureTrailingSlash_nullPath_returnsNull() {
+    String result = UriUtil.ensureTrailingSlash(null);
+
+    assertThat(result).isNull();
+  }
 }

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/UriUtilTest.java
@@ -19,6 +19,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class UriUtilTest {
 
@@ -26,10 +28,9 @@ class UriUtilTest {
   private static final String TEST_OBJECT = "test-object";
   private static final String TEST_PATH = "dir/subdir";
 
-  @Test
-  void getItemIdFromString_gcsBucket_succeeds() {
-    String gcsBucketName = "gs://" + TEST_BUCKET;
-
+  @ParameterizedTest
+  @ValueSource(strings = {"gs://" + TEST_BUCKET, "gs://" + TEST_BUCKET + "/"})
+  void getItemIdFromString_gcsBucket_succeeds(String gcsBucketName) {
     GcsItemId itemId = UriUtil.getItemIdFromString(gcsBucketName);
 
     assertThat(itemId.getBucketName()).isEqualTo(TEST_BUCKET);
@@ -46,21 +47,12 @@ class UriUtilTest {
     assertThat(itemId.getObjectName()).hasValue(TEST_OBJECT);
   }
 
-  @Test
-  void getItemIdFromString_rootPath_returnsRootItemId() {
-    String rootPath = "gs:/";
-
+  @ParameterizedTest
+  @ValueSource(strings = {"gs:/", "gs://"})
+  void getItemIdFromString_rootPath_returnsRootItemId(String rootPath) {
     GcsItemId itemId = UriUtil.getItemIdFromString(rootPath);
 
     assertThat(itemId).isEqualTo(GcsItemId.ROOT);
-  }
-
-  @Test
-  void getItemIdFromString_gsOnly_throwsIllegalArgumentException() {
-    IllegalArgumentException e =
-        assertThrows(IllegalArgumentException.class, () -> UriUtil.getItemIdFromString("gs://"));
-
-    assertThat(e).hasMessageThat().isEqualTo("GCS path must include a bucket name: gs://");
   }
 
   @Test
@@ -71,10 +63,9 @@ class UriUtilTest {
     assertThat(e).hasMessageThat().isEqualTo("path should not be null");
   }
 
-  @Test
-  void getItemIdFromString_invalidPath_throwsIllegalArgumentException() {
-    String invalidPath = "http://test-bucket/test-object";
-
+  @ParameterizedTest
+  @ValueSource(strings = {"http://test-bucket/test-object", "gs:///", "gs:/test-bucket", ""})
+  void getItemIdFromString_invalidPath_throwsIllegalArgumentException(String invalidPath) {
     IllegalArgumentException e =
         assertThrows(
             IllegalArgumentException.class, () -> UriUtil.getItemIdFromString(invalidPath));

--- a/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeGcsClientImplTest.java
+++ b/test-lib/src/test/java/com/google/cloud/gcs/analyticscore/client/FakeGcsClientImplTest.java
@@ -76,10 +76,15 @@ class FakeGcsClientImplTest {
   }
 
   @Test
-  void getGcsItemInfo_objectDoesNotExists_throws() {
+  void getGcsItemInfo_objectDoesNotExists_returnsNotFoundItemInfo() throws IOException {
     GcsItemId itemId =
         GcsItemId.builder().setBucketName("test-bucket").setObjectName("not-exists").build();
-    assertThrows(IOException.class, () -> fakeGcsClient.getGcsItemInfo(itemId));
+
+    GcsItemInfo itemInfo = fakeGcsClient.getGcsItemInfo(itemId);
+
+    assertThat(itemInfo.getItemId()).isEqualTo(itemId);
+    assertThat(itemInfo.exists()).isFalse();
+    assertThat(itemInfo.getSize()).isEqualTo(-1L);
   }
 
   @Test


### PR DESCRIPTION
## Type of Change

- [x] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
- **Client Metadata APIs**: Added getBucketInfo, getFolderInfo (via StorageControlClient for HNS folders), and listObjectInfo APIs to GcsClient and GcsClientImpl.
- **DTO Extensions:** Expanded GcsItemInfo, GcsItemId, and GcsFileInfo to support root/bucket identifiers, directory item types, checksums (VerificationAttributes), timestamps, content types, and metadata generation fields.
- **URI Utilities:** Added helper methods in UriUtil for manipulating trailing slashes.
- **Unit Tests:** Added comprehensive test suites across GcsClientImpl, GcsItemId, GcsItemInfo, GcsFileInfo, and UriUtil.

### Why?
Provides low-level metadata querying capabilities (for objects, buckets, and HNS folders) and updates DTO structures to match with hadoop FileInfo structure.

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [ ] All files include the Apache License 2.0 header
- [ ] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? [Yes/No]*
