### PR TITLE
feat: Add grpc support and add configurable client type enum

### DIFF
--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/ClientType.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/ClientType.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.client;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Locale;
+
+/** Supported client types for interacting with Google Cloud Storage. */
+public enum ClientType {
+  /** Standard HTTP / JSON client. */
+  JSON,
+  /** gRPC client using standard read channels. */
+  GRPC,
+  /** gRPC client using bidirectional streaming read channels. */
+  BIDI;
+
+  /**
+   * Parses the given string into a {@link ClientType}.
+   *
+   * @param value the string value to parse
+   * @return the corresponding {@link ClientType}
+   * @throws IllegalArgumentException if the value cannot be parsed
+   */
+  public static ClientType fromString(String value) {
+    checkNotNull(value, "clientType must not be null");
+    switch (value.trim().toUpperCase(Locale.ROOT)) {
+      case "JSON":
+        return JSON;
+      case "GRPC":
+        return GRPC;
+      case "BIDI":
+        return BIDI;
+      default:
+        throw new IllegalArgumentException(
+            String.format(
+                "Invalid client type: '%s'. Supported values are 'JSON', 'GRPC', 'BIDI'.", value));
+    }
+  }
+}

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientImpl.java
@@ -131,7 +131,7 @@ class GcsClientImpl implements GcsClient {
         gcsItemInfo.getItemId().isGcsObject(),
         "Expected GCS object to be provided. But got: " + gcsItemInfo.getItemId());
 
-    if (readOptions.isBidiReadEnabled()) {
+    if (isBidiEnabled()) {
       return new GcsBidiReadChannel(
           storage, gcsItemInfo, readOptions, executorServiceSupplier, telemetry);
     }
@@ -146,7 +146,7 @@ class GcsClientImpl implements GcsClient {
     checkNotNull(gcsItemId, "gcsItemId should not be null");
     checkNotNull(readOptions, "readOptions should not be null");
     ItemInfoProvider itemInfoProvider = this::getGcsItemInfo;
-    if (readOptions.isBidiReadEnabled()) {
+    if (isBidiEnabled()) {
       return new GcsBidiReadChannel(
           storage, gcsItemId, readOptions, executorServiceSupplier, telemetry, itemInfoProvider);
     } else {
@@ -406,12 +406,16 @@ class GcsClientImpl implements GcsClient {
     }
   }
 
+  private boolean isBidiEnabled() {
+    return clientOptions.getClientType() == ClientType.BIDI;
+  }
+
   @VisibleForTesting
   protected Storage createStorage(Optional<Credentials> credentials) {
     StorageOptions.Builder builder =
-        clientOptions.getGcsReadOptions().isBidiReadEnabled()
-            ? StorageOptions.grpc()
-            : StorageOptions.newBuilder();
+        clientOptions.getClientType() == ClientType.JSON
+            ? StorageOptions.newBuilder()
+            : StorageOptions.grpc();
     String userAgent = getUserAgent();
     builder.setHeaderProvider(FixedHeaderProvider.create(ImmutableMap.of("User-Agent", userAgent)));
     clientOptions.getProjectId().ifPresent(builder::setProjectId);

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsClientOptions.java
@@ -52,6 +52,9 @@ public abstract class GcsClientOptions {
       "channel.write.pcu.part-file.name-prefix";
   private static final String TEMPORARY_PATHS_KEY = "channel.write.temporary-paths";
 
+  private static final String CLIENT_TYPE_KEY = "analytics-core.client.type";
+  private static final ClientType DEFAULT_CLIENT_TYPE = ClientType.JSON;
+
   /**
    * Upload strategies matching the configurations offered by the google-cloud-storage Java client.
    */
@@ -68,6 +71,8 @@ public abstract class GcsClientOptions {
     NEVER,
     ON_SUCCESS
   }
+
+  public abstract ClientType getClientType();
 
   public abstract Optional<String> getProjectId();
 
@@ -101,6 +106,7 @@ public abstract class GcsClientOptions {
   // TODO: Benchmark and determine the optimal default values for write options.
   public static Builder builder() {
     return new AutoValue_GcsClientOptions.Builder()
+        .setClientType(DEFAULT_CLIENT_TYPE)
         .setGcsReadOptions(GcsReadOptions.builder().build())
         .setGcsWriteOptions(GcsWriteOptions.builder().build())
         .setUploadChunkSize(24 * MB)
@@ -115,6 +121,10 @@ public abstract class GcsClientOptions {
   public static GcsClientOptions createFromOptions(
       Map<String, String> analyticsCoreOptions, String prefix) {
     GcsClientOptions.Builder optionsBuilder = builder();
+    String clientTypeStr = analyticsCoreOptions.get(prefix + CLIENT_TYPE_KEY);
+    if (clientTypeStr != null) {
+      optionsBuilder.setClientType(ClientType.fromString(clientTypeStr));
+    }
     if (analyticsCoreOptions.containsKey(prefix + PROJECT_ID_KEY)) {
       optionsBuilder.setProjectId(analyticsCoreOptions.get(prefix + PROJECT_ID_KEY));
     }
@@ -166,6 +176,8 @@ public abstract class GcsClientOptions {
   /** Builder for {@link GcsClientOptions}. */
   @AutoValue.Builder
   public abstract static class Builder {
+
+    public abstract Builder setClientType(ClientType clientType);
 
     public abstract Builder setProjectId(String projectId);
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptions.java
@@ -24,20 +24,11 @@ import java.util.Map;
 public abstract class GcsFileSystemOptions {
 
   private static final String READ_THREAD_COUNT_KEY = "analytics-core.read.thread.count";
-  private static final String CLIENT_TYPE_KEY = "client.type";
   private static final String HNS_API_ENABLED_KEY = "analytics-core.hierarchical.namespace.enable";
   private static final String METADATA_LOOKUP_PARALLEL_ENABLED_KEY =
       "analytics-core.metadata.lookup.parallel.enable";
 
-  /** Cloud Storage client to use. */
-  public enum ClientType {
-    HTTP_CLIENT,
-    GRPC_CLIENT,
-  }
-
   public abstract int getReadThreadCount();
-
-  public abstract ClientType getClientType();
 
   public abstract GcsClientOptions getGcsClientOptions();
 
@@ -55,7 +46,6 @@ public abstract class GcsFileSystemOptions {
   public static Builder builder() {
     return new AutoValue_GcsFileSystemOptions.Builder()
         .setReadThreadCount(16)
-        .setClientType(ClientType.HTTP_CLIENT)
         .setHnsApiEnabled(true)
         .setMetadataLookupParallelEnabled(true)
         .setGcsClientOptions(GcsClientOptions.builder().build())
@@ -69,10 +59,6 @@ public abstract class GcsFileSystemOptions {
     if (analyticsCoreOptions.containsKey(prefix + READ_THREAD_COUNT_KEY)) {
       optionsBuilder.setReadThreadCount(
           Integer.parseInt(analyticsCoreOptions.get(prefix + READ_THREAD_COUNT_KEY)));
-    }
-    if (analyticsCoreOptions.containsKey(prefix + CLIENT_TYPE_KEY)) {
-      optionsBuilder.setClientType(
-          ClientType.valueOf(analyticsCoreOptions.get(prefix + CLIENT_TYPE_KEY)));
     }
     if (analyticsCoreOptions.containsKey(prefix + HNS_API_ENABLED_KEY)) {
       optionsBuilder.setHnsApiEnabled(
@@ -98,8 +84,6 @@ public abstract class GcsFileSystemOptions {
   /** Builder for {@link GcsFileSystemOptions}. */
   @AutoValue.Builder
   public abstract static class Builder {
-
-    public abstract Builder setClientType(ClientType clientType);
 
     public abstract Builder setReadThreadCount(int readThreadCount);
 

--- a/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptions.java
+++ b/client/src/main/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptions.java
@@ -33,7 +33,6 @@ public abstract class GcsReadOptions {
   private static final String LARGE_FILE_FOOTER_PREFETCH_SIZE_KEY =
       "analytics-core.large-file.footer.prefetch.size-bytes";
   private static final String USER_PROJECT_KEY = "user-project";
-  private static final String BIDI_READ_ENABLED_KEY = "analytics-core.read.bidi.enabled";
   private static final String BIDI_TIMEOUT_SECONDS = "analytics-core.read.bidi.timeout-seconds";
   private static final String INPLACE_SEEK_LIMIT_KEY =
       "analytics-core.read.inplace-seek-limit-bytes";
@@ -48,7 +47,6 @@ public abstract class GcsReadOptions {
 
   private static final boolean DEFAULT_FOOTER_PREFETCH_ENABLED = true;
 
-  private static final boolean DEFAULT_BIDI_READ_ENABLED = false;
   private static final int DEFAULT_BIDI_TIMEOUT_SECONDS = 10;
 
   private static final int DEFAULT_INPLACE_SEEK_LIMIT = 128 * KB;
@@ -73,8 +71,6 @@ public abstract class GcsReadOptions {
   public abstract boolean isFooterPrefetchEnabled();
 
   public abstract int getSmallObjectCacheThresholdBytes();
-
-  public abstract boolean isBidiReadEnabled();
 
   public abstract int getBidiTimeout();
 
@@ -101,7 +97,6 @@ public abstract class GcsReadOptions {
         .setFileAccessPattern(DEFAULT_FILE_ACCESS_PATTERN)
         .setAdaptiveReadSequentialReadThreshold(DEFAULT_ADAPTIVE_READ_SEQUENTIAL_READ_THRESHOLD)
         .setRandomReadMinRequestSize(DEFAULT_RANDOM_READ_MIN_REQUEST_SIZE)
-        .setBidiReadEnabled(DEFAULT_BIDI_READ_ENABLED)
         .setBidiTimeout(DEFAULT_BIDI_TIMEOUT_SECONDS);
   }
 
@@ -136,10 +131,6 @@ public abstract class GcsReadOptions {
       optionsBuilder.setSmallObjectCacheThresholdBytes(
           ConfigurationUtil.safeParseInteger(
               analyticsCoreOptions, prefix + SMALL_FILE_CACHE_THRESHOLD_KEY));
-    }
-    if (analyticsCoreOptions.containsKey(prefix + BIDI_READ_ENABLED_KEY)) {
-      optionsBuilder.setBidiReadEnabled(
-          Boolean.parseBoolean(analyticsCoreOptions.get(prefix + BIDI_READ_ENABLED_KEY)));
     }
     if (analyticsCoreOptions.containsKey(prefix + BIDI_TIMEOUT_SECONDS)) {
       optionsBuilder.setBidiTimeout(
@@ -191,8 +182,6 @@ public abstract class GcsReadOptions {
     public abstract Builder setFooterPrefetchSizeLargeFile(int footerPrefetchSizeLargeFile);
 
     public abstract Builder setSmallObjectCacheThresholdBytes(int smallObjectCacheThresholdBytes);
-
-    public abstract Builder setBidiReadEnabled(boolean enabled);
 
     public abstract Builder setBidiTimeout(int bidiTimeout);
 

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/ClientTypeTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/ClientTypeTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.gcs.analyticscore.client;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ClientTypeTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"JSON", "json", "Json"})
+  void fromString_jsonValues_returnsJson(String value) {
+    // Act
+    ClientType clientType = ClientType.fromString(value);
+
+    // Assert
+    assertThat(clientType).isEqualTo(ClientType.JSON);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"GRPC", "grpc", "Grpc"})
+  void fromString_grpcValues_returnsGrpc(String value) {
+    // Act
+    ClientType clientType = ClientType.fromString(value);
+
+    // Assert
+    assertThat(clientType).isEqualTo(ClientType.GRPC);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"BIDI", "bidi", "Bidi"})
+  void fromString_bidiValues_returnsBidi(String value) {
+    // Act
+    ClientType clientType = ClientType.fromString(value);
+
+    // Assert
+    assertThat(clientType).isEqualTo(ClientType.BIDI);
+  }
+
+  @Test
+  void fromString_nullValue_throwsNullPointerException() {
+    // Act & Assert
+    assertThrows(NullPointerException.class, () -> ClientType.fromString(null));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "INVALID",
+        "unknown",
+        "",
+        "HTTP_CLIENT",
+        "http_client",
+        "GRPC_CLIENT",
+        "grpc_client"
+      })
+  void fromString_invalidValue_throwsIllegalArgumentException(String value) {
+    // Act & Assert
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> ClientType.fromString(value));
+    assertThat(exception).hasMessageThat().contains("Invalid client type");
+  }
+}

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientImplTest.java
@@ -473,7 +473,12 @@ class GcsClientImplTest {
   }
 
   private GcsClientImpl createClientWithMockStorage(Storage mockStorage) {
-    return new GcsClientImpl(TEST_GCS_CLIENT_OPTIONS, executorServiceSupplier, telemetry) {
+    return createClientWithMockStorage(mockStorage, TEST_GCS_CLIENT_OPTIONS);
+  }
+
+  private GcsClientImpl createClientWithMockStorage(
+      Storage mockStorage, GcsClientOptions clientOptions) {
+    return new GcsClientImpl(clientOptions, executorServiceSupplier, telemetry) {
       @Override
       protected Storage createStorage(Optional<Credentials> credentials) {
         return mockStorage;
@@ -979,7 +984,7 @@ class GcsClientImplTest {
   }
 
   @Test
-  void createStorage_bidiDisabled_usesHttpTransport() throws IOException {
+  void createStorage_jsonClientType_usesHttpTransport() throws IOException {
     GcsClientImpl client =
         new GcsClientImpl(
             NoCredentials.getInstance(),
@@ -994,7 +999,21 @@ class GcsClientImplTest {
     GcsClientOptions options =
         GcsClientOptions.builder()
             .setProjectId(TEST_PROJECT)
-            .setGcsReadOptions(GcsReadOptions.builder().setBidiReadEnabled(true).build())
+            .setClientType(ClientType.BIDI)
+            .build();
+
+    GcsClientImpl client =
+        new GcsClientImpl(NoCredentials.getInstance(), options, executorServiceSupplier, telemetry);
+
+    assertThat(client.storage.getOptions()).isInstanceOf(GrpcStorageOptions.class);
+  }
+
+  @Test
+  void createStorage_grpcClientType_usesGrpcTransport() throws IOException {
+    GcsClientOptions options =
+        GcsClientOptions.builder()
+            .setProjectId(TEST_PROJECT)
+            .setClientType(ClientType.GRPC)
             .build();
 
     GcsClientImpl client =
@@ -1005,8 +1024,9 @@ class GcsClientImplTest {
 
   @Test
   void openReadChannel_bidiEnabled_returnsGcsBidiReadChannel() throws IOException {
-    GcsReadOptions readOptions =
-        GcsReadOptions.builder().setUserProjectId(TEST_PROJECT).setBidiReadEnabled(true).build();
+    GcsClientOptions clientOptions =
+        GcsClientOptions.builder().setClientType(ClientType.BIDI).build();
+    GcsReadOptions readOptions = GcsReadOptions.builder().setUserProjectId(TEST_PROJECT).build();
     GcsItemId itemId =
         GcsItemId.builder().setBucketName(TEST_BUCKET_NAME).setObjectName(TEST_OBJECT_NAME).build();
     GcsItemInfo itemInfo =
@@ -1014,7 +1034,7 @@ class GcsClientImplTest {
     Storage mockStorage = mock(Storage.class);
     ApiFuture<BlobReadSession> mockSessionFuture = mock(ApiFuture.class);
     when(mockStorage.blobReadSession(any(BlobId.class))).thenReturn(mockSessionFuture);
-    GcsClient bidiClient = createClientWithMockStorage(mockStorage);
+    GcsClient bidiClient = createClientWithMockStorage(mockStorage, clientOptions);
 
     VectoredSeekableByteChannel channel = bidiClient.openReadChannel(itemInfo, readOptions);
 
@@ -1023,14 +1043,15 @@ class GcsClientImplTest {
 
   @Test
   void openReadChannel_itemId_bidiEnabled_returnsGcsBidiReadChannel() throws IOException {
-    GcsReadOptions readOptions =
-        GcsReadOptions.builder().setUserProjectId(TEST_PROJECT).setBidiReadEnabled(true).build();
+    GcsClientOptions clientOptions =
+        GcsClientOptions.builder().setClientType(ClientType.BIDI).build();
+    GcsReadOptions readOptions = GcsReadOptions.builder().setUserProjectId(TEST_PROJECT).build();
     GcsItemId itemId =
         GcsItemId.builder().setBucketName(TEST_BUCKET_NAME).setObjectName(TEST_OBJECT_NAME).build();
     Storage mockStorage = mock(Storage.class);
     ApiFuture<BlobReadSession> mockSessionFuture = mock(ApiFuture.class);
     when(mockStorage.blobReadSession(any(BlobId.class))).thenReturn(mockSessionFuture);
-    GcsClient bidiClient = createClientWithMockStorage(mockStorage);
+    GcsClient bidiClient = createClientWithMockStorage(mockStorage, clientOptions);
 
     VectoredSeekableByteChannel channel = bidiClient.openReadChannel(itemId, readOptions);
 

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsClientOptionsTest.java
@@ -32,6 +32,7 @@ class GcsClientOptionsTest {
   void builder_withDefaultValues_returnsExpectedDefaults() {
     GcsClientOptions options = GcsClientOptions.builder().build();
 
+    assertThat(options.getClientType()).isEqualTo(ClientType.JSON);
     assertThat(options.getProjectId().isPresent()).isFalse();
     assertThat(options.getClientLibToken().isPresent()).isFalse();
     assertThat(options.getServiceHost().isPresent()).isFalse();
@@ -53,6 +54,7 @@ class GcsClientOptionsTest {
   void builder_withCustomValues_setsAllProperties() {
     GcsClientOptions options =
         GcsClientOptions.builder()
+            .setClientType(ClientType.BIDI)
             .setProjectId("test-project")
             .setClientLibToken("test-token")
             .setServiceHost("test-host")
@@ -66,6 +68,7 @@ class GcsClientOptionsTest {
             .setTemporaryPaths(ImmutableList.of("/tmp/path1", "/tmp/path2"))
             .build();
 
+    assertThat(options.getClientType()).isEqualTo(ClientType.BIDI);
     assertThat(options.getProjectId()).hasValue("test-project");
     assertThat(options.getClientLibToken()).hasValue("test-token");
     assertThat(options.getServiceHost()).hasValue("test-host");
@@ -85,6 +88,7 @@ class GcsClientOptionsTest {
   void createFromOptions_withValidProperties_parsesCorrectly() {
     Map<String, String> rawOptions =
         ImmutableMap.<String, String>builder()
+            .put("gcs.analytics-core.client.type", "GRPC")
             .put("gcs.project-id", "test-project")
             .put("gcs.client-lib-token", "test-token")
             .put("gcs.service.host", "test-host")
@@ -100,6 +104,7 @@ class GcsClientOptionsTest {
 
     GcsClientOptions options = GcsClientOptions.createFromOptions(rawOptions, "gcs.");
 
+    assertThat(options.getClientType()).isEqualTo(ClientType.GRPC);
     assertThat(options.getProjectId()).hasValue("test-project");
     assertThat(options.getClientLibToken()).hasValue("test-token");
     assertThat(options.getServiceHost()).hasValue("test-host");

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsFileSystemOptionsTest.java
@@ -31,14 +31,14 @@ class GcsFileSystemOptionsTest {
     ImmutableMap<String, String> properties =
         ImmutableMap.of(
             "fs.gs.project-id", "test-project",
-            "fs.gs.client.type", "GRPC_CLIENT",
+            "fs.gs.analytics-core.client.type", "GRPC",
             "fs.gs.analytics-core.read.thread.count", "32",
             "fs.gs.analytics-core.hierarchical.namespace.enable", "true");
 
     GcsFileSystemOptions options = GcsFileSystemOptions.createFromOptions(properties, "fs.gs.");
 
     assertThat(options.getGcsClientOptions().getProjectId().get()).isEqualTo("test-project");
-    assertThat(options.getClientType()).isEqualTo(GcsFileSystemOptions.ClientType.GRPC_CLIENT);
+    assertThat(options.getGcsClientOptions().getClientType()).isEqualTo(ClientType.GRPC);
     assertThat(options.getReadThreadCount()).isEqualTo(32);
     assertThat(options.isHnsApiEnabled()).isTrue();
   }
@@ -72,7 +72,7 @@ class GcsFileSystemOptionsTest {
     GcsFileSystemOptions options = GcsFileSystemOptions.createFromOptions(properties, "fs.gs.");
 
     assertThat(options.getGcsClientOptions().getProjectId().isEmpty()).isTrue();
-    assertThat(options.getClientType()).isEqualTo(GcsFileSystemOptions.ClientType.HTTP_CLIENT);
+    assertThat(options.getGcsClientOptions().getClientType()).isEqualTo(ClientType.JSON);
     assertThat(options.getReadThreadCount()).isEqualTo(16);
     assertThat(options.isHnsApiEnabled()).isTrue();
 
@@ -81,6 +81,16 @@ class GcsFileSystemOptionsTest {
     assertThat(cacheOptions.getFooterCacheMaxSizeBytes()).isEqualTo(100 * MB);
     assertThat(cacheOptions.isSmallObjectCacheEnabled()).isFalse();
     assertThat(cacheOptions.getSmallObjectCacheMaxSizeBytes()).isEqualTo(200 * MB);
+  }
+
+  @Test
+  void createFromOptions_withBidiClientType_shouldParseCorrectly() {
+    ImmutableMap<String, String> properties =
+        ImmutableMap.of("fs.gs.analytics-core.client.type", "BIDI");
+
+    GcsFileSystemOptions options = GcsFileSystemOptions.createFromOptions(properties, "fs.gs.");
+
+    assertThat(options.getGcsClientOptions().getClientType()).isEqualTo(ClientType.BIDI);
   }
 
   @Test

--- a/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptionsTest.java
+++ b/client/src/test/java/com/google/cloud/gcs/analyticscore/client/GcsReadOptionsTest.java
@@ -48,7 +48,6 @@ class GcsReadOptionsTest {
             .put("gcs.analytics-core.read.file-access-pattern", "random")
             .put("gcs.analytics-core.adaptive-read.sequential-read-threshold", "5")
             .put("gcs.analytics-core.random-read.min-request-size", "65536")
-            .put("gcs.analytics-core.read.bidi.enabled", "true")
             .put("gcs.analytics-core.read.bidi.timeout-seconds", "30")
             .build();
     String prefix = "gcs.";
@@ -63,7 +62,6 @@ class GcsReadOptionsTest {
     assertThat(readOptions.getFooterPrefetchSizeSmallFile()).isEqualTo(41943);
     assertThat(readOptions.getFooterPrefetchSizeLargeFile()).isEqualTo(4194304);
     assertThat(readOptions.getSmallObjectCacheThresholdBytes()).isEqualTo(102400);
-    assertThat(readOptions.isBidiReadEnabled()).isEqualTo(true);
     assertThat(readOptions.getBidiTimeout()).isEqualTo(30);
     assertThat(readOptions.getInplaceSeekLimit()).isEqualTo(16777216);
     assertThat(readOptions.getFileAccessPattern()).isEqualTo(FileAccessPattern.RANDOM);
@@ -95,7 +93,6 @@ class GcsReadOptionsTest {
     assertThat(readOptions.getFooterPrefetchSizeSmallFile()).isEqualTo(50 * KB);
     assertThat(readOptions.getFooterPrefetchSizeLargeFile()).isEqualTo(MB);
     assertThat(readOptions.getSmallObjectCacheThresholdBytes()).isEqualTo(MB);
-    assertThat(readOptions.isBidiReadEnabled()).isEqualTo(false);
     assertThat(readOptions.getBidiTimeout()).isEqualTo(10);
     assertThat(readOptions.getInplaceSeekLimit()).isEqualTo(128 * KB);
     assertThat(readOptions.getFileAccessPattern()).isEqualTo(FileAccessPattern.AUTO_SEQUENTIAL);
@@ -153,25 +150,10 @@ class GcsReadOptionsTest {
   }
 
   @Test
-  void createFromOptions_withBidiReadEnabledSet_shouldParseCorrectly() {
-    Map<String, String> propertiesTrue =
-        ImmutableMap.of("gcs.analytics-core.read.bidi.enabled", "true");
-    GcsReadOptions readOptionsTrue = GcsReadOptions.createFromOptions(propertiesTrue, "gcs.");
-    assertThat(readOptionsTrue.isBidiReadEnabled()).isTrue();
-    assertThat(readOptionsTrue.getBidiTimeout()).isEqualTo(10); // default value
-
-    Map<String, String> propertiesFalse =
-        ImmutableMap.of("gcs.analytics-core.read.bidi.enabled", "false");
-    GcsReadOptions readOptionsFalse = GcsReadOptions.createFromOptions(propertiesFalse, "gcs.");
-    assertThat(readOptionsFalse.isBidiReadEnabled()).isFalse();
-  }
-
-  @Test
   void createFromOptions_withBidiTimeoutSet_shouldParseCorrectly() {
     Map<String, String> properties =
         ImmutableMap.of("gcs.analytics-core.read.bidi.timeout-seconds", "45");
     GcsReadOptions readOptions = GcsReadOptions.createFromOptions(properties, "gcs.");
     assertThat(readOptions.getBidiTimeout()).isEqualTo(45);
-    assertThat(readOptions.isBidiReadEnabled()).isFalse(); // default value
   }
 }

--- a/core/src/jmh/java/com/google/cloud/gcs/analyticscore/core/ParquetRecordReadBenchmark.java
+++ b/core/src/jmh/java/com/google/cloud/gcs/analyticscore/core/ParquetRecordReadBenchmark.java
@@ -44,7 +44,7 @@ public class ParquetRecordReadBenchmark {
               Map.of("gcs.analytics-core.small-file.footer.prefetch.size-bytes", state.footerPrefetchSize,
                       "gcs.analytics-core.large-file.footer.prefetch.size-bytes", state.footerPrefetchSize,
                       "gcs.analytics-core.small-file.cache.max-size-bytes", "1048576",
-                      "gcs.analytics-core.read.bidi.enabled", String.valueOf(state.enableBidiRead)), "gcs.");
+                      "gcs.analytics-core.client.type", state.clientType), "gcs.");
         String requestedSchema = "message requested_schema {\n"
                 + "required binary c_customer_id (STRING);\n"
                 + "optional binary c_first_name (STRING);\n"

--- a/core/src/jmh/java/com/google/cloud/gcs/analyticscore/core/ParquetRecordReadState.java
+++ b/core/src/jmh/java/com/google/cloud/gcs/analyticscore/core/ParquetRecordReadState.java
@@ -28,6 +28,6 @@ public class ParquetRecordReadState {
     @Param({ "0", "102400" })
     public String footerPrefetchSize;
 
-    @Param({"true", "false"})
-    public boolean enableBidiRead;
+    @Param({"JSON", "GRPC", "BIDI"})
+    public String clientType;
 }

--- a/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GcsAnalyticsCoreOptionsTest.java
+++ b/core/src/test/java/com/google/cloud/gcs/analyticscore/core/GcsAnalyticsCoreOptionsTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.gcs.analyticscore.core;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.cloud.gcs.analyticscore.client.ClientType;
 import com.google.cloud.gcs.analyticscore.client.GcsClientOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
 import com.google.common.collect.ImmutableMap;
@@ -32,8 +33,8 @@ class GcsAnalyticsCoreOptionsTest {
         ImmutableMap.of(
             appendPrefix + "analytics-core.read.thread.count",
             "32",
-            appendPrefix + "client.type",
-            "GRPC_CLIENT",
+            appendPrefix + "analytics-core.client.type",
+            "GRPC",
             appendPrefix + "project-id",
             "test-project",
             appendPrefix + "user-project",
@@ -52,8 +53,7 @@ class GcsAnalyticsCoreOptionsTest {
     GcsClientOptions clientOptions = fileSystemOptions.getGcsClientOptions();
 
     assertThat(fileSystemOptions.getReadThreadCount()).isEqualTo(32);
-    assertThat(fileSystemOptions.getClientType())
-        .isEqualTo(GcsFileSystemOptions.ClientType.GRPC_CLIENT);
+    assertThat(clientOptions.getClientType()).isEqualTo(ClientType.GRPC);
     assertThat(clientOptions.getProjectId().get()).isEqualTo("test-project");
     assertThat(clientOptions.getClientLibToken().get()).isEqualTo("test-token");
     assertThat(clientOptions.getServiceHost().get()).isEqualTo("test-host");
@@ -68,7 +68,7 @@ class GcsAnalyticsCoreOptionsTest {
     ImmutableMap<String, String> options =
         ImmutableMap.of(
             "analytics-core.read.thread.count", "24",
-            "client.type", "HTTP_CLIENT",
+            "analytics-core.client.type", "JSON",
             "project-id", "test-project-no-prefix",
             "client-lib-token", "test-token-no-prefix",
             "service.host", "test-host-no-prefix",
@@ -79,8 +79,7 @@ class GcsAnalyticsCoreOptionsTest {
     GcsClientOptions clientOptions = fileSystemOptions.getGcsClientOptions();
 
     assertThat(fileSystemOptions.getReadThreadCount()).isEqualTo(24);
-    assertThat(fileSystemOptions.getClientType())
-        .isEqualTo(GcsFileSystemOptions.ClientType.HTTP_CLIENT);
+    assertThat(clientOptions.getClientType()).isEqualTo(ClientType.JSON);
     assertThat(clientOptions.getProjectId().get()).isEqualTo("test-project-no-prefix");
     assertThat(clientOptions.getClientLibToken().get()).isEqualTo("test-token-no-prefix");
     assertThat(clientOptions.getServiceHost().get()).isEqualTo("test-host-no-prefix");
@@ -93,7 +92,7 @@ class GcsAnalyticsCoreOptionsTest {
     ImmutableMap<String, String> options =
         ImmutableMap.of(
             "wrong.prefix.analytics-core.read.thread.count", "32",
-            "wrong.prefix.client.type", "GRPC_CLIENT",
+            "wrong.prefix.analytics-core.client.type", "GRPC",
             "wrong.prefix.project-id", "test-project");
     GcsFileSystemOptions defaultOptions = GcsFileSystemOptions.builder().build();
     GcsAnalyticsCoreOptions coreOptions = new GcsAnalyticsCoreOptions(appendPrefix, options);
@@ -103,7 +102,8 @@ class GcsAnalyticsCoreOptionsTest {
 
     assertThat(fileSystemOptions.getReadThreadCount())
         .isEqualTo(defaultOptions.getReadThreadCount());
-    assertThat(fileSystemOptions.getClientType()).isEqualTo(defaultOptions.getClientType());
+    assertThat(clientOptions.getClientType())
+        .isEqualTo(defaultOptions.getGcsClientOptions().getClientType());
     assertThat(clientOptions.getProjectId().isPresent()).isFalse();
   }
 }


### PR DESCRIPTION
## Type of Change

- [x] `feat`: A new feature
- [ ] `fix`: A bug fix
- [ ] `docs`: Documentation only changes
- [ ] `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] `perf`: A code change that improves performance
- [ ] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries such as documentation generation

## Description

### What?
- Introduced `ClientType` enum (`JSON`, `GRPC`, `BIDI`) with configuration key `analytics-core.client.type` in `GcsClientOptions` (defaulting to `JSON`).
- Added support for unary gRPC reads in `GcsClientImpl`.

### Why?
- **Feature Parity**: Added unary gRPC support for feature parity with existing client capabilities.
- **Zero Impact on Default Performance**: The change is guarded behind the `analytics-core.client.type` flag and defaults to `JSON`, ensuring existing performance is not impacted.
## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(core): ...`)
- [x] All files include the Apache License 2.0 header
- [ ] Documentation has been updated to reflect changes

---
*Generated/Assisted by Agent? [Yes/No]*
